### PR TITLE
Implement directory-based singleton for ZenExplorer

### DIFF
--- a/e2e/zenexplorer_instances.spec.js
+++ b/e2e/zenexplorer_instances.spec.js
@@ -1,0 +1,80 @@
+import { test, expect } from '@playwright/test';
+
+test('ZenExplorer directory-based singleton behavior', async ({ page }) => {
+    test.setTimeout(120000);
+    await page.goto('http://localhost:5173/win98-web/');
+
+    // Handle startup prompt if it exists (press Enter)
+    await page.keyboard.press('Enter');
+
+    // Wait for splash screen to disappear if it exists
+    const splash = page.locator('#splash-screen');
+    if (await splash.count() > 0) {
+        await expect(splash).not.toBeVisible({ timeout: 30000 });
+    }
+
+    // Close any startup windows if they appear
+    const tipWindow = page.locator('.window:has-text("Welcome")');
+    try {
+        await expect(tipWindow).toBeVisible({ timeout: 5000 });
+        await tipWindow.locator('button:has-text("Close")').click();
+    } catch (e) {
+        // Welcome window might not appear
+    }
+
+    // Function to launch ZenExplorer
+    const launchZenExplorer = async (stepName) => {
+        await page.click('button:has-text("Start")');
+        await page.locator('.start-menu-item:has-text("Programs")').hover();
+        await page.click('text=File Manager (ZenFS)');
+    };
+
+    // 1. Launch first instance (defaults to / aka My Computer)
+    await launchZenExplorer('first');
+    await expect(page.locator('.window-title:has-text("My Computer")')).toBeVisible({ timeout: 10000 });
+
+    // Count windows
+    let windows = await page.locator('.window-title:has-text("My Computer")').count();
+    expect(windows).toBe(1);
+
+    // 2. Launch second instance (should focus existing one, not create new)
+    await launchZenExplorer('second');
+    await page.waitForTimeout(2000);
+    windows = await page.locator('.window-title:has-text("My Computer")').count();
+    expect(windows).toBe(1);
+
+    // 3. Navigate first instance to C:
+    let zenWin1 = page.locator('.window').filter({ has: page.locator('.window-title:has-text("My Computer")') });
+    const cDriveIcon = zenWin1.locator('.explorer-icon').filter({ hasText: '(C:)' });
+    await cDriveIcon.dblclick();
+
+    // The title changes, so re-locate
+    zenWin1 = page.locator('.window').filter({ has: page.locator('.window-title:has-text("(C:)")') });
+    await expect(zenWin1).toBeVisible({ timeout: 10000 });
+
+    // 4. Launch again (should create new instance at / because first one moved to /C:)
+    await launchZenExplorer('third');
+
+    // Wait for two windows to exist
+    await expect(page.locator('.window[data-app-id="zenexplorer"]')).toHaveCount(2, { timeout: 10000 });
+
+    // Now wait for the title to update to My Computer
+    // We use a regex to ensure we are matching the whole title and avoid partial matches if any
+    await expect(page.locator('.window-title').filter({ hasText: /^My Computer$/ })).toBeVisible({ timeout: 15000 });
+
+    const myCompWins = await page.locator('.window-title').filter({ hasText: /^My Computer$/ }).count();
+    const cDriveWins = await page.locator('.window-title').filter({ hasText: /^\(C:\)$/ }).count();
+
+    expect(myCompWins).toBe(1);
+    expect(cDriveWins).toBe(1);
+
+    // 5. Navigate second instance (the one at My Computer) to C: (should be allowed per requirement 2)
+    const zenWin2 = page.locator('.window').filter({ has: page.locator('.window-title').filter({ hasText: /^My Computer$/ }) });
+    const cDriveIcon2 = zenWin2.locator('.explorer-icon').filter({ hasText: '(C:)' });
+    await cDriveIcon2.dblclick();
+
+    // Now we should have two windows with title "(C:)"
+    await expect(page.locator('.window-title').filter({ hasText: /^\(C:\)$/ })).toHaveCount(2, { timeout: 15000 });
+
+    await page.screenshot({ path: 'zen_instances_final.png' });
+});

