### PR TITLE
Floppy Disk Image Support in ZenExplorer

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "@zenfs/core": "^2.4.4",
         "@zenfs/dom": "^1.2.7",
         "ani-cursor": "^0.0.5",
+        "fatfs-wasm": "^3.0.7",
         "html2canvas": "^1.4.1",
         "os-gui": "^0.7.3"
       },
@@ -3605,6 +3606,12 @@
         }
       ],
       "license": "BSD-3-Clause"
+    },
+    "node_modules/fatfs-wasm": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/fatfs-wasm/-/fatfs-wasm-3.0.7.tgz",
+      "integrity": "sha512-5xHV7zYfOeKZ20PrKhrcrRQyudChSRB6nfSyl9YVpkpe9KWUk3aYRFj+FZOELCL1QPPrMJwRS/s7CGD3ljumVg==",
+      "license": "MIT"
     },
     "node_modules/fdir": {
       "version": "6.5.0",

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "@zenfs/core": "^2.4.4",
     "@zenfs/dom": "^1.2.7",
     "ani-cursor": "^0.0.5",
+    "fatfs-wasm": "^3.0.7",
     "html2canvas": "^1.4.1",
     "os-gui": "^0.7.3"
   }

--- a/src/apps/zenexplorer/MenuBarBuilder.js
+++ b/src/apps/zenexplorer/MenuBarBuilder.js
@@ -110,8 +110,13 @@ export class MenuBarBuilder {
         default: true,
       },
       {
-        label: "&Insert Floppy",
+        label: "&Insert Floppy Image...",
         action: () => this.app.insertFloppy(),
+        enabled: () => !mounts.has("/A:"),
+      },
+      {
+        label: "&Create Blank Floppy Image...",
+        action: () => this.app.createBlankFloppy(),
         enabled: () => !mounts.has("/A:"),
       },
       {

--- a/src/apps/zenexplorer/README.md
+++ b/src/apps/zenexplorer/README.md
@@ -34,7 +34,7 @@ ZenExplorer follows a modular architecture to separate concerns and maintain a c
 - **Undo**: Multi-level undo for file operations.
 
 ### Media Support
-- **Drive A:**: Mount local folders as a floppy drive using the File System Access API.
+- **Drive A:**: Mount floppy disk images (.img, .ima) as a floppy drive using the File System Access API. Supports creating new blank images and automatic persistence.
 - **Drive E:**: Mount `.iso` files as a virtual CD-ROM.
 
 ### System Integration

--- a/src/apps/zenexplorer/ZenExplorerApp.js
+++ b/src/apps/zenexplorer/ZenExplorerApp.js
@@ -338,6 +338,10 @@ export class ZenExplorerApp extends Application {
     return this.driveManager.insertFloppy();
   }
 
+  createBlankFloppy() {
+    return this.driveManager.createBlankFloppy();
+  }
+
   ejectFloppy() {
     return this.driveManager.ejectFloppy();
   }

--- a/src/apps/zenexplorer/utils/ZenContextMenuBuilder.js
+++ b/src/apps/zenexplorer/utils/ZenContextMenuBuilder.js
@@ -108,8 +108,12 @@ export class ZenContextMenuBuilder {
           });
         } else {
           menuItems.push({
-            label: "Insert",
+            label: "Insert Disk Image...",
             action: () => this.app.driveManager.insertFloppy(),
+          });
+          menuItems.push({
+            label: "Create Blank Disk Image...",
+            action: () => this.app.driveManager.createBlankFloppy(),
           });
         }
       }

