### PR TITLE
Browsing History and MRU in Zen Explorer

### DIFF
--- a/src/apps/zenexplorer/ZenExplorerApp.js
+++ b/src/apps/zenexplorer/ZenExplorerApp.js
@@ -200,8 +200,8 @@ export class ZenExplorerApp extends Application {
 
             this.currentPath = path;
 
-            // Update MRU (Unique, top 10, current at top)
-            this.mruFolders = [path, ...this.mruFolders.filter(p => p !== path)].slice(0, 10);
+            // Update MRU (Log of last 10 visits, oldest to latest)
+            this.mruFolders = [...this.mruFolders, path].slice(-10);
 
             // Refresh menu bar
             this._updateMenuBar();


### PR DESCRIPTION
Implemented browsing history and MRU (Most Recently Used) list for Zen Explorer. 

Key changes:
- Updated `ZenExplorerApp` to maintain a history stack and a list of the 10 most recently browsed folders.
- Added a `Go` menu with `Back`, `Forward`, and `Up One Level` actions.
- Modified the `File` menu to include a section of radio items representing the last 10 visited folders, with the currently active folder selected.
- Navigation methods (`goBack`, `goForward`, `goUp`) handle history indexing and stack pruning.
- The `MenuBar` is refreshed upon each navigation to ensure dynamic items (MRU list) and item states (enabled/disabled) are up-to-date.
- Per-window storage ensures history is isolated and cleared upon closing the application instance.

---
*PR created automatically by Jules for task [18380193540654887325](https://jules.google.com/task/18380193540654887325) started by @azayrahmad*