### PR TITLE
Move ZenFS initialization to boot sequence

### DIFF
--- a/src/apps/notepad/NotepadApp.js
+++ b/src/apps/notepad/NotepadApp.js
@@ -1,6 +1,5 @@
 import { Application } from '../Application.js';
 import { fs } from "@zenfs/core";
-import { initFileSystem } from "../../utils/zenfs-init.js";
 import './notepad.css';
 import '../../components/notepad-editor.css';
 import { languages } from '../../config/languages.js';
@@ -213,7 +212,6 @@ export class NotepadApp extends Application {
             const isZenFSPath = data.startsWith('/') && !data.startsWith('http');
             if (isZenFSPath) {
                 try {
-                    await initFileSystem();
                     const text = await fs.promises.readFile(data, 'utf8');
                     this.zenfsPath = data;
                     this.fileName = data.split("/").pop();
@@ -764,7 +762,6 @@ export class NotepadApp extends Application {
     async saveLocally() {
         if (!this.zenfsPath) return;
         try {
-            await initFileSystem();
             await fs.promises.writeFile(this.zenfsPath, this.editor.getValue());
             this.isDirty = false;
             this.updateTitle();

--- a/src/apps/zenexplorer/ZenExplorerApp.js
+++ b/src/apps/zenexplorer/ZenExplorerApp.js
@@ -122,9 +122,6 @@ export class ZenExplorerApp extends Application {
       this.currentPath = initialPath;
     }
 
-    // 1. Initialize File System
-    await RecycleBinManager.init();
-
     // 2. Setup Window
     const win = new window.$Window({
       title: this.title,

--- a/src/apps/zenexplorer/ZenExplorerApp.js
+++ b/src/apps/zenexplorer/ZenExplorerApp.js
@@ -1,6 +1,5 @@
 import { Application, openApps } from "../Application.js";
 import { mounts } from "@zenfs/core";
-import { initFileSystem } from "../../utils/zenfs-init.js";
 import { ICONS } from "../../config/icons.js";
 import { getAssociation } from "../../utils/directory.js";
 import { launchApp } from "../../utils/appManager.js";
@@ -124,7 +123,6 @@ export class ZenExplorerApp extends Application {
     }
 
     // 1. Initialize File System
-    await initFileSystem();
     await RecycleBinManager.init();
 
     // 2. Setup Window

--- a/src/main.js
+++ b/src/main.js
@@ -33,6 +33,7 @@ import { initColorModeManager } from "./utils/colorModeManager.js";
 import screensaver from "./utils/screensaverUtils.js";
 import { initScreenManager } from "./utils/screenManager.js";
 import { fs } from "@zenfs/core";
+import { initFileSystem } from "./utils/zenfs-init.js";
 
 // Window Management System
 class WindowManagerSystem {
@@ -213,6 +214,12 @@ async function initializeOS() {
       let logElement = startBootProcessStep("Connecting to network...");
       await new Promise((resolve) => setTimeout(resolve, 1000));
       finalizeBootProcessStep(logElement, navigator.onLine ? "OK" : "FAILED");
+    });
+
+    await executeBootStep(async () => {
+      let logElement = startBootProcessStep("Initializing file system...");
+      await initFileSystem();
+      finalizeBootProcessStep(logElement, "OK");
     });
 
     const createAssetLogCallbacks = (logElement, baseMessage) => {

--- a/src/main.js
+++ b/src/main.js
@@ -34,6 +34,7 @@ import screensaver from "./utils/screensaverUtils.js";
 import { initScreenManager } from "./utils/screenManager.js";
 import { fs } from "@zenfs/core";
 import { initFileSystem } from "./utils/zenfs-init.js";
+import { RecycleBinManager } from "./apps/zenexplorer/utils/RecycleBinManager.js";
 
 // Window Management System
 class WindowManagerSystem {
@@ -217,8 +218,22 @@ async function initializeOS() {
     });
 
     await executeBootStep(async () => {
-      let logElement = startBootProcessStep("Initializing file system...");
-      await initFileSystem();
+      const baseMsg = "Initializing file system...";
+      let logElement = startBootProcessStep(baseMsg);
+      await initFileSystem((subStep) => {
+        if (logElement && logElement.firstChild) {
+          logElement.firstChild.nodeValue = `${baseMsg} ${subStep}`;
+        }
+      });
+      if (logElement && logElement.firstChild) {
+        logElement.firstChild.nodeValue = baseMsg;
+      }
+      finalizeBootProcessStep(logElement, "OK");
+    });
+
+    await executeBootStep(async () => {
+      let logElement = startBootProcessStep("Initializing Recycle Bin...");
+      await RecycleBinManager.init();
       finalizeBootProcessStep(logElement, "OK");
     });
 

--- a/src/utils/zenfs-init.js
+++ b/src/utils/zenfs-init.js
@@ -1,22 +1,36 @@
-import { configure, InMemory, fs } from "@zenfs/core";
+import { resolveMountConfig, InMemory, fs } from "@zenfs/core";
 import { IndexedDB } from "@zenfs/dom";
 
 let isInitialized = false;
 
-export async function initFileSystem() {
+export async function initFileSystem(onProgress) {
     if (isInitialized) return;
 
     try {
-        await configure({
-            mounts: {
-                "/": InMemory,
-                "/C:": {
-                    backend: IndexedDB,
-                    name: "win98-c-drive",
-                },
-            },
-        });
+        if (onProgress) onProgress("Mounting root...");
+        // / is mounted by default, but we can re-mount it if needed or just skip
+        // For now, let's just ensure we have our mounts.
+        // If / is already mounted, we might need to unmount it first to use manual mount.
+        try {
+            fs.umount('/');
+        } catch (e) {
+            // Root might not be unmountable or not mounted
+        }
+        const rootFs = await resolveMountConfig(InMemory);
+        fs.mount('/', rootFs);
 
+        if (onProgress) onProgress("Mounting C: drive...");
+        const cDriveFs = await resolveMountConfig({
+            backend: IndexedDB,
+            name: "win98-c-drive",
+        });
+        // Ensure C: mount point exists in root
+        if (!fs.existsSync('/C:')) {
+            await fs.promises.mkdir('/C:');
+        }
+        fs.mount('/C:', cDriveFs);
+
+        if (onProgress) onProgress("Checking system folders...");
         // Ensure A: and E: drive directory exists in the root
         if (!fs.existsSync('/A:')) {
             await fs.promises.mkdir('/A:');
@@ -34,5 +48,6 @@ export async function initFileSystem() {
         console.log("ZenFS initialized successfully.");
     } catch (error) {
         console.error("Failed to initialize ZenFS:", error);
+        throw error;
     }
 }

--- a/src/utils/zenfs-utils.js
+++ b/src/utils/zenfs-utils.js
@@ -1,5 +1,4 @@
 import { fs } from "@zenfs/core";
-import { initFileSystem } from "./zenfs-init.js";
 
 /**
  * Checks if a path is a ZenFS virtual path.
@@ -71,7 +70,6 @@ export function getMimeType(filename) {
  * @returns {Promise<Blob>}
  */
 export async function getZenFSFileAsBlob(path) {
-  await initFileSystem();
   const data = await fs.promises.readFile(path);
   const type = getMimeType(path);
   return new Blob([data], { type });
@@ -83,7 +81,6 @@ export async function getZenFSFileAsBlob(path) {
  * @returns {Promise<string>}
  */
 export async function getZenFSFileAsText(path) {
-  await initFileSystem();
   return await fs.promises.readFile(path, "utf8");
 }
 


### PR DESCRIPTION
Moved the ZenFS initialization process from on-demand app-level calls to a centralized system boot step in `src/main.js`. This ensures the filesystem is ready before any applications are launched and simplifies the initialization logic in individual components. The boot screen now includes a log entry for filesystem initialization. Cleanup was performed to remove redundant imports and calls in ZenExplorer, Notepad, and utility functions.

---
*PR created automatically by Jules for task [17349338749717400965](https://jules.google.com/task/17349338749717400965) started by @azayrahmad*