### PR TITLE
Icon Rearrangement and Auto Arrange in ZenExplorer

### DIFF
--- a/src/apps/explorer/explorer.css
+++ b/src/apps/explorer/explorer.css
@@ -77,7 +77,15 @@
 }
 
 .explorer-icon-view.has-absolute-icons {
+    display: block;
     position: relative;
+    min-height: 100%;
+    min-width: 100%;
+}
+
+.explorer-icon-view.has-absolute-icons .explorer-icon {
+    position: absolute;
+    margin: 0;
 }
 
 .explorer-icon {

--- a/src/apps/zenexplorer/FileOperations.js
+++ b/src/apps/zenexplorer/FileOperations.js
@@ -6,6 +6,7 @@ import { joinPath, normalizePath, getPathName } from "./utils/PathUtils.js";
 import ZenClipboardManager from "./utils/ZenClipboardManager.js";
 import { RecycleBinManager } from "./utils/RecycleBinManager.js";
 import ZenUndoManager from "./utils/ZenUndoManager.js";
+import ZenLayoutManager from "./utils/ZenLayoutManager.js";
 
 /**
  * FileOperations - Handles file system operations with user interaction
@@ -54,8 +55,9 @@ export class FileOperations {
      * Move items directly to a destination
      * @param {Array<string>} sourcePaths
      * @param {string} destinationPath
+     * @param {Object} options
      */
-    async moveItemsDirect(sourcePaths, destinationPath) {
+    async moveItemsDirect(sourcePaths, destinationPath, options = {}) {
         const targetPaths = [];
         try {
             for (const itemPath of sourcePaths) {
@@ -63,6 +65,16 @@ export class FileOperations {
                 const targetPath = await this.getUniquePastePath(destinationPath, itemName, "cut");
                 await fs.promises.rename(itemPath, targetPath);
                 targetPaths.push(targetPath);
+            }
+
+            // Save positions if provided
+            if (options.dropX !== undefined && options.dropY !== undefined) {
+                const positions = {};
+                targetPaths.forEach((path, i) => {
+                    const name = getPathName(path);
+                    positions[name] = { x: options.dropX + i * 10, y: options.dropY + i * 10 };
+                });
+                await ZenLayoutManager.updateItemPositions(destinationPath, positions);
             }
 
             ZenUndoManager.push({
@@ -81,8 +93,9 @@ export class FileOperations {
      * Copy items directly to a destination
      * @param {Array<string>} sourcePaths
      * @param {string} destinationPath
+     * @param {Object} options
      */
-    async copyItemsDirect(sourcePaths, destinationPath) {
+    async copyItemsDirect(sourcePaths, destinationPath, options = {}) {
         const targetPaths = [];
         try {
             for (const itemPath of sourcePaths) {
@@ -90,6 +103,16 @@ export class FileOperations {
                 const targetPath = await this.getUniquePastePath(destinationPath, itemName, "copy");
                 await this.copyRecursive(itemPath, targetPath);
                 targetPaths.push(targetPath);
+            }
+
+            // Save positions if provided
+            if (options.dropX !== undefined && options.dropY !== undefined) {
+                const positions = {};
+                targetPaths.forEach((path, i) => {
+                    const name = getPathName(path);
+                    positions[name] = { x: options.dropX + i * 10, y: options.dropY + i * 10 };
+                });
+                await ZenLayoutManager.updateItemPositions(destinationPath, positions);
             }
 
             ZenUndoManager.push({

--- a/src/apps/zenexplorer/ZenExplorerApp.js
+++ b/src/apps/zenexplorer/ZenExplorerApp.js
@@ -21,6 +21,7 @@ import { ZenKeyboardHandler } from "./utils/ZenKeyboardHandler.js";
 import { RecycleBinManager } from "./utils/RecycleBinManager.js";
 import { PropertiesManager } from "./utils/PropertiesManager.js";
 import ZenDragDropManager from "./utils/ZenDragDropManager.js";
+import ZenLayoutManager from "./utils/ZenLayoutManager.js";
 
 export class ZenExplorerApp extends Application {
   static config = {
@@ -127,6 +128,9 @@ export class ZenExplorerApp extends Application {
 
     // 7f. FS change listener
     this._setupFSListener();
+
+    // 7g. Layout change listener
+    this._setupLayoutListener();
 
     // 8. Initial Navigation
     this.navigateTo(this.currentPath);
@@ -282,12 +286,130 @@ export class ZenExplorerApp extends Application {
     document.addEventListener("zen-fs-change", this._fsHandler);
   }
 
+  /**
+   * Setup Layout change listener
+   * @private
+   */
+  _setupLayoutListener() {
+    this._layoutHandler = (e) => {
+      if (e.detail.path === this.currentPath) {
+        this.navigateTo(this.currentPath, true, true);
+      }
+    };
+    document.addEventListener("zen-layout-change", this._layoutHandler);
+  }
+
   async navigateTo(path, isHistoryNav = false, skipMRU = false) {
     const result = await this.navController.navigateTo(path, isHistoryNav, skipMRU);
     if (this.iconContainer) {
       this.iconContainer.setAttribute("data-current-path", this.currentPath);
+      // Update autoArrange state from layout
+      const layout = await ZenLayoutManager.getLayout(this.currentPath);
+      this.autoArrange = layout.autoArrange;
     }
     return result;
+  }
+
+  /**
+   * Handle icon rearrangement within the current folder
+   * @param {string[]} sourcePaths - Paths of dragged items
+   * @param {number} clientX - Drop X coordinate
+   * @param {number} clientY - Drop Y coordinate
+   */
+  /**
+   * Toggle Auto Arrange for the current folder
+   */
+  async toggleAutoArrange() {
+    const layout = await ZenLayoutManager.getLayout(this.currentPath);
+    layout.autoArrange = !layout.autoArrange;
+    if (layout.autoArrange) {
+      layout.positions = {}; // Delete manual positions when turning ON
+    } else {
+      // Capture current grid positions when turning OFF
+      const icons = this.iconContainer.querySelectorAll(".explorer-icon");
+      const containerRect = this.iconContainer.getBoundingClientRect();
+      const scrollLeft = this.iconContainer.scrollLeft;
+      const scrollTop = this.iconContainer.scrollTop;
+
+      icons.forEach((icon) => {
+        const name = icon.getAttribute("data-name");
+        const rect = icon.getBoundingClientRect();
+        layout.positions[name] = {
+          x: rect.left - containerRect.left + scrollLeft,
+          y: rect.top - containerRect.top + scrollTop,
+        };
+      });
+    }
+    await ZenLayoutManager.saveLayout(this.currentPath, layout);
+    this.autoArrange = layout.autoArrange;
+    // Refresh the view to apply changes (e.g., add/remove classes and absolute positioning)
+    this.directoryView.renderDirectoryContents(this.currentPath);
+  }
+
+  async handleRearrange(sourcePaths, clientX, clientY) {
+    const layout = await ZenLayoutManager.getLayout(this.currentPath);
+    const rect = this.iconContainer.getBoundingClientRect();
+    const scrollLeft = this.iconContainer.scrollLeft;
+    const scrollTop = this.iconContainer.scrollTop;
+
+    if (!layout.autoArrange) {
+      // Free-form placement
+      sourcePaths.forEach((path, index) => {
+        const name = path.split("/").pop();
+        // Place item at drop coordinates, adjusting for container scroll and offset
+        // We use a small offset for multiple items
+        layout.positions[name] = {
+          x: clientX - rect.left + scrollLeft + index * 10,
+          y: clientY - rect.top + scrollTop + index * 10,
+        };
+      });
+    } else {
+      // Auto-arrange reordering
+      const icons = [...this.iconContainer.querySelectorAll(".explorer-icon")];
+      let targetIcon = null;
+
+      // Find icon under the cursor
+      for (const icon of icons) {
+        const iconRect = icon.getBoundingClientRect();
+        if (
+          clientX >= iconRect.left &&
+          clientX <= iconRect.right &&
+          clientY >= iconRect.top &&
+          clientY <= iconRect.bottom
+        ) {
+          targetIcon = icon;
+          break;
+        }
+      }
+
+      const draggedNames = sourcePaths.map((p) => p.split("/").pop());
+      // Get current order from DOM if not in layout
+      const currentOrder =
+        layout.order && layout.order.length > 0
+          ? [...layout.order]
+          : icons.map((i) => i.getAttribute("data-name"));
+
+      // Remove dragged items from current order to re-insert them
+      let newOrder = currentOrder.filter(
+        (name) => !draggedNames.includes(name),
+      );
+
+      if (targetIcon) {
+        const targetName = targetIcon.getAttribute("data-name");
+        const targetIndex = newOrder.indexOf(targetName);
+        if (targetIndex !== -1) {
+          newOrder.splice(targetIndex, 0, ...draggedNames);
+        } else {
+          newOrder.push(...draggedNames);
+        }
+      } else {
+        // Drop at end
+        newOrder.push(...draggedNames);
+      }
+      layout.order = newOrder;
+    }
+
+    await ZenLayoutManager.saveLayout(this.currentPath, layout);
   }
 
   enterRenameMode(icon) {
@@ -428,6 +550,9 @@ export class ZenExplorerApp extends Application {
     }
     if (this._fsHandler) {
       document.removeEventListener("zen-fs-change", this._fsHandler);
+    }
+    if (this._layoutHandler) {
+      document.removeEventListener("zen-layout-change", this._layoutHandler);
     }
   }
 }

--- a/src/apps/zenexplorer/ZenExplorerApp.js
+++ b/src/apps/zenexplorer/ZenExplorerApp.js
@@ -346,21 +346,17 @@ export class ZenExplorerApp extends Application {
     this.directoryView.renderDirectoryContents(this.currentPath);
   }
 
-  async handleRearrange(sourcePaths, clientX, clientY) {
+  async handleRearrange(sourcePaths, x, y) {
     const layout = await ZenLayoutManager.getLayout(this.currentPath);
-    const rect = this.iconContainer.getBoundingClientRect();
-    const scrollLeft = this.iconContainer.scrollLeft;
-    const scrollTop = this.iconContainer.scrollTop;
 
     if (!layout.autoArrange) {
       // Free-form placement
       sourcePaths.forEach((path, index) => {
         const name = path.split("/").pop();
-        // Place item at drop coordinates, adjusting for container scroll and offset
-        // We use a small offset for multiple items
+        // Use adjusted coordinates directly
         layout.positions[name] = {
-          x: clientX - rect.left + scrollLeft + index * 10,
-          y: clientY - rect.top + scrollTop + index * 10,
+          x: x + index * 10,
+          y: y + index * 10,
         };
       });
     } else {
@@ -368,14 +364,13 @@ export class ZenExplorerApp extends Application {
       const icons = [...this.iconContainer.querySelectorAll(".explorer-icon")];
       let targetIcon = null;
 
-      // Find icon under the cursor
+      // Find icon under the cursor using container-relative coordinates
       for (const icon of icons) {
-        const iconRect = icon.getBoundingClientRect();
         if (
-          clientX >= iconRect.left &&
-          clientX <= iconRect.right &&
-          clientY >= iconRect.top &&
-          clientY <= iconRect.bottom
+          x >= icon.offsetLeft &&
+          x <= icon.offsetLeft + icon.offsetWidth &&
+          y >= icon.offsetTop &&
+          y <= icon.offsetTop + icon.offsetHeight
         ) {
           targetIcon = icon;
           break;

--- a/src/apps/zenexplorer/components/ZenDirectoryView.js
+++ b/src/apps/zenexplorer/components/ZenDirectoryView.js
@@ -11,6 +11,7 @@ import {
   joinPath,
   getParentPath,
 } from "../utils/PathUtils.js";
+import ZenLayoutManager from "../utils/ZenLayoutManager.js";
 
 export class ZenDirectoryView {
   constructor(app) {
@@ -55,19 +56,70 @@ export class ZenDirectoryView {
    * Render directory contents
    */
   async renderDirectoryContents(path) {
+    const layout = await ZenLayoutManager.getLayout(path);
     let files = await fs.promises.readdir(path);
 
-    // Sort files alphabetically (so A: comes before C:)
-    files.sort((a, b) => a.localeCompare(b));
+    // Hide metadata file in recycle bin and layout file
+    files = files.filter((f) => f !== ".zen_layout.json");
+    if (RecycleBinManager.isRecycleBinPath(path)) {
+      files = files.filter((f) => f !== ".metadata.json");
+    }
+
+    // Apply layout logic only for icon views (large/small)
+    const isIconView =
+      this.app.viewMode === "large" || this.app.viewMode === "small";
+
+    if (isIconView) {
+      if (layout.autoArrange) {
+        this.app.iconContainer.classList.remove("has-absolute-icons");
+
+        const order = layout.order || [];
+        const getOrderIndex = (name) => {
+          const index = order.indexOf(name);
+          return index === -1 ? Infinity : index;
+        };
+
+        // Split into folders and files
+        const folderFiles = [];
+        const normalFiles = [];
+
+        for (const file of files) {
+          const fullPath = joinPath(path, file);
+          try {
+            const stat = await fs.promises.stat(fullPath);
+            if (stat.isDirectory()) folderFiles.push(file);
+            else normalFiles.push(file);
+          } catch (e) {
+            normalFiles.push(file);
+          }
+        }
+
+        // Sort each group by custom order, then alphabetically
+        const sortByOrder = (a, b) => {
+          const orderA = getOrderIndex(a);
+          const orderB = getOrderIndex(b);
+          if (orderA !== orderB) return orderA - orderB;
+          return a.localeCompare(b);
+        };
+
+        folderFiles.sort(sortByOrder);
+        normalFiles.sort(sortByOrder);
+
+        files = [...folderFiles, ...normalFiles];
+      } else {
+        this.app.iconContainer.classList.add("has-absolute-icons");
+        // Alphabetical sort as baseline for free-form
+        files.sort((a, b) => a.localeCompare(b));
+      }
+    } else {
+      this.app.iconContainer.classList.remove("has-absolute-icons");
+      // Default alphabetical sort (so A: comes before C:)
+      files.sort((a, b) => a.localeCompare(b));
+    }
 
     // Clear view
     this.app.iconContainer.innerHTML = "";
     this.app.iconManager.clearSelection();
-
-    // Hide metadata file in recycle bin
-    if (RecycleBinManager.isRecycleBinPath(path)) {
-      files = files.filter((f) => f !== ".metadata.json");
-    }
 
     const isRecycleBin = RecycleBinManager.isRecycleBinPath(path);
     const metadata = isRecycleBin
@@ -182,6 +234,26 @@ export class ZenDirectoryView {
           }
         });
 
+        // Apply absolute position if auto-arrange is off
+        if (isIconView && !layout.autoArrange) {
+          iconDiv.style.position = "absolute";
+          if (layout.positions && layout.positions[file]) {
+            iconDiv.style.left = `${layout.positions[file].x}px`;
+            iconDiv.style.top = `${layout.positions[file].y}px`;
+          } else {
+            // Fallback placement for items without saved positions
+            const gridX = 75;
+            const gridY = 85;
+            const cols =
+              Math.floor(this.app.iconContainer.clientWidth / gridX) || 1;
+            const index = icons.length;
+            const x = (index % cols) * gridX + 10;
+            const y = Math.floor(index / cols) * gridY + 10;
+            iconDiv.style.left = `${x}px`;
+            iconDiv.style.top = `${y}px`;
+          }
+        }
+
         icons.push(iconDiv);
       } catch (e) {
         console.warn("Could not stat", fullPath);
@@ -192,7 +264,32 @@ export class ZenDirectoryView {
     this.app.iconContainer.innerHTML = "";
     this.app.iconManager.clearSelection();
     const fragment = document.createDocumentFragment();
-    icons.forEach((icon) => fragment.appendChild(icon));
+
+    let maxRight = 0;
+    let maxBottom = 0;
+
+    icons.forEach((icon) => {
+      fragment.appendChild(icon);
+      if (isIconView && !layout.autoArrange) {
+        const left = parseInt(icon.style.left) || 0;
+        const top = parseInt(icon.style.top) || 0;
+        maxRight = Math.max(maxRight, left + 75);
+        maxBottom = Math.max(maxBottom, top + 90);
+      }
+    });
+
+    // Add spacer for absolute layout to enable scrollbars
+    if (isIconView && !layout.autoArrange) {
+      const spacer = document.createElement("div");
+      spacer.style.position = "absolute";
+      spacer.style.left = `${maxRight}px`;
+      spacer.style.top = `${maxBottom}px`;
+      spacer.style.width = "1px";
+      spacer.style.height = "1px";
+      spacer.style.visibility = "hidden";
+      fragment.appendChild(spacer);
+    }
+
     this.app.iconContainer.appendChild(fragment);
 
     this.app.statusBar.setText(`${icons.length} object(s)`);

--- a/src/apps/zenexplorer/utils/ZenContextMenuBuilder.js
+++ b/src/apps/zenexplorer/utils/ZenContextMenuBuilder.js
@@ -189,6 +189,18 @@ export class ZenContextMenuBuilder {
           },
         ],
       },
+      {
+        label: "Arrange Icons",
+        submenu: [
+          {
+            label: "Auto Arrange",
+            checkbox: {
+              check: () => this.app.autoArrange,
+              toggle: () => this.app.toggleAutoArrange(),
+            },
+          },
+        ],
+      },
       "MENU_DIVIDER",
       {
         label: "Paste",

--- a/src/apps/zenexplorer/utils/ZenDragDropManager.js
+++ b/src/apps/zenexplorer/utils/ZenDragDropManager.js
@@ -72,11 +72,11 @@ export class ZenDragDropManager {
             clone.classList.remove('selected');
             clone.classList.add('ghost-item');
 
-            if (index > 0) {
-                clone.style.position = 'absolute';
-                clone.style.left = `${index * 4}px`;
-                clone.style.top = `${index * 4}px`;
-            }
+            // Reset positioning style from the original icon (important for free-form mode)
+            clone.style.position = index === 0 ? 'static' : 'absolute';
+            clone.style.left = index === 0 ? '' : `${index * 4}px`;
+            clone.style.top = index === 0 ? '' : `${index * 4}px`;
+            clone.style.margin = '0';
 
             ghost.appendChild(clone);
         });

--- a/src/apps/zenexplorer/utils/ZenDragDropManager.js
+++ b/src/apps/zenexplorer/utils/ZenDragDropManager.js
@@ -1,3 +1,5 @@
+import { openApps } from "../../Application.js";
+
 /**
  * ZenDragDropManager - Handles custom drag and drop for ZenExplorer
  */
@@ -166,6 +168,9 @@ export class ZenDragDropManager {
         if (!this.dropTarget) return;
 
         let destinationPath = null;
+        let targetWindow = this.dropTarget.closest('.window');
+        let targetApp = targetWindow ? openApps.get(targetWindow.id) : null;
+
         if (this.dropTarget.classList.contains('explorer-icon')) {
             destinationPath = this.dropTarget.getAttribute('data-path');
         } else if (this.dropTarget.classList.contains('explorer-icon-view')) {
@@ -176,17 +181,30 @@ export class ZenDragDropManager {
 
         const sourcePaths = this.draggedItems.map(item => item.path);
 
-        // Prevent dropping on itself or same folder if not copy
+        // Calculate coordinates relative to target container
+        let dropX = null;
+        let dropY = null;
+        if (targetApp && targetApp.iconContainer) {
+            const rect = targetApp.iconContainer.getBoundingClientRect();
+            dropX = e.clientX - rect.left + targetApp.iconContainer.scrollLeft;
+            dropY = e.clientY - rect.top + targetApp.iconContainer.scrollTop;
+        }
+
+        // Check if we are dragging into the same folder
         const sourceDir = sourcePaths[0].substring(0, sourcePaths[0].lastIndexOf('/')) || '/';
         if (!isCopy && destinationPath === sourceDir) {
+            // Handle rearrangement
+            if (this.sourceApp.handleRearrange) {
+                await this.sourceApp.handleRearrange(sourcePaths, e.clientX, e.clientY);
+            }
             return;
         }
 
         try {
             if (isCopy) {
-                await this.sourceApp.fileOps.copyItemsDirect(sourcePaths, destinationPath);
+                await this.sourceApp.fileOps.copyItemsDirect(sourcePaths, destinationPath, { dropX, dropY });
             } else {
-                await this.sourceApp.fileOps.moveItemsDirect(sourcePaths, destinationPath);
+                await this.sourceApp.fileOps.moveItemsDirect(sourcePaths, destinationPath, { dropX, dropY });
             }
         } catch (err) {
             console.error('Drop failed:', err);

--- a/src/apps/zenexplorer/utils/ZenDragDropManager.js
+++ b/src/apps/zenexplorer/utils/ZenDragDropManager.js
@@ -186,8 +186,9 @@ export class ZenDragDropManager {
         let dropY = null;
         if (targetApp && targetApp.iconContainer) {
             const rect = targetApp.iconContainer.getBoundingClientRect();
-            dropX = e.clientX - rect.left + targetApp.iconContainer.scrollLeft;
-            dropY = e.clientY - rect.top + targetApp.iconContainer.scrollTop;
+            // Subtract offsetX/offsetY so the icon's top-left is where it was relative to the cursor
+            dropX = e.clientX - rect.left + targetApp.iconContainer.scrollLeft - this.offsetX;
+            dropY = e.clientY - rect.top + targetApp.iconContainer.scrollTop - this.offsetY;
         }
 
         // Check if we are dragging into the same folder
@@ -195,7 +196,7 @@ export class ZenDragDropManager {
         if (!isCopy && destinationPath === sourceDir) {
             // Handle rearrangement
             if (this.sourceApp.handleRearrange) {
-                await this.sourceApp.handleRearrange(sourcePaths, e.clientX, e.clientY);
+                await this.sourceApp.handleRearrange(sourcePaths, dropX, dropY);
             }
             return;
         }

--- a/src/apps/zenexplorer/utils/ZenLayoutManager.js
+++ b/src/apps/zenexplorer/utils/ZenLayoutManager.js
@@ -1,0 +1,71 @@
+import { fs } from "@zenfs/core";
+import { joinPath } from "./PathUtils.js";
+
+/**
+ * ZenLayoutManager - Manages folder layouts (icon positions and order)
+ */
+export const ZenLayoutManager = {
+  /**
+   * Get layout for a specific path
+   * @param {string} path
+   * @returns {Promise<Object>}
+   */
+  async getLayout(path) {
+    const layoutPath = joinPath(path, ".zen_layout.json");
+    try {
+      const content = await fs.promises.readFile(layoutPath, "utf8");
+      return JSON.parse(content);
+    } catch (e) {
+      // Default layout
+      return {
+        autoArrange: true,
+        positions: {},
+        order: [],
+      };
+    }
+  },
+
+  /**
+   * Save layout for a specific path
+   * @param {string} path
+   * @param {Object} layout
+   */
+  async saveLayout(path, layout) {
+    const layoutPath = joinPath(path, ".zen_layout.json");
+    try {
+      await fs.promises.writeFile(layoutPath, JSON.stringify(layout, null, 2));
+      // Notify other windows
+      document.dispatchEvent(
+        new CustomEvent("zen-layout-change", { detail: { path } }),
+      );
+    } catch (e) {
+      console.error("Failed to save layout:", e);
+    }
+  },
+
+  /**
+   * Update position for a single item
+   * @param {string} path - Folder path
+   * @param {string} name - Item name
+   * @param {number} x
+   * @param {number} y
+   */
+  async updateItemPosition(path, name, x, y) {
+    const layout = await this.getLayout(path);
+    layout.positions[name] = { x, y };
+    await this.saveLayout(path, layout);
+  },
+
+  /**
+   * Update positions for multiple items
+   * @param {string} path - Folder path
+   * @param {Object} positions - Map of name to {x, y}
+   */
+  async updateItemPositions(path, positions) {
+    const layout = await this.getLayout(path);
+    layout.positions = { ...layout.positions, ...positions };
+    await this.saveLayout(path, layout);
+  },
+};
+
+export default ZenLayoutManager;


### PR DESCRIPTION
Implemented a comprehensive icon rearrangement system for ZenExplorer. 

Key features:
1. **Auto Arrange Toggle:** Per-folder persistence of Auto Arrange state.
2. **Manual Placement:** When Auto Arrange is OFF, icons can be placed anywhere (free-form). Current grid positions are preserved when turning it off.
3. **Custom Ordering:** When Auto Arrange is ON, dragging icons changes their order in the grid (while keeping folders before files).
4. **Cross-Window Support:** Dragging an icon into another ZenExplorer window preserves the drop coordinates if that folder has Auto Arrange OFF.
5. **Persistence:** Layout data is stored in a hidden `.zen_layout.json` file in each folder.
6. **UI Integration:** Added "Arrange Icons" submenu to the background context menu with a checkbox for Auto Arrange.
7. **Robustness:** Added fallback placement for new files and ensured scrollbars work correctly in absolute layout mode.

---
*PR created automatically by Jules for task [6260396605823046155](https://jules.google.com/task/6260396605823046155) started by @azayrahmad*