### PR TITLE
Enable Removable Disk Mounting in Zen Explorer

### DIFF
--- a/src/apps/zenexplorer/MenuBarBuilder.js
+++ b/src/apps/zenexplorer/MenuBarBuilder.js
@@ -4,6 +4,7 @@ import { getDisplayName, getParentPath } from "./utils/PathUtils.js";
 import ZenClipboardManager from "./utils/ZenClipboardManager.js";
 import { PropertiesManager } from "./utils/PropertiesManager.js";
 import ZenUndoManager from "./utils/ZenUndoManager.js";
+import { ZenRemovableDiskManager } from "./utils/ZenRemovableDiskManager.js";
 
 /**
  * MenuBarBuilder - Constructs menu bar for ZenExplorer
@@ -128,6 +129,11 @@ export class MenuBarBuilder {
         label: "&Eject CD",
         action: () => this.app.ejectCD(),
         enabled: () => mounts.has("/E:"),
+      },
+      {
+        label: "&Insert Removable Disk",
+        action: () => this.app.driveManager.insertRemovableDisk(),
+        enabled: () => ZenRemovableDiskManager.getAvailableLetter() !== null,
       },
       "MENU_DIVIDER",
       {

--- a/src/apps/zenexplorer/ZenExplorerApp.js
+++ b/src/apps/zenexplorer/ZenExplorerApp.js
@@ -120,6 +120,9 @@ export class ZenExplorerApp extends Application {
     // 7d. Undo listener
     this._setupUndoListener();
 
+    // 7e. Removable Disk listener
+    this._setupRemovableDiskListener();
+
     // 8. Initial Navigation
     this.navigateTo(this.currentPath);
 
@@ -337,6 +340,25 @@ export class ZenExplorerApp extends Application {
     document.addEventListener("zen-cd-change", this._cdHandler);
   }
 
+  /**
+   * Setup Removable Disk change listener
+   * @private
+   */
+  _setupRemovableDiskListener() {
+    this._removableDiskHandler = () => {
+      const driveMatch = this.currentPath.match(/^\/([A-Z]:)/);
+      if (driveMatch && !mounts.has(driveMatch[0])) {
+        this.navigateTo("/");
+      } else {
+        this.navigateTo(this.currentPath, true, true);
+      }
+    };
+    document.addEventListener(
+      "zen-removable-disk-change",
+      this._removableDiskHandler,
+    );
+  }
+
   _onClose() {
     if (this.resizeObserver) {
       this.resizeObserver.disconnect();
@@ -352,6 +374,12 @@ export class ZenExplorerApp extends Application {
     }
     if (this._cdHandler) {
       document.removeEventListener("zen-cd-change", this._cdHandler);
+    }
+    if (this._removableDiskHandler) {
+      document.removeEventListener(
+        "zen-removable-disk-change",
+        this._removableDiskHandler,
+      );
     }
     if (this._recycleBinHandler) {
       document.removeEventListener(

--- a/src/apps/zenexplorer/utils/PathUtils.js
+++ b/src/apps/zenexplorer/utils/PathUtils.js
@@ -1,5 +1,6 @@
 import { ZenFloppyManager } from "./ZenFloppyManager.js";
 import { ZenCDManager } from "./ZenCDManager.js";
+import { ZenRemovableDiskManager } from "./ZenRemovableDiskManager.js";
 
 /**
  * Utility functions for path manipulation in ZenExplorer
@@ -98,6 +99,10 @@ export function getDisplayName(path) {
         return label ? `${label} (${name.toUpperCase()})` : `CD-ROM (${name.toUpperCase()})`;
     }
     if (name && name.match(/^[A-Z]:$/i)) {
+        const letter = name.charAt(0).toUpperCase();
+        if (ZenRemovableDiskManager.isMounted(letter)) {
+            return `Removable Disk (${letter}:)`;
+        }
         return `(${name.toUpperCase()})`;
     }
     return name || path;

--- a/src/apps/zenexplorer/utils/ZenContextMenuBuilder.js
+++ b/src/apps/zenexplorer/utils/ZenContextMenuBuilder.js
@@ -1,6 +1,7 @@
 import { mounts } from "@zenfs/core";
 import { RecycleBinManager } from "./RecycleBinManager.js";
 import { PropertiesManager } from "./PropertiesManager.js";
+import { ZenRemovableDiskManager } from "./ZenRemovableDiskManager.js";
 import { getParentPath, getPathName } from "./PathUtils.js";
 import ZenClipboardManager from "./ZenClipboardManager.js";
 import { ShowDialogWindow } from "../../../components/DialogWindow.js";
@@ -22,6 +23,9 @@ export class ZenContextMenuBuilder {
     const isFloppyMounted = mounts.has("/A:");
     const isCD = path === "/E:";
     const isCDMounted = mounts.has("/E:");
+    const driveLetterMatch = path.match(/^\/([A-Z]):$/i);
+    const driveLetter = driveLetterMatch ? driveLetterMatch[1].toUpperCase() : null;
+    const isRemovableDiskMounted = driveLetter && ZenRemovableDiskManager.isMounted(driveLetter);
     const isRecycledItem = RecycleBinManager.isRecycledItemPath(path);
     const isRecycleBin = RecycleBinManager.isRecycleBinPath(path);
 
@@ -118,6 +122,13 @@ export class ZenContextMenuBuilder {
             action: () => this.app.driveManager.insertCD(),
           });
         }
+      }
+
+      if (isRemovableDiskMounted) {
+        menuItems.push({
+          label: "Eject",
+          action: () => this.app.driveManager.ejectRemovableDisk(driveLetter),
+        });
       }
 
       menuItems.push(

--- a/src/apps/zenexplorer/utils/ZenRemovableDiskManager.js
+++ b/src/apps/zenexplorer/utils/ZenRemovableDiskManager.js
@@ -1,0 +1,33 @@
+/**
+ * ZenRemovableDiskManager - Singleton to track mounted removable disks
+ */
+
+const mountedDisks = new Map(); // letter -> label
+
+export const ZenRemovableDiskManager = {
+    mount(letter, label) {
+        mountedDisks.set(letter.toUpperCase(), label);
+    },
+    unmount(letter) {
+        mountedDisks.delete(letter.toUpperCase());
+    },
+    getLabel(letter) {
+        return mountedDisks.get(letter.toUpperCase());
+    },
+    getMountedLetters() {
+        return Array.from(mountedDisks.keys());
+    },
+    isMounted(letter) {
+        return mountedDisks.has(letter.toUpperCase());
+    },
+    getAvailableLetter() {
+        const excluded = ['A', 'B', 'C', 'E'];
+        for (let i = 0; i < 26; i++) {
+            const letter = String.fromCharCode(65 + i);
+            if (!excluded.includes(letter) && !mountedDisks.has(letter)) {
+                return letter;
+            }
+        }
+        return null;
+    }
+};


### PR DESCRIPTION
This change enables users to mount local folders as removable drives (D: through Z:, excluding E:) in Zen Explorer. 

Key features:
- **Automatic Letter Assignment**: Drives are assigned the first available letter from D to Z, skipping A, B, C, and E.
- **Dynamic Visibility**: Drive icons only appear in "My Computer" when they are actively mounted.
- **Labeling**: Mounted drives are labeled as "Removable Disk (X:)".
- **Integration**: Added "Insert Removable Disk" to the File menu and an "Eject" option to the context menu for mounted drives.
- **Multi-window Sync**: Mount and eject operations trigger a custom event that refreshes all open explorer windows.
- **Limit**: Supports up to 22 concurrent removable disks (D, F-Z).

---
*PR created automatically by Jules for task [17060169572921107927](https://jules.google.com/task/17060169572921107927) started by @azayrahmad*