--- a/src/apps/zenexplorer/utils/ZenDriveManager.js
+++ b/src/apps/zenexplorer/utils/ZenDriveManager.js
@@ -9,10 +9,35 @@ import {
 import { ZenFloppyManager } from "./ZenFloppyManager.js";
 import { ZenCDManager } from "./ZenCDManager.js";
 import { ZenRemovableDiskManager } from "./ZenRemovableDiskManager.js";
+import { FAT } from "./ZenFatFS.js";
 
 export class ZenDriveManager {
   constructor(app) {
     this.app = app;
+    this._floppyWriteTimeout = null;
+    this._currentFloppyHandle = null;
+    this._currentFloppyData = null;
+  }
+
+  /**
+   * Flush pending floppy writes immediately
+   */
+  async flushFloppy() {
+    if (this._floppyWriteTimeout) {
+      clearTimeout(this._floppyWriteTimeout);
+      this._floppyWriteTimeout = null;
+    }
+
+    if (this._currentFloppyHandle && this._currentFloppyData) {
+      try {
+        const writable = await this._currentFloppyHandle.createWritable();
+        await writable.write(this._currentFloppyData);
+        await writable.close();
+        console.log("Floppy disk image flushed successfully.");
+      } catch (err) {
+        console.error("Failed to flush floppy:", err);
+      }
+    }
   }
 
   /**
@@ -24,8 +49,15 @@ export class ZenDriveManager {
       text: "Insert floppy disk into drive A:\\",
       buttons: [
         {
-          label: "OK",
+          label: "Insert Image",
           action: (win) => this.insertFloppy(win),
+        },
+        {
+          label: "Create Blank",
+          action: (win) => {
+            win.close();
+            this.createBlankFloppy();
+          },
         },
         { label: "Cancel" },
       ],
@@ -33,11 +65,36 @@ export class ZenDriveManager {
   }
 
   /**
-   * Insert floppy using WebAccess
+   * Persist floppy data to local file
+   */
+  async _persistFloppy(handle, data) {
+    this._currentFloppyHandle = handle;
+    this._currentFloppyData = data;
+
+    if (this._floppyWriteTimeout) {
+      clearTimeout(this._floppyWriteTimeout);
+    }
+    this._floppyWriteTimeout = setTimeout(async () => {
+      await this.flushFloppy();
+    }, 1000); // 1 second debounce
+  }
+
+  /**
+   * Insert floppy image
    */
   async insertFloppy(dialogWin) {
+    await this.flushFloppy();
     try {
-      const handle = await window.showDirectoryPicker();
+      const [handle] = await window.showOpenFilePicker({
+        types: [
+          {
+            description: "Floppy Disk Images",
+            accept: {
+              "application/octet-stream": [".img", ".ima"],
+            },
+          },
+        ],
+      });
 
       // Close dialog immediately after selection
       if (dialogWin) dialogWin.close();
@@ -46,7 +103,21 @@ export class ZenDriveManager {
       requestWaitState(busyRequesterId, this.app.win.element);
 
       try {
-        const floppyFs = await WebAccess.create({ handle });
+        const file = await handle.getFile();
+        const buffer = await file.arrayBuffer();
+        const data = new Uint8Array(buffer);
+        this._currentFloppyHandle = handle;
+        this._currentFloppyData = data;
+
+        const floppyFs = await FAT.create({
+          data,
+          onWrite: () => this._persistFloppy(handle, data),
+        });
+
+        if (mounts.has("/A:")) {
+          umount("/A:");
+        }
+
         mount("/A:", floppyFs);
         ZenFloppyManager.setLabel(handle.name);
         document.dispatchEvent(new CustomEvent("zen-floppy-change"));
@@ -61,12 +132,70 @@ export class ZenDriveManager {
   }
 
   /**
+   * Create a blank floppy disk image
+   */
+  async createBlankFloppy() {
+    await this.flushFloppy();
+    try {
+      const handle = await window.showSaveFilePicker({
+        suggestedName: "FLOPPY.img",
+        types: [
+          {
+            description: "Floppy Disk Images",
+            accept: {
+              "application/octet-stream": [".img", ".ima"],
+            },
+          },
+        ],
+      });
+
+      const busyRequesterId = "zen-floppy-create";
+      requestWaitState(busyRequesterId, this.app.win.element);
+
+      try {
+        // Standard 1.44MB size
+        const data = new Uint8Array(1440 * 1024);
+        this._currentFloppyHandle = handle;
+        this._currentFloppyData = data;
+
+        // Format and create FS
+        const floppyFs = await FAT.createAndFormat({
+          data,
+          onWrite: () => this._persistFloppy(handle, data),
+        });
+
+        // Write initial blank image to file
+        const writable = await handle.createWritable();
+        await writable.write(data);
+        await writable.close();
+
+        if (mounts.has("/A:")) {
+          umount("/A:");
+        }
+
+        mount("/A:", floppyFs);
+        ZenFloppyManager.setLabel(handle.name);
+        document.dispatchEvent(new CustomEvent("zen-floppy-change"));
+      } finally {
+        releaseWaitState(busyRequesterId, this.app.win.element);
+      }
+    } catch (err) {
+      if (err.name !== "AbortError") {
+        console.error("Failed to create floppy:", err);
+      }
+    }
+  }
+
+  /**
    * Eject floppy
    */
-  ejectFloppy() {
+  async ejectFloppy() {
+    await this.flushFloppy();
     if (mounts.has("/A:")) {
       umount("/A:");
       ZenFloppyManager.clear();
+      this._currentFloppyHandle = null;
+      this._currentFloppyData = null;
       document.dispatchEvent(new CustomEvent("zen-floppy-change"));
     }
   }

--- a/src/apps/zenexplorer/utils/ZenFatFS.js
+++ b/src/apps/zenexplorer/utils/ZenFatFS.js
@@ -1,0 +1,160 @@
+import {
+    FileSystem,
+    Stats,
+    Sync,
+    constants
+} from '@zenfs/core';
+
+const { S_IFDIR, S_IFREG } = constants;
+import { FatFsDisk, FatFsMode } from 'fatfs-wasm';
+
+/**
+ * ZenFatFS implements a ZenFS backend using fatfs-wasm.
+ */
+class FatFS extends FileSystem {
+    constructor(disk, label, onWrite) {
+        super(0x464154, 'fatfs'); // 'FAT'
+        this.disk = disk;
+        this.label = label;
+        this.onWrite = onWrite;
+
+        // Mount the disk
+        this.disk.mount('', 1);
+    }
+
+    _notifyWrite() {
+        if (this.onWrite) {
+            this.onWrite();
+        }
+    }
+
+    _getStats(path) {
+        if (path === '/' || path === '.') {
+            return new Stats({
+                mode: S_IFDIR | 0o777,
+                size: 0,
+            });
+        }
+
+        try {
+            const info = this.disk.stat(path);
+            return new Stats({
+                mode: (info.isDirectory ? S_IFDIR : S_IFREG) | 0o777,
+                size: info.size,
+                mtimeMs: info.date.getTime(),
+                atimeMs: info.date.getTime(),
+                ctimeMs: info.date.getTime(),
+            });
+        } catch (e) {
+            const err = new Error(e.message || 'File not found');
+            err.code = 'ENOENT';
+            throw err;
+        }
+    }
+
+    statSync(path) {
+        return this._getStats(path);
+    }
+
+    readdirSync(path) {
+        const entries = [];
+        const dir = this.disk.openDir(path);
+        try {
+            let entry;
+            while (entry = dir.read()) {
+                if (!entry.name) break;
+                if (entry.name !== '.' && entry.name !== '..') {
+                    entries.push(entry.name);
+                }
+            }
+        } finally {
+            dir.close();
+        }
+        return entries;
+    }
+
+    createFileSync(path, options) {
+        this.disk.writeFile(path, new Uint8Array(0));
+        this._notifyWrite();
+        return this._getStats(path);
+    }
+
+    unlinkSync(path) {
+        this.disk.unlink(path);
+        this._notifyWrite();
+    }
+
+    rmdirSync(path) {
+        this.disk.unlink(path);
+        this._notifyWrite();
+    }
+
+    mkdirSync(path, options) {
+        this.disk.mkdir(path);
+        this._notifyWrite();
+        return this._getStats(path);
+    }
+
+    renameSync(oldPath, newPath) {
+        this.disk.rename(oldPath, newPath);
+        this._notifyWrite();
+    }
+
+    readSync(path, buffer, offset, length, position) {
+        const file = this.disk.open(path, FatFsMode.READ);
+        try {
+            file.lseek(position);
+            return file.read(buffer.subarray(offset, offset + length));
+        } finally {
+            file.close();
+        }
+    }
+
+    writeSync(path, buffer, offset, length, position) {
+        const file = this.disk.open(path, FatFsMode.WRITE | FatFsMode.OPEN_ALWAYS);
+        try {
+            file.lseek(position);
+            const written = file.write(buffer.subarray(offset, offset + length));
+            this._notifyWrite();
+            return written;
+        } finally {
+            file.close();
+        }
+    }
+
+    truncateSync(path, len) {
+        const file = this.disk.open(path, FatFsMode.WRITE | FatFsMode.OPEN_ALWAYS);
+        try {
+            file.lseek(len);
+            file.truncate();
+        } finally {
+            file.close();
+        }
+        this._notifyWrite();
+    }
+
+    utimesSync(path, atime, mtime) {
+        this.disk.utime(path, mtime);
+        this._notifyWrite();
+    }
+}
+
+const SyncFatFS = Sync(FatFS);
+
+export const FAT = {
+    name: 'FAT',
+    options: {
+        data: { type: 'object', required: true },
+        label: { type: 'string', required: false },
+        onWrite: { type: 'function', required: false }
+    },
+    async create(options) {
+        const disk = await FatFsDisk.create(options.data);
+        return new SyncFatFS(disk, options.label, options.onWrite);
+    },
+    async createAndFormat(options) {
+        const disk = await FatFsDisk.create(options.data);
+        disk.mkfs();
+        return new SyncFatFS(disk, options.label, options.onWrite);
+    }
+};

--- a/vite.config.js
+++ b/vite.config.js
@@ -12,6 +12,9 @@ export default defineConfig({
   define: {
     "import.meta.env.APP_VERSION": JSON.stringify(appVersion),
   },
+  optimizeDeps: {
+    exclude: ["fatfs-wasm"],
+  },
   assetsInclude: ["**/*.ani"],
   base: "/win98-web/",
   plugins: [


### PR DESCRIPTION
This change enables ZenExplorer to work with actual floppy disk images instead of just local folders.

Key changes:
1.  **ZenFatFS Backend**: A new ZenFS-compatible filesystem backend that uses `fatfs-wasm` to provide synchronous read/write access to FAT12 disk images.
2.  **Image Management**: `ZenDriveManager` now handles the lifecycle of floppy images, including mounting via `showOpenFilePicker`, creating blank 1.44MB images via `showSaveFilePicker`, and formatting them.
3.  **Persistence**: Changes made to the virtual floppy are automatically saved back to the local file handle using a debounced mechanism. A new `flushFloppy` method ensures all pending writes are committed before a disk is ejected or swapped.
4.  **UI Integration**:
    *   The floppy insertion dialog now offers "Insert Image" and "Create Blank" options.
    *   The "My Computer" context menu and ZenExplorer's File menu include floppy management actions (Insert, Create, Eject).
5.  **ZenFS Compatibility**: The `ZenFatFS` implementation was refined to strictly follow ZenFS method signatures and expectations, ensuring reliable file operations within the disk image.

---
*PR created automatically by Jules for task [1789957135256284818](https://jules.google.com/task/1789957135256284818) started by @azayrahmad*