### PR TITLE
Implement inline rename in Zen Explorer

### DIFF
--- a/e2e/verify_naming.spec.js
+++ b/e2e/verify_naming.spec.js
@@ -20,10 +20,12 @@ test('ZenExplorer copy naming logic', async ({ page }) => {
         await zenWin.locator('.explorer-icon-view').click({ button: 'right' });
         await page.locator('.menu-item:has-text("New")').click();
         await page.locator('.menu-popup .menu-item:has-text("Folder")').click();
-        const dialog = page.locator('.window').filter({ hasText: 'Create New Folder' }).last();
-        await dialog.locator('input[type="text"]').fill(name);
-        await dialog.locator('button:has-text("OK")').click();
-        await expect(dialog).not.toBeVisible();
+
+        const renameInput = zenWin.locator('.icon-label-input');
+        await expect(renameInput).toBeVisible();
+        await renameInput.fill(name);
+        await renameInput.press('Enter');
+        await expect(renameInput).not.toBeVisible();
     };
 
     // 1. Create TestFolder

--- a/e2e/verify_zen_verification.spec.js
+++ b/e2e/verify_zen_verification.spec.js
@@ -16,9 +16,12 @@ test('ZenExplorer folder management', async ({ page }) => {
     await zenWin.locator('.explorer-icon-view').click({ button: 'right' });
     await page.locator('.menu-item:has-text("New")').click();
     await page.locator('.menu-popup .menu-item:has-text("Folder")').click();
-    const dialog = page.locator('.window').filter({ hasText: 'Create New Folder' }).last();
-    await dialog.locator('input[type="text"]').fill('VerificationFolder');
-    await dialog.locator('button:has-text("OK")').click();
+
+    const renameInput = zenWin.locator('.icon-label-input');
+    await expect(renameInput).toBeVisible();
+    await renameInput.fill('VerificationFolder');
+    await renameInput.press('Enter');
+    await expect(renameInput).not.toBeVisible();
 
     // Select it
     const icon = zenWin.locator('.explorer-icon').filter({ hasText: 'VerificationFolder' });

--- a/e2e/zenexplorer_rename.spec.js
+++ b/e2e/zenexplorer_rename.spec.js
@@ -1,0 +1,88 @@
+import { test, expect } from '@playwright/test';
+
+test('ZenExplorer inline rename mechanism', async ({ page }) => {
+    test.setTimeout(120000);
+    await page.goto('http://localhost:5173/win98-web/');
+
+    // Press a key to skip the "Press any key to continue" boot prompt
+    await page.waitForTimeout(5000);
+    await page.keyboard.press('Enter');
+
+    // Wait for the taskbar and start button to appear
+    const startButton = page.locator('button:has-text("Start")');
+    await expect(startButton).toBeVisible({ timeout: 60000 });
+
+    // Open ZenExplorer
+    await startButton.click();
+    await page.click('text=Programs');
+    await page.click('text=File Manager (ZenFS)');
+
+    const zenWin = page.locator('#zenexplorer');
+    await expect(zenWin).toBeVisible();
+    await page.screenshot({ path: '1_zen_opened.png' });
+
+    // Navigate to C:
+    await zenWin.locator('.explorer-icon').filter({ hasText: '(C:)' }).dblclick();
+    await page.screenshot({ path: '2_c_drive.png' });
+
+    // 1. Test New Folder (inline)
+    await zenWin.locator('.explorer-icon-view').click({ button: 'right' });
+    await page.locator('.menu-item:has-text("New")').click();
+    await page.locator('.menu-popup .menu-item:has-text("Folder")').click();
+
+    // Should see an input instead of a dialog
+    const renameInput = zenWin.locator('.icon-label-input');
+    await expect(renameInput).toBeVisible();
+    await expect(renameInput).toHaveValue('New Folder');
+    await page.screenshot({ path: '3_new_folder_input.png' });
+
+    // Rename to "TestFolder"
+    await renameInput.fill('TestFolder');
+    await renameInput.press('Enter');
+
+    // Should be saved
+    await expect(renameInput).not.toBeVisible();
+    const folder = zenWin.locator('.explorer-icon[data-name="TestFolder"]');
+    await expect(folder).toBeVisible();
+    await page.screenshot({ path: '4_folder_created.png' });
+
+    // 2. Test click-to-rename
+    // First click to select
+    await folder.click();
+
+    // Wait for the delay (500ms in code)
+    await page.waitForTimeout(1000);
+
+    // Click again to trigger rename
+    await folder.click();
+
+    // Should see input again
+    await expect(renameInput).toBeVisible();
+    await expect(renameInput).toHaveValue('TestFolder');
+    await page.screenshot({ path: '5_click_to_rename.png' });
+
+    // Cancel with Escape
+    await renameInput.fill('ChangedName');
+    await renameInput.press('Escape');
+
+    // Should revert
+    await expect(renameInput).not.toBeVisible();
+    await page.screenshot({ path: '6_after_cancel.png' });
+    await expect(zenWin.locator('.explorer-icon').filter({ hasText: /^TestFolder$/ })).toBeVisible();
+
+    // 3. Test Blur to save
+    const folder2 = zenWin.locator('.explorer-icon[data-name="TestFolder"]');
+    await folder2.click();
+    await page.waitForTimeout(1000);
+    await folder2.click();
+    await expect(renameInput).toBeVisible();
+    await renameInput.fill('BlurredName');
+
+    // Click background to blur
+    await renameInput.blur();
+
+    // Should save
+    await expect(renameInput).not.toBeVisible();
+    await expect(zenWin.locator('.explorer-icon[data-name="BlurredName"]')).toBeVisible();
+    await page.screenshot({ path: '7_final.png' });
+});

--- a/src/apps/explorer/explorer.css
+++ b/src/apps/explorer/explorer.css
@@ -113,3 +113,19 @@
 .explorer-content.small-width .explorer-title {
     display: block; /* Show the title */
 }
+
+.explorer-icon .icon-label-input {
+    width: 100%;
+    box-sizing: border-box;
+    border: 1px solid black;
+    background: white;
+    color: black;
+    text-align: center;
+    font-family: inherit;
+    font-size: inherit;
+    padding: 0;
+    margin: 0;
+    outline: none;
+    z-index: 10;
+    position: relative;
+}

--- a/src/apps/zenexplorer/FileOperations.js
+++ b/src/apps/zenexplorer/FileOperations.js
@@ -220,71 +220,61 @@ export class FileOperations {
     }
 
     /**
-     * Rename item with input dialog
+     * Rename item using inline rename
      * @param {string} fullPath - Full path to item
      */
     async renameItem(fullPath) {
-        const oldName = fullPath.split("/").pop();
-
-        showInputDialog({
-            title: "Rename",
-            label: "New name:",
-            defaultValue: oldName,
-            parentWindow: this.app.win,
-            onSubmit: async (newName) => {
-                if (newName === oldName) return;
-
-                try {
-                    const parentPath = fullPath.substring(0, fullPath.lastIndexOf("/"));
-                    const newPath = parentPath === "" ? `/${newName}` : `${parentPath}/${newName}`;
-                    await fs.promises.rename(fullPath, newPath);
-                    this.app.navigateTo(this.app.currentPath);
-                } catch (e) {
-                    handleFileSystemError("rename", e, oldName);
-                }
-            }
-        });
+        this.app.enterRenameModeByPath(fullPath);
     }
 
     /**
-     * Create new folder with input dialog
+     * Create new folder with inline rename
      */
     async createNewFolder() {
-        showInputDialog({
-            title: "Create New Folder",
-            label: "Folder name:",
-            defaultValue: "New Folder",
-            parentWindow: this.app.win,
-            onSubmit: async (name) => {
-                try {
-                    const newPath = joinPath(this.app.currentPath, name);
-                    await fs.promises.mkdir(newPath);
-                    this.app.navigateTo(this.app.currentPath); // Refresh
-                } catch (e) {
-                    handleFileSystemError("create", e, "folder");
-                }
-            }
-        });
+        try {
+            const name = await this.getUniqueName(this.app.currentPath, "New Folder");
+            const newPath = joinPath(this.app.currentPath, name);
+            await fs.promises.mkdir(newPath);
+            await this.app.navigateTo(this.app.currentPath, true, true);
+            this.app.enterRenameModeByPath(newPath);
+        } catch (e) {
+            handleFileSystemError("create", e, "folder");
+        }
     }
 
     /**
-     * Create new text document with input dialog
+     * Create new text document with inline rename
      */
     async createNewTextFile() {
-        showInputDialog({
-            title: "Create New Text Document",
-            label: "File name:",
-            defaultValue: "New Text Document.txt",
-            parentWindow: this.app.win,
-            onSubmit: async (name) => {
-                try {
-                    const newPath = joinPath(this.app.currentPath, name);
-                    await fs.promises.writeFile(newPath, "");
-                    this.app.navigateTo(this.app.currentPath); // Refresh
-                } catch (e) {
-                    handleFileSystemError("create", e, "file");
-                }
+        try {
+            const name = await this.getUniqueName(this.app.currentPath, "New Text Document", ".txt");
+            const newPath = joinPath(this.app.currentPath, name);
+            await fs.promises.writeFile(newPath, "");
+            await this.app.navigateTo(this.app.currentPath, true, true);
+            this.app.enterRenameModeByPath(newPath);
+        } catch (e) {
+            handleFileSystemError("create", e, "file");
+        }
+    }
+
+    /**
+     * Get a unique name for a new item
+     * @private
+     */
+    async getUniqueName(parentPath, baseName, extension = "") {
+        let name = baseName + extension;
+        let counter = 1;
+        while (true) {
+            const checkPath = joinPath(parentPath, name);
+            try {
+                await fs.promises.stat(checkPath);
+                // Exists, try next
+                counter++;
+                name = `${baseName} (${counter})${extension}`;
+            } catch (e) {
+                // Doesn't exist, we can use it
+                return name;
             }
-        });
+        }
     }
 }

--- a/src/apps/zenexplorer/ZenExplorerApp.js
+++ b/src/apps/zenexplorer/ZenExplorerApp.js
@@ -24,7 +24,6 @@ import ZenClipboardManager from "./utils/ZenClipboardManager.js";
 import { ZenFloppyManager } from "./utils/ZenFloppyManager.js";
 import { RecycleBinManager } from "./utils/RecycleBinManager.js";
 import { playSound } from "../../utils/soundManager.js";
-import { ShowDialogWindow } from "../../components/DialogWindow.js";
 
 // MenuBar is expected to be global from public/os-gui/MenuBar.js
 
@@ -45,6 +44,9 @@ export class ZenExplorerApp extends Application {
         this.currentPath = "/";
         this.navHistory = new NavigationHistory();
         this.fileOps = new FileOperations(this);
+        this.lastSelectedIcon = null;
+        this.selectionTimestamp = 0;
+        this._isRenaming = false;
     }
 
     async _createWindow(initialPath) {
@@ -309,8 +311,21 @@ export class ZenExplorerApp extends Application {
                 new window.ContextMenu(menuItems, e);
             },
             onSelectionChange: () => {
-                const count = this.iconManager.selectedIcons.size;
+                const selectedIcons = this.iconManager.selectedIcons;
+                const count = selectedIcons.size;
                 this.statusBar.setText(`${count} object(s) selected`);
+
+                if (count === 1) {
+                    const icon = [...selectedIcons][0];
+                    if (this.lastSelectedIcon !== icon) {
+                        this.lastSelectedIcon = icon;
+                        this.selectionTimestamp = Date.now();
+                    }
+                } else {
+                    this.lastSelectedIcon = null;
+                    this.selectionTimestamp = 0;
+                }
+
                 if (this.menuBar) {
                     this._updateMenuBar();
                 }
@@ -579,6 +594,17 @@ export class ZenExplorerApp extends Application {
                 const isDir = fileStat.isDirectory();
                 const iconDiv = await renderFileIcon(file, fullPath, isDir, { metadata, recycleBinEmpty });
                 this.iconManager.configureIcon(iconDiv);
+
+                // Add click listener for inline rename
+                iconDiv.addEventListener("click", (e) => {
+                    if (this._isRenaming) return;
+                    if (this.lastSelectedIcon === iconDiv && (Date.now() - this.selectionTimestamp) > 500) {
+                        this.enterRenameMode(iconDiv);
+                        e.stopPropagation();
+                    }
+                });
+
+
                 icons.push(iconDiv);
             } catch (e) {
                 console.warn("Could not stat", fullPath);
@@ -593,6 +619,92 @@ export class ZenExplorerApp extends Application {
         this.iconContainer.appendChild(fragment);
 
         this.statusBar.setText(`${icons.length} object(s)`);
+    }
+
+    /**
+     * Enter inline rename mode for an icon
+     * @param {HTMLElement} icon - The icon element
+     */
+    async enterRenameMode(icon) {
+        if (this._isRenaming) return;
+
+        const path = icon.getAttribute("data-path");
+        const isRootItem = getParentPath(path) === "/";
+        const isRecycleBin = RecycleBinManager.isRecycleBinPath(path);
+
+        if (isRootItem || isRecycleBin) return;
+
+        this._isRenaming = true;
+
+        const label = icon.querySelector(".icon-label");
+        const fullPath = icon.getAttribute("data-path");
+        const oldName = fullPath.split("/").pop();
+
+        const input = document.createElement("input");
+        input.type = "text";
+        input.className = "icon-label-input";
+        input.value = oldName;
+
+        label.innerHTML = "";
+        label.appendChild(input);
+
+        // Select filename without extension
+        const dotIndex = oldName.lastIndexOf(".");
+        if (dotIndex > 0 && icon.getAttribute("data-type") !== "directory") {
+            input.setSelectionRange(0, dotIndex);
+        } else {
+            input.select();
+        }
+        input.focus();
+
+        const finishRename = async (save) => {
+            if (!this._isRenaming) return;
+            this._isRenaming = false;
+
+            const newName = input.value.trim();
+            if (save && newName && newName !== oldName) {
+                try {
+                    const parentPath = getParentPath(fullPath);
+                    const newPath = joinPath(parentPath, newName);
+                    await fs.promises.rename(fullPath, newPath);
+                    await this.navigateTo(this.currentPath, true, true);
+                } catch (e) {
+                    alert(`Error renaming: ${e.message}`);
+                    label.textContent = getDisplayName(fullPath);
+                }
+            } else {
+                label.textContent = getDisplayName(fullPath);
+            }
+        };
+
+        input.onkeydown = (e) => {
+            e.stopPropagation();
+            if (e.key === "Enter") {
+                finishRename(true);
+            } else if (e.key === "Escape") {
+                finishRename(false);
+            }
+        };
+
+        input.onblur = () => {
+            finishRename(true);
+        };
+
+        // Prevent click propagation to avoid re-triggering rename
+        input.onclick = (e) => e.stopPropagation();
+        input.ondblclick = (e) => e.stopPropagation();
+    }
+
+    /**
+     * Enter rename mode finding icon by path
+     * @param {string} path
+     */
+    enterRenameModeByPath(path) {
+        const icon = this.iconContainer.querySelector(`.explorer-icon[data-path="${path}"]`);
+        if (icon) {
+            this.iconManager.setSelection(new Set([icon]));
+            this.enterRenameMode(icon);
+        }
     }
 
     goUp() {


### PR DESCRIPTION
This change implements an inline rename mechanism for Zen Explorer, replacing the previous dialog-based approach. Users can now rename files and folders by clicking an already-selected icon or via the context menu/menu bar. The new mechanism is also applied when creating new folders and text documents. Save is triggered by Enter or Blur, while Escape cancels. Existing E2E tests have been updated to support this new workflow, and a new test suite has been added to verify it.

---
*PR created automatically by Jules for task [778489473527717333](https://jules.google.com/task/778489473527717333) started by @azayrahmad*