### PR TITLE
Optional Modal Overlay and Sound on Click

### DIFF
--- a/public/os-gui/dialog-window.css
+++ b/public/os-gui/dialog-window.css
@@ -34,6 +34,9 @@
     left: 0;
     width: 100%;
     height: 100%;
-    background: var(--checker-black) repeat;
     z-index: 4; /* Below the window's default z-index */
+}
+
+.modal-overlay.visible {
+    background: var(--checker-black) repeat;
 }

--- a/src/components/DialogWindow.js
+++ b/src/components/DialogWindow.js
@@ -119,7 +119,7 @@ function ShowDialogWindow(options) {
     }
 
     modalOverlay.onclick = () => {
-      playSound("SystemExclamation");
+      playSound("Default");
     };
 
     // Use a high z-index, but relative to the window manager's current z-index

--- a/src/components/DialogWindow.js
+++ b/src/components/DialogWindow.js
@@ -16,6 +16,7 @@ import { playSound } from "../utils/soundManager.js";
  * @property {DialogButton[]} [buttons] - The buttons to display in the dialog.
  * @property {string} [soundEvent] - The name of the sound event to play.
  * @property {boolean} [modal=false] - Whether the dialog should be modal.
+ * @property {boolean} [showOverlay=false] - Whether to show the visual overlay for modal dialogs.
  */
 
 /**
@@ -32,6 +33,7 @@ function ShowDialogWindow(options) {
     buttons = [{ label: "OK", action: () => {}, isDefault: true }],
     soundEvent,
     modal = false,
+    showOverlay = false,
     parentWindow,
   } = options;
 
@@ -112,6 +114,13 @@ function ShowDialogWindow(options) {
     const screen = document.getElementById("screen");
     modalOverlay = document.createElement("div");
     modalOverlay.className = "modal-overlay";
+    if (showOverlay) {
+      modalOverlay.classList.add("visible");
+    }
+
+    modalOverlay.onclick = () => {
+      playSound("SystemExclamation");
+    };
 
     // Use a high z-index, but relative to the window manager's current z-index
     // This should be just below the dialog window itself.

--- a/src/components/StartMenu.js
+++ b/src/components/StartMenu.js
@@ -530,6 +530,7 @@ class StartMenu {
         title: 'Shut Down Windows',
         content: content, // Pass the DOM element directly
         modal: true,
+        showOverlay: true,
         buttons: [
             {
                 label: 'OK',


### PR DESCRIPTION
This change makes the visual dithered overlay for modal dialogs optional and disabled by default. It remains enabled for the shutdown dialog. Additionally, clicking the overlay (whether visible or not) now plays the SystemExclamation sound, matching Windows 98 behavior where clicking outside a modal dialog triggers a warning sound.

---
*PR created automatically by Jules for task [7264904359147210541](https://jules.google.com/task/7264904359147210541) started by @azayrahmad*