### PR TITLE
Fix ZenExplorer Drag-and-Drop and Layout Persistence

### DIFF
--- a/src/apps/zenexplorer/utils/ZenDragDropManager.js
+++ b/src/apps/zenexplorer/utils/ZenDragDropManager.js
@@ -210,6 +210,12 @@ export class ZenDragDropManager {
             return;
         }
 
+        // Prevent moving/copying root items to other folders
+        if (sourceDir === "/") {
+            console.warn("Cannot move or copy root items to other folders.");
+            return;
+        }
+
         try {
             if (isCopy) {
                 await this.sourceApp.fileOps.copyItemsDirect(sourcePaths, destinationPath, { dropX, dropY });

--- a/src/apps/zenexplorer/utils/ZenDragDropManager.js
+++ b/src/apps/zenexplorer/utils/ZenDragDropManager.js
@@ -1,4 +1,5 @@
 import { openApps } from "../../Application.js";
+import { getParentPath } from "./PathUtils.js";
 
 /**
  * ZenDragDropManager - Handles custom drag and drop for ZenExplorer
@@ -117,8 +118,16 @@ export class ZenDragDropManager {
                     const targetPath = icon.getAttribute('data-path');
                     // Don't allow dropping on itself or its children
                     if (!this.draggedItems.some(item => item.path === targetPath || targetPath.startsWith(item.path + '/'))) {
-                         newTarget = icon;
-                         break;
+                         // Prevent dropping a root item onto another root item (treat as layouting)
+                         const sourceDir = this.draggedItems[0] ? getParentPath(this.draggedItems[0].path) : null;
+                         const targetDir = getParentPath(targetPath);
+
+                         if (sourceDir === "/" && targetDir === "/") {
+                             // Ignore icon target to allow falling through to background for rearrangement
+                         } else {
+                             newTarget = icon;
+                             break;
+                         }
                     }
                 }
             }

--- a/src/apps/zenexplorer/utils/ZenLayoutManager.js
+++ b/src/apps/zenexplorer/utils/ZenLayoutManager.js
@@ -1,17 +1,31 @@
 import { fs } from "@zenfs/core";
-import { joinPath } from "./PathUtils.js";
+import { joinPath, getPathName } from "./PathUtils.js";
+import { ZenShellManager } from "./ZenShellManager.js";
 
 /**
  * ZenLayoutManager - Manages folder layouts (icon positions and order)
  */
 export const ZenLayoutManager = {
   /**
+   * Get the layout file path for a given directory path.
+   * Redirects root and virtual folders to /C:/WINDOWS for persistence.
+   * @private
+   */
+  _getLayoutPath(path) {
+    if (path === "/" || ZenShellManager.getExtensionForPath(path)) {
+      const name = getPathName(path);
+      return `/C:/WINDOWS/${name}.zen_layout.json`;
+    }
+    return joinPath(path, ".zen_layout.json");
+  },
+
+  /**
    * Get layout for a specific path
    * @param {string} path
    * @returns {Promise<Object>}
    */
   async getLayout(path) {
-    const layoutPath = joinPath(path, ".zen_layout.json");
+    const layoutPath = this._getLayoutPath(path);
     try {
       const content = await fs.promises.readFile(layoutPath, "utf8");
       return JSON.parse(content);
@@ -31,7 +45,7 @@ export const ZenLayoutManager = {
    * @param {Object} layout
    */
   async saveLayout(path, layout) {
-    const layoutPath = joinPath(path, ".zen_layout.json");
+    const layoutPath = this._getLayoutPath(path);
     try {
       await fs.promises.writeFile(layoutPath, JSON.stringify(layout, null, 2));
       // Notify other windows

--- a/src/utils/zenfs-init.js
+++ b/src/utils/zenfs-init.js
@@ -25,6 +25,11 @@ export async function initFileSystem() {
             await fs.promises.mkdir('/E:');
         }
 
+        // Ensure WINDOWS directory exists on C: for persistence
+        if (!fs.existsSync('/C:/WINDOWS')) {
+            await fs.promises.mkdir('/C:/WINDOWS');
+        }
+
         isInitialized = true;
         console.log("ZenFS initialized successfully.");
     } catch (error) {


### PR DESCRIPTION
This change improves the user experience in ZenExplorer by:
1. Preventing accidental moves of root items (like drive icons) into each other. Dragging one drive icon onto another in 'My Computer' now correctly triggers icon rearrangement instead of attempting a move.
2. Enabling persistence for folder layouts in 'My Computer' and system folders like 'Control Panel'. These layouts are now saved to /C:/WINDOWS/ to ensure they survive page refreshes, as the root filesystem is typically ephemeral.
3. Ensuring the necessary persistent storage directory (/C:/WINDOWS) is created during system initialization.

---
*PR created automatically by Jules for task [7169159526499461368](https://jules.google.com/task/7169159526499461368) started by @azayrahmad*