### PR TITLE
Recycle Bin for ZenExplorer

### DIFF
--- a/src/apps/zenexplorer/FileOperations.js
+++ b/src/apps/zenexplorer/FileOperations.js
@@ -202,7 +202,13 @@ export class FileOperations {
                             } else {
                                 await RecycleBinManager.moveItemsToRecycleBin(paths);
                             }
-                            this.app.navigateTo(this.app.currentPath);
+
+                            // If it was permanent and NOT in recycle bin, we need to refresh manually
+                            // because no event was dispatched. If an event was dispatched,
+                            // ZenExplorerApp already refreshed.
+                            if (isPermanent && !alreadyInRecycle) {
+                                this.app.navigateTo(this.app.currentPath);
+                            }
                         } catch (e) {
                             handleFileSystemError("delete", e, "items");
                         }

--- a/src/apps/zenexplorer/FileOperations.js
+++ b/src/apps/zenexplorer/FileOperations.js
@@ -4,6 +4,7 @@ import { showInputDialog } from "./components/InputDialog.js";
 import { handleFileSystemError } from "./utils/ErrorHandler.js";
 import { joinPath, normalizePath, getPathName } from "./utils/PathUtils.js";
 import ZenClipboardManager from "./utils/ZenClipboardManager.js";
+import { RecycleBinManager } from "./utils/RecycleBinManager.js";
 
 /**
  * FileOperations - Handles file system operations with user interaction
@@ -150,13 +151,22 @@ export class FileOperations {
     /**
      * Delete items with confirmation dialog
      * @param {Array<string>} paths - Paths to delete
+     * @param {boolean} permanent - Whether to bypass Recycle Bin
      */
