### PR TITLE
Maintain relative positions during multi-file drag and drop in ZenExplorer

### DIFF
--- a/src/apps/zenexplorer/FileOperations.js
+++ b/src/apps/zenexplorer/FileOperations.js
@@ -72,7 +72,8 @@ export class FileOperations {
                 const positions = {};
                 targetPaths.forEach((path, i) => {
                     const name = getPathName(path);
-                    positions[name] = { x: options.dropX + i * 10, y: options.dropY + i * 10 };
+                    const offset = options.offsets ? options.offsets[i] : { x: i * 10, y: i * 10 };
+                    positions[name] = { x: options.dropX + offset.x, y: options.dropY + offset.y };
                 });
                 await ZenLayoutManager.updateItemPositions(destinationPath, positions);
             }
@@ -110,7 +111,8 @@ export class FileOperations {
                 const positions = {};
                 targetPaths.forEach((path, i) => {
                     const name = getPathName(path);
-                    positions[name] = { x: options.dropX + i * 10, y: options.dropY + i * 10 };
+                    const offset = options.offsets ? options.offsets[i] : { x: i * 10, y: i * 10 };
+                    positions[name] = { x: options.dropX + offset.x, y: options.dropY + offset.y };
                 });
                 await ZenLayoutManager.updateItemPositions(destinationPath, positions);
             }

--- a/src/apps/zenexplorer/ZenExplorerApp.js
+++ b/src/apps/zenexplorer/ZenExplorerApp.js
@@ -337,9 +337,20 @@ export class ZenExplorerApp extends Application {
       this.iconContainer.setAttribute("data-current-path", this.currentPath);
       // Update autoArrange state from layout
       const layout = await ZenLayoutManager.getLayout(this.currentPath);
-      this.autoArrange = layout.autoArrange;
+      this._autoArrange = layout.autoArrange;
     }
     return result;