--- a/src/apps/zenexplorer/FileOperations.js
+++ b/src/apps/zenexplorer/FileOperations.js
@@ -83,7 +83,8 @@ export class FileOperations {
                 data: { from: sourcePaths, to: targetPaths }
             });
 
-            document.dispatchEvent(new CustomEvent("zen-fs-change"));
+            await this.app.navigateTo(this.app.currentPath, true, true);
+            document.dispatchEvent(new CustomEvent("zen-fs-change", { detail: { sourceAppId: this.app.win.element.id } }));
         } catch (e) {
             handleFileSystemError("move", e, "items");
             throw e;
@@ -122,7 +123,8 @@ export class FileOperations {
                 data: { created: targetPaths }
             });
 
-            document.dispatchEvent(new CustomEvent("zen-fs-change"));
+            await this.app.navigateTo(this.app.currentPath, true, true);
+            document.dispatchEvent(new CustomEvent("zen-fs-change", { detail: { sourceAppId: this.app.win.element.id } }));
         } catch (e) {
             handleFileSystemError("copy", e, "items");
             throw e;
@@ -277,7 +279,8 @@ export class FileOperations {
                             // because no event was dispatched. If an event was dispatched,
                             // ZenExplorerApp already refreshed.
                             if (isPermanent && !alreadyInRecycle) {
-                                this.app.navigateTo(this.app.currentPath);
+                                await this.app.navigateTo(this.app.currentPath, true, true);
+                                document.dispatchEvent(new CustomEvent("zen-fs-change", { detail: { sourceAppId: this.app.win.element.id } }));
                             }
                         } catch (e) {
                             handleFileSystemError("delete", e, "items");
@@ -306,6 +309,7 @@ export class FileOperations {
             const newPath = joinPath(this.app.currentPath, name);
             await fs.promises.mkdir(newPath);
             await this.app.navigateTo(this.app.currentPath, true, true);
+            document.dispatchEvent(new CustomEvent("zen-fs-change", { detail: { sourceAppId: this.app.win.element.id } }));
             this.app.enterRenameModeByPath(newPath);
         } catch (e) {
             handleFileSystemError("create", e, "folder");
@@ -321,6 +325,7 @@ export class FileOperations {
             const newPath = joinPath(this.app.currentPath, name);
             await fs.promises.writeFile(newPath, "");
             await this.app.navigateTo(this.app.currentPath, true, true);
+            document.dispatchEvent(new CustomEvent("zen-fs-change", { detail: { sourceAppId: this.app.win.element.id } }));
             this.app.enterRenameModeByPath(newPath);
         } catch (e) {
             handleFileSystemError("create", e, "file");
@@ -374,7 +379,8 @@ export class FileOperations {
                     break;
             }
             ZenUndoManager.pop(); // Only pop if successful
-            this.app.navigateTo(this.app.currentPath);
+            await this.app.navigateTo(this.app.currentPath, true, true);
+            document.dispatchEvent(new CustomEvent("zen-fs-change", { detail: { sourceAppId: this.app.win.element.id } }));
         } catch (e) {
             ShowDialogWindow({
                 title: "Undo",

--- a/src/apps/zenexplorer/ZenExplorerApp.js
+++ b/src/apps/zenexplorer/ZenExplorerApp.js
@@ -1,4 +1,4 @@
-import { Application } from "../Application.js";
+import { Application, openApps } from "../Application.js";
 import { mounts } from "@zenfs/core";
 import { initFileSystem } from "../../utils/zenfs-init.js";
 import { ICONS } from "../../config/icons.js";
@@ -55,6 +55,67 @@ export class ZenExplorerApp extends Application {
     this.driveManager = new ZenDriveManager(this);
     this.contextMenuBuilder = new ZenContextMenuBuilder(this);
     this.keyboardHandler = new ZenKeyboardHandler(this);
+  }
+
+  async launch(data = null) {
+    const targetPath = this._normalizePath(data);
+    let existingAppAtSamePath = null;
+    let anyZenExplorer = false;
+
+    for (const app of openApps.values()) {
+      if (app.config?.id === this.id) {
+        anyZenExplorer = true;
+        if (this._normalizePath(app.currentPath) === targetPath) {
+          existingAppAtSamePath = app;
+          break;
+        }
+      }
+    }
+
+    if (existingAppAtSamePath) {
+      if (existingAppAtSamePath.win) {
+        existingAppAtSamePath.win.focus();
+      }
+      return;
+    }
+
+    // If we have any existing ZenExplorer, we need a unique windowId
+    // to bypass the singleton-like check in Application.launch.
+    if (anyZenExplorer) {
+      const filePath =
+        typeof data === "string"
+          ? data
+          : data?.file || data?.filePath || data?.path || "/";
+
+      // If data was already an object with windowId, respect it
+      if (data && typeof data === "object" && data.windowId) {
+        return super.launch(data);
+      }
+
+      return super.launch({
+        file: filePath,
+        windowId: `${this.id}-${Date.now()}-${Math.random()}`,
+      });
+    }
+
+    // First instance: use default launch behavior (maintains #zenexplorer ID if launched without path)
+    return super.launch(data);
+  }
+
+  _normalizePath(path) {
+    let p = "/";
+    if (typeof path === "string") {
+      p = path;
+    } else if (path && typeof path === "object") {
+      p = path.file || path.filePath || path.path || "/";
+    }
+
+    if (typeof p !== "string") p = "/";
+
+    p = p.replace(/\\/g, "/");
+    if (!p.startsWith("/")) p = "/" + p;
+    if (p.length > 1 && p.endsWith("/")) p = p.slice(0, -1);
+    return p;
   }
 
   async _createWindow(initialPath) {

--- a/src/apps/zenexplorer/ZenExplorerApp.js
+++ b/src/apps/zenexplorer/ZenExplorerApp.js
@@ -373,7 +373,10 @@ export class ZenExplorerApp extends Application {
    * @private
    */
   _setupFSListener() {
-    this._fsHandler = () => {
+    this._fsHandler = (e) => {
+      if (e.detail?.sourceAppId === this.win.element.id) {
+        return;
+      }
       this.navigateTo(this.currentPath, true, true);
     };
     document.addEventListener("zen-fs-change", this._fsHandler);

--- a/src/apps/zenexplorer/components/ZenDirectoryView.js
+++ b/src/apps/zenexplorer/components/ZenDirectoryView.js
@@ -421,7 +421,8 @@ export class ZenDirectoryView {
         label.textContent = getDisplayName(fullPath);
       }
 
-      await this.app.navController.navigateTo(this.app.currentPath, true, true);
+      await this.app.navigateTo(this.app.currentPath, true, true);
+      document.dispatchEvent(new CustomEvent("zen-fs-change", { detail: { sourceAppId: this.app.win.element.id } }));
     };
 
     textarea.onkeydown = (e) => {


### PR DESCRIPTION
This change implements a directory-based singleton policy for ZenExplorer. 
When launching ZenExplorer, it now checks if any existing instance is already browsing the target directory. If so, that instance is focused instead of opening a new window.
If no instance is browsing that directory, a new window is opened. 
This allows multiple ZenExplorer windows to exist as long as they are on different directories, satisfying the user requirement.
The implementation includes robust path normalization to treat '/C:' and '/C:/' as identical.
It also includes a new E2E test file 'e2e/zenexplorer_instances.spec.js' and maintains backward compatibility with existing tests.

---
*PR created automatically by Jules for task [6015237136504144494](https://jules.google.com/task/6015237136504144494) started by @azayrahmad*