-    async deleteItems(paths) {
+    async deleteItems(paths, permanent = false) {
         if (paths.length === 0) return;
 
-        const message = paths.length === 1
-            ? `Are you sure you want to permanently delete '${paths[0].split("/").pop()}'?`
-            : `Are you sure you want to permanently delete these ${paths.length} items?`;
+        // If items are already in Recycle Bin, deletion is always permanent
+        const alreadyInRecycle = paths.some(path => RecycleBinManager.isRecycledItemPath(path));
+        const isPermanent = permanent || alreadyInRecycle;
+
+        const message = isPermanent
+            ? (paths.length === 1
+                ? `Are you sure you want to permanently delete '${getPathName(paths[0])}'?`
+                : `Are you sure you want to permanently delete these ${paths.length} items?`)
+            : (paths.length === 1
+                ? `Are you sure you want to send '${getPathName(paths[0])}' to the Recycle Bin?`
+                : `Are you sure you want to send these ${paths.length} items to the Recycle Bin?`);
 
         ShowDialogWindow({
             title: "Confirm File Delete",
@@ -169,8 +179,28 @@ export class FileOperations {
                     isDefault: true,
                     action: async () => {
                         try {
-                            for (const path of paths) {
-                                await fs.promises.rm(path, { recursive: true });
+                            if (isPermanent) {
+                                for (const path of paths) {
+                                    await fs.promises.rm(path, { recursive: true });
+                                }
+                                // If it was in recycle bin, we should also clean up metadata
+                                if (alreadyInRecycle) {
+                                    const metadata = await RecycleBinManager.getMetadata();
+                                    let changed = false;
+                                    for (const path of paths) {
+                                        const id = getPathName(path);
+                                        if (metadata[id]) {
+                                            delete metadata[id];
+                                            changed = true;
+                                        }
+                                    }
+                                    if (changed) {
+                                        await RecycleBinManager.saveMetadata(metadata);
+                                        document.dispatchEvent(new CustomEvent("zen-recycle-bin-change"));
+                                    }
+                                }
+                            } else {
+                                await RecycleBinManager.moveItemsToRecycleBin(paths);
                             }
                             this.app.navigateTo(this.app.currentPath);
                         } catch (e) {

--- a/src/apps/zenexplorer/utils/RecycleBinManager.js
+++ b/src/apps/zenexplorer/utils/RecycleBinManager.js
@@ -1,0 +1,262 @@
+import { fs } from "@zenfs/core";
+import { joinPath, getPathName, getParentPath } from "./PathUtils.js";
+
+const RECYCLE_PATH = "/C:/Recycled";
+const METADATA_FILE = joinPath(RECYCLE_PATH, ".metadata.json");
+
+/**
+ * RecycleBinManager - Manages the Recycle Bin system for ZenExplorer
+ */
+export class RecycleBinManager {
+    /**
+     * Initialize the Recycle Bin folder and metadata
+     */
+    static async init() {
+        try {
+            const stats = await fs.promises.stat(RECYCLE_PATH);
+            if (!stats.isDirectory()) {
+                await fs.promises.mkdir(RECYCLE_PATH, { recursive: true });
+            }
+        } catch (e) {
+            await fs.promises.mkdir(RECYCLE_PATH, { recursive: true });
+        }
+
+        try {
+            await fs.promises.stat(METADATA_FILE);
+        } catch (e) {
+            await fs.promises.writeFile(METADATA_FILE, JSON.stringify({}));
+        }
+    }
+
+    /**
+     * Get the current metadata object
+     * @returns {Promise<Object>}
+     */
+    static async getMetadata() {
+        try {
+            const content = await fs.promises.readFile(METADATA_FILE, 'utf8');
+            return JSON.parse(content);
+        } catch (e) {
+            return {};
+        }
+    }
+
+    /**
+     * Save the metadata object
+     * @param {Object} metadata
+     */
+    static async saveMetadata(metadata) {
+        await fs.promises.writeFile(METADATA_FILE, JSON.stringify(metadata, null, 2));
+    }
+
+    /**
+     * Move multiple items to the Recycle Bin
+     * @param {string[]} paths
+     */
+    static async moveItemsToRecycleBin(paths) {
+        const metadata = await this.getMetadata();
+        let changed = false;
+
+        for (const path of paths) {
+            if (this.isRecycledItemPath(path)) continue;
+
+            const id = (typeof crypto.randomUUID === 'function')
+                ? crypto.randomUUID()
+                : Date.now().toString(36) + Math.random().toString(36).substring(2);
+
+            const name = getPathName(path);
+            const targetPath = joinPath(RECYCLE_PATH, id);
+
+            try {
+                await fs.promises.rename(path, targetPath);
+            } catch (e) {
+                await this.copyRecursive(path, targetPath);
+                await fs.promises.rm(path, { recursive: true });
+            }
+
+            metadata[id] = {
+                id,
+                originalPath: path,
+                originalName: name,
+                deletionDate: new Date().toISOString()
+            };
+            changed = true;
+        }
+
+        if (changed) {
+            await this.saveMetadata(metadata);
+            document.dispatchEvent(new CustomEvent("zen-recycle-bin-change"));
+        }
+    }
+
+    /**
+     * Move an item to the Recycle Bin
+     * @param {string} path
+     */
+    static async moveToRecycleBin(path) {
+        await this.moveItemsToRecycleBin([path]);
+    }
+
+    /**
+     * Restore multiple items from the Recycle Bin
+     * @param {string[]} ids
+     */
+    static async restoreItems(ids) {
+        const metadata = await this.getMetadata();
+        let changed = false;
+
+        for (const id of ids) {
+            const entry = metadata[id];
+            if (!entry) continue;
+
+            const srcPath = joinPath(RECYCLE_PATH, id);
+            let destPath = entry.originalPath;
+            const parentPath = getParentPath(destPath);
+
+            try {
+                await fs.promises.stat(parentPath);
+            } catch (e) {
+                await fs.promises.mkdir(parentPath, { recursive: true });
+            }
+
+            destPath = await this._getUniqueRestorePath(destPath);
+
+            try {
+                await fs.promises.rename(srcPath, destPath);
+            } catch (e) {
+                await this.copyRecursive(srcPath, destPath);
+                await fs.promises.rm(srcPath, { recursive: true });
+            }
+
+            delete metadata[id];
+            changed = true;
+        }
+
+        if (changed) {
+            await this.saveMetadata(metadata);
+            document.dispatchEvent(new CustomEvent("zen-recycle-bin-change"));
+        }
+    }
+
+    /**
+     * Restore an item from the Recycle Bin
+     * @param {string} id
+     */
+    static async restoreItem(id) {
+        await this.restoreItems([id]);
+    }
+
+    /**
+     * Empty the Recycle Bin
+     */
+    static async emptyRecycleBin() {
+        const metadata = await this.getMetadata();
+        const ids = Object.keys(metadata);
+
+        for (const id of ids) {
+            const path = joinPath(RECYCLE_PATH, id);
+            try {
+                await fs.promises.rm(path, { recursive: true });
+            } catch (e) {
+                console.error(`Failed to delete recycled item ${id}`, e);
+            }
+        }
+
+        await this.saveMetadata({});
+        document.dispatchEvent(new CustomEvent("zen-recycle-bin-change"));
+    }
+
+    /**
+     * Check if the Recycle Bin is empty
+     * @returns {Promise<boolean>}
+     */
+    static async isEmpty() {
+        const metadata = await this.getMetadata();
+        return Object.keys(metadata).length === 0;
+    }
+
+    /**
+     * Check if a path is the Recycle Bin folder itself
+     * @param {string} path
+     * @returns {boolean}
+     */
+    static isRecycleBinPath(path) {
+        return path === RECYCLE_PATH;
+    }
+
+    /**
+     * Check if a path is an item inside the Recycle Bin
+     * @param {string} path
+     * @returns {boolean}
+     */
+    static isRecycledItemPath(path) {
+        return path.startsWith(RECYCLE_PATH + "/") && path !== METADATA_FILE;
+    }
+
+    /**
+     * Get unique path for restoration using "Copy of" logic
+     * @private
+     */
+    static async _getUniqueRestorePath(path) {
+        let currentPath = path;
+        try {
+            await fs.promises.stat(currentPath);
+            // File exists, need new name
+        } catch (e) {
+            return currentPath;
+        }
+
+        const parent = getParentPath(path);
+        const originalName = getPathName(path);
+
+        // Windows-style copy naming: "Copy of X", "Copy (2) of X", etc.
+        const copyNOfRegex = /^Copy \((\d+)\) of (.*)$/;
+        const copyOfRegex = /^Copy of (.*)$/;
+
+        let baseName = originalName;
+        let match;
+        if ((match = originalName.match(copyNOfRegex))) {
+            baseName = match[2];
+        } else if ((match = originalName.match(copyOfRegex))) {
+            baseName = match[1];
+        }
+
+        let candidateName = `Copy of ${baseName}`;
+        currentPath = joinPath(parent, candidateName);
+        try {
+            await fs.promises.stat(currentPath);
+            // "Copy of X" exists, try "Copy (2) of X", etc.
+            let counter = 2;
+            while (true) {
+                candidateName = `Copy (${counter}) of ${baseName}`;
+                currentPath = joinPath(parent, candidateName);
+                try {
+                    await fs.promises.stat(currentPath);
+                    counter++;
+                } catch (e) {
+                    return currentPath;
+                }
+            }
+        } catch (e) {
+            return currentPath;
+        }
+    }
+
+    /**
+     * Recursively copy a file or directory
+     * @private
+     */
+    static async copyRecursive(src, dest) {
+        const stats = await fs.promises.stat(src);
+        if (stats.isDirectory()) {
+            await fs.promises.mkdir(dest, { recursive: true });
+            const files = await fs.promises.readdir(src);
+            for (const file of files) {
+                await this.copyRecursive(joinPath(src, file), joinPath(dest, file));
+            }
+        } else {
+            const data = await fs.promises.readFile(src);
+            await fs.promises.writeFile(dest, data);
+        }
+    }
+}


### PR DESCRIPTION
Implemented a comprehensive Recycle Bin system for ZenExplorer.
- Deleted items are moved to /C:/Recycled with unique IDs and metadata tracking original paths.
- Recycle Bin folder icon toggles between empty and full states.
- Items in Recycle Bin cannot be opened; they show Properties instead.
- Context menu for recycled items provides a Restore option.
- Properties dialog for recycled items shows 'Origin' instead of 'Location'.
- Supported Shift+Delete for permanent deletion.
- Implemented bulk operations to ensure consistency and performance during multi-file move/restore.
- Hidden .metadata.json from the Recycle Bin file list.

---
*PR created automatically by Jules for task [17072225180997280184](https://jules.google.com/task/17072225180997280184) started by @azayrahmad*