+  }
+
+  get autoArrange() {
+    if (this.viewMode === 'list' || this.viewMode === 'details') {
+      return true;
+    }
+    return this._autoArrange;
+  }
+
+  set autoArrange(value) {
+    this._autoArrange = value;
   }
 
   /**
@@ -378,17 +389,18 @@ export class ZenExplorerApp extends Application {
     this.directoryView.renderDirectoryContents(this.currentPath);
   }
 
-  async handleRearrange(sourcePaths, x, y) {
+  async handleRearrange(sourcePaths, x, y, offsets) {
     const layout = await ZenLayoutManager.getLayout(this.currentPath);
 
     if (!layout.autoArrange) {
       // Free-form placement
       sourcePaths.forEach((path, index) => {
         const name = path.split("/").pop();
+        const offset = offsets ? offsets[index] : { x: index * 10, y: index * 10 };
         // Use adjusted coordinates directly
         layout.positions[name] = {
-          x: x + index * 10,
-          y: y + index * 10,
+          x: x + offset.x,
+          y: y + offset.y,
         };
       });
     } else {

--- a/src/apps/zenexplorer/utils/ZenContextMenuBuilder.js
+++ b/src/apps/zenexplorer/utils/ZenContextMenuBuilder.js
@@ -198,6 +198,7 @@ export class ZenContextMenuBuilder {
         submenu: [
           {
             label: "Auto Arrange",
+            enabled: () => this.app.viewMode === 'large' || this.app.viewMode === 'small',
             checkbox: {
               check: () => this.app.autoArrange,
               toggle: () => this.app.toggleAutoArrange(),

--- a/src/apps/zenexplorer/utils/ZenDragDropManager.js
+++ b/src/apps/zenexplorer/utils/ZenDragDropManager.js
@@ -26,20 +26,24 @@ export class ZenDragDropManager {
     startDrag(iconElements, sourceApp, x, y) {
         if (this.isDragging) return;
         this.isDragging = true;
-        this.draggedItems = iconElements.map(el => ({
-            element: el,
-            path: el.getAttribute('data-path'),
-            type: el.getAttribute('data-type')
-        }));
+        this.draggedItems = iconElements.map(el => {
+            const rect = el.getBoundingClientRect();
+            return {
+                element: el,
+                path: el.getAttribute('data-path'),
+                type: el.getAttribute('data-type'),
+                offsetX: x - rect.left,
+                offsetY: y - rect.top
+            };
+        });
         this.sourceApp = sourceApp;
         this.startX = x;
         this.startY = y;
 
-        // Calculate offset from first icon
-        if (iconElements.length > 0) {
-            const rect = iconElements[0].getBoundingClientRect();
-            this.offsetX = x - rect.left;
-            this.offsetY = y - rect.top;
+        // Base offset from first icon for ghost positioning
+        if (this.draggedItems.length > 0) {
+            this.offsetX = this.draggedItems[0].offsetX;
+            this.offsetY = this.draggedItems[0].offsetY;
         }
 
         this._createGhost(iconElements, x, y);
@@ -68,14 +72,15 @@ export class ZenDragDropManager {
         ghost.style.opacity = '0.6';
 
         iconElements.forEach((el, index) => {
+            const item = this.draggedItems[index];
             const clone = el.cloneNode(true);
             clone.classList.remove('selected');
             clone.classList.add('ghost-item');
 
-            // Reset positioning style from the original icon (important for free-form mode)
-            clone.style.position = index === 0 ? 'static' : 'absolute';
-            clone.style.left = index === 0 ? '' : `${index * 4}px`;
-            clone.style.top = index === 0 ? '' : `${index * 4}px`;
+            // Maintain relative positioning from the original icons
+            clone.style.position = 'absolute';
+            clone.style.left = `${this.offsetX - item.offsetX}px`;
+            clone.style.top = `${this.offsetY - item.offsetY}px`;
             clone.style.margin = '0';
 
             ghost.appendChild(clone);
@@ -180,6 +185,10 @@ export class ZenDragDropManager {
         if (!destinationPath) return;
 
         const sourcePaths = this.draggedItems.map(item => item.path);
+        const offsets = this.draggedItems.map(item => ({
+            x: this.offsetX - item.offsetX,
+            y: this.offsetY - item.offsetY
+        }));
 
         // Calculate coordinates relative to target container
         let dropX = null;
@@ -196,16 +205,16 @@ export class ZenDragDropManager {
         if (!isCopy && destinationPath === sourceDir) {
             // Handle rearrangement
             if (this.sourceApp.handleRearrange) {
-                await this.sourceApp.handleRearrange(sourcePaths, dropX, dropY);
+                await this.sourceApp.handleRearrange(sourcePaths, dropX, dropY, offsets);
             }
             return;
         }
 
         try {
             if (isCopy) {
-                await this.sourceApp.fileOps.copyItemsDirect(sourcePaths, destinationPath, { dropX, dropY });
+                await this.sourceApp.fileOps.copyItemsDirect(sourcePaths, destinationPath, { dropX, dropY, offsets });
             } else {
-                await this.sourceApp.fileOps.moveItemsDirect(sourcePaths, destinationPath, { dropX, dropY });
+                await this.sourceApp.fileOps.moveItemsDirect(sourcePaths, destinationPath, { dropX, dropY, offsets });
             }
         } catch (err) {
             console.error('Drop failed:', err);


### PR DESCRIPTION
This PR updates ZenExplorer to maintain the relative spatial arrangement of multiple selected files when they are dragged and dropped. Previously, all files would be stacked on top of each other at the drop location.

Key changes:
- `ZenDragDropManager`: Now calculates the offset of each selected item relative to the mouse cursor at the start of a drag. These offsets are used to position icons in the drag ghost and passed to the drop handlers.
- `FileOperations`: `moveItemsDirect` and `copyItemsDirect` now accept an `offsets` array to correctly position multiple items in the destination folder.
- `ZenExplorerApp`: `handleRearrange` updated to use per-item offsets for same-folder dragging in free-form mode. Added a getter/setter for `autoArrange` to enforce it as `true` in List and Details views.
- `ZenContextMenuBuilder`: Disabled the "Auto Arrange" menu item when the view mode is 'list' or 'details'.

These changes ensure a more intuitive drag-and-drop experience that preserves the user's manual layout while respecting view-specific constraints.

---
*PR created automatically by Jules for task [4819921153072331836](https://jules.google.com/task/4819921153072331836) started by @azayrahmad*