### PR TITLE
Implement Progress Bars for Drag-and-Drop and Deletion in ZenExplorer

### DIFF
--- a/src/apps/zenexplorer/FileOperations.js
+++ b/src/apps/zenexplorer/FileOperations.js
@@ -47,11 +47,29 @@ export class FileOperations {
         const { items, operation } = ZenClipboardManager.get();
         if (items.length === 0) return;
 
-        console.log("Importing ProgressBarDialogWindow...");
+        // If pasting into Recycle Bin, it's a recycle operation
+        if (RecycleBinManager.isRecycleBinPath(destinationPath)) {
+            const { ProgressBarDialogWindow } = await import("./components/ProgressBarDialogWindow.js");
+            const totalSize = await this.getTotalSize(items);
+            const dialog = new ProgressBarDialogWindow("recycle", items.length, totalSize);
+            try {
+                await RecycleBinManager.moveItemsToRecycleBin(items, dialog);
+                if (operation === "cut") ZenClipboardManager.clear();
+            } finally {
+                dialog.close();
+            }
+            return;
+        }
+
+        // If pasting FROM Recycle Bin, it's a restore operation (effectively)
+        if (items.some(p => RecycleBinManager.isRecycledItemPath(p))) {
+            await this.restoreItems(items);
+            if (operation === "cut") ZenClipboardManager.clear();
+            return;
+        }
+
         const { ProgressBarDialogWindow } = await import("./components/ProgressBarDialogWindow.js");
-        console.log("Imported ProgressBarDialogWindow", !!ProgressBarDialogWindow);
         const totalSize = await this.getTotalSize(items);
-        console.log("Total size:", totalSize);
         const dialog = new ProgressBarDialogWindow(operation, items.length, totalSize);
 
         try {
@@ -535,6 +553,32 @@ export class FileOperations {
                 // Doesn't exist, we can use it
                 return name;
             }
+        }
+    }
+
+    /**
+     * Restore items from Recycle Bin with progress
+     */
+    async restoreItems(paths) {
+        if (paths.length === 0) return;
+
+        const busyId = `restore-${Math.random()}`;
+        requestBusyState(busyId, this.app.win.element);
+
+        const { ProgressBarDialogWindow } = await import("./components/ProgressBarDialogWindow.js");
+        const totalSize = await this.getTotalSize(paths);
+        const dialog = new ProgressBarDialogWindow("restore", paths.length, totalSize);
+
+        try {
+            const ids = paths.map(p => getPathName(p));
+            await RecycleBinManager.restoreItems(ids, dialog);
+        } catch (e) {
+            handleFileSystemError("restore", e, "items");
+        } finally {
+            dialog.close();
+            releaseBusyState(busyId, this.app.win.element);
+            await this.app.navigateTo(this.app.currentPath, true, true);
+            document.dispatchEvent(new CustomEvent("zen-fs-change", { detail: { sourceAppId: this.app.win.element.id } }));
         }
     }
 

--- a/src/apps/zenexplorer/FileOperations.js
+++ b/src/apps/zenexplorer/FileOperations.js
@@ -539,6 +539,52 @@ export class FileOperations {
     }
 
     /**
+     * Empty the Recycle Bin with progress
+     */
+    async emptyRecycleBin() {
+        const isEmpty = await RecycleBinManager.isEmpty();
+        if (isEmpty) return;
+
+        ShowDialogWindow({
+            title: "Confirm Empty Recycle Bin",
+            text: "Are you sure you want to permanently delete all items in the Recycle Bin?",
+            parentWindow: this.app.win,
+            modal: true,
+            buttons: [
+                {
+                    label: "Yes",
+                    isDefault: true,
+                    action: async () => {
+                        const busyId = `empty-recycle-${Math.random()}`;
+                        requestBusyState(busyId, this.app.win.element);
+
+                        const metadata = await RecycleBinManager.getMetadata();
+                        const ids = Object.keys(metadata);
+                        const paths = ids.map(id => joinPath("/C:/Recycled", id));
+
+                        const { ProgressBarDialogWindow } = await import("./components/ProgressBarDialogWindow.js");
+                        const totalSize = await this.getTotalSize(paths);
+                        const dialog = new ProgressBarDialogWindow("empty", ids.length, totalSize);
+
+                        try {
+                            await RecycleBinManager.emptyRecycleBin(dialog);
+                            const { playSound } = await import("../../utils/soundManager.js");
+                            playSound("EmptyRecycleBin");
+                        } catch (e) {
+                            handleFileSystemError("delete", e, "items");
+                        } finally {
+                            dialog.close();
+                            releaseBusyState(busyId, this.app.win.element);
+                            await this.app.navigateTo(this.app.currentPath, true, true);
+                        }
+                    }
+                },
+                { label: "No" }
+            ]
+        });
+    }
+
+    /**
      * Undo the last file operation
      */
     async undo() {

--- a/src/apps/zenexplorer/FileOperations.js
+++ b/src/apps/zenexplorer/FileOperations.js
@@ -375,13 +375,19 @@ export class FileOperations {
                     action: async () => {
                         const busyId = `delete-${Math.random()}`;
                         requestBusyState(busyId, this.app.win.element);
+
+                        const { ProgressBarDialogWindow } = await import("./components/ProgressBarDialogWindow.js");
+                        const totalSize = await this.getTotalSize(paths);
+                        const dialog = new ProgressBarDialogWindow(isPermanent ? "delete" : "recycle", paths.length, totalSize);
+
                         try {
                             if (isPermanent) {
                                 for (const path of paths) {
-                                    await fs.promises.rm(path, { recursive: true });
+                                    if (dialog.cancelled) break;
+                                    await this.removeRecursiveWithProgress(path, dialog);
                                 }
                                 // If it was in recycle bin, we should also clean up metadata
-                                if (alreadyInRecycle) {
+                                if (alreadyInRecycle && !dialog.cancelled) {
                                     const metadata = await RecycleBinManager.getMetadata();
                                     let changed = false;
                                     for (const path of paths) {
@@ -397,11 +403,13 @@ export class FileOperations {
                                     }
                                 }
                             } else {
-                                const recycledIds = await RecycleBinManager.moveItemsToRecycleBin(paths);
-                                ZenUndoManager.push({
-                                    type: 'delete',
-                                    data: { recycledIds }
-                                });
+                                const recycledIds = await RecycleBinManager.moveItemsToRecycleBin(paths, dialog);
+                                if (recycledIds.length > 0) {
+                                    ZenUndoManager.push({
+                                        type: 'delete',
+                                        data: { recycledIds }
+                                    });
+                                }
                             }
 
                             // If it was permanent and NOT in recycle bin, we need to refresh manually
@@ -414,6 +422,7 @@ export class FileOperations {
                         } catch (e) {
                             handleFileSystemError("delete", e, "items");
                         } finally {
+                            dialog.close();
                             releaseBusyState(busyId, this.app.win.element);
                         }
                     }
@@ -468,6 +477,43 @@ export class FileOperations {
             handleFileSystemError("create", e, "file");
         } finally {
             releaseBusyState(busyId, this.app.win.element);
+        }
+    }
+
+    /**
+     * Recursively remove a file or directory with progress reporting
+     * @private
+     */
+    async removeRecursiveWithProgress(path, dialog) {
+        if (dialog && dialog.cancelled) return;
+
+        let stats;
+        try {
+            stats = await fs.promises.stat(path);
+        } catch (e) {
+            // If it doesn't exist, just return
+            return;
+        }
+
+        const sourceDir = getParentPath(path);
+
+        if (stats.isDirectory()) {
+            const files = await fs.promises.readdir(path);
+            for (const file of files) {
+                if (dialog && dialog.cancelled) return;
+                await this.removeRecursiveWithProgress(joinPath(path, file), dialog);
+            }
+            if (dialog && dialog.cancelled) return;
+            await fs.promises.rmdir(path);
+        } else {
+            if (dialog) {
+                dialog.update(path, sourceDir, null, 0);
+            }
+            await fs.promises.unlink(path);
+            if (dialog) {
+                dialog.finishItem(stats.size);
+                dialog.update(path, sourceDir, null, 0);
+            }
         }
     }
 

--- a/src/apps/zenexplorer/components/ProgressBarDialogWindow.js
+++ b/src/apps/zenexplorer/components/ProgressBarDialogWindow.js
@@ -20,11 +20,19 @@ export class ProgressBarDialogWindow {
   }
 
   _createUI() {
-    const title = this.operation === "copy" ? "Copying..." : "Moving...";
-    const gifUrl =
-      this.operation === "copy"
-        ? new URL("../assets/copying.gif", import.meta.url).href
-        : new URL("../assets/moving.gif", import.meta.url).href;
+    const title = {
+      copy: "Copying...",
+      move: "Moving...",
+      recycle: "Recycling...",
+      delete: "Deleting..."
+    }[this.operation] || "Processing...";
+
+    const gifUrl = {
+      copy: new URL("../assets/copying.gif", import.meta.url).href,
+      move: new URL("../assets/moving.gif", import.meta.url).href,
+      recycle: new URL("../assets/moving.gif", import.meta.url).href,
+      delete: new URL("../assets/copying.gif", import.meta.url).href
+    }[this.operation] || new URL("../assets/moving.gif", import.meta.url).href;
 
     const content = document.createElement("div");
     content.className = "progress-dialog-content";
@@ -126,16 +134,24 @@ export class ProgressBarDialogWindow {
     const fileName = getDisplayName(currentItemPath);
     if (this.fileNameEl) this.fileNameEl.textContent = fileName;
 
-    let sourceName = getDisplayName(sourcePath);
-    if (sourceName.length > 20) {
-      sourceName = sourceName.substring(0, 17) + "...";
+    if (this.fromToEl) {
+      let sourceName = sourcePath ? getDisplayName(sourcePath) : "";
+      if (sourceName.length > 20) {
+        sourceName = sourceName.substring(0, 17) + "...";
+      }
+
+      if (this.operation === "delete") {
+        this.fromToEl.textContent = `Deleting from '${sourceName}'`;
+      } else if (this.operation === "recycle") {
+        this.fromToEl.textContent = `From '${sourceName}' to Recycle Bin`;
+      } else {
+        let destName = destPath ? getDisplayName(destPath) : "";
+        if (destName.length > 20) {
+          destName = destName.substring(0, 17) + "...";
+        }
+        this.fromToEl.textContent = `From '${sourceName}' to '${destName}'`;
+      }
     }
-    let destName = getDisplayName(destPath);
-    if (destName.length > 20) {
-      destName = destName.substring(0, 17) + "...";
-    }
-    if (this.fromToEl)
-      this.fromToEl.textContent = `From '${sourceName}' to '${destName}'`;
 
     const totalProcessed = this.processedSize + currentProcessedSizeInFile;
     const percent =

--- a/src/apps/zenexplorer/components/ProgressBarDialogWindow.js
+++ b/src/apps/zenexplorer/components/ProgressBarDialogWindow.js
@@ -24,14 +24,16 @@ export class ProgressBarDialogWindow {
       copy: "Copying...",
       move: "Moving...",
       recycle: "Recycling...",
-      delete: "Deleting..."
+      delete: "Deleting...",
+      empty: "Emptying Recycle Bin..."
     }[this.operation] || "Processing...";
 
     const gifUrl = {
       copy: new URL("../assets/copying.gif", import.meta.url).href,
       move: new URL("../assets/moving.gif", import.meta.url).href,
       recycle: new URL("../assets/moving.gif", import.meta.url).href,
-      delete: new URL("../assets/copying.gif", import.meta.url).href
+      delete: new URL("../assets/copying.gif", import.meta.url).href,
+      empty: new URL("../assets/moving.gif", import.meta.url).href
     }[this.operation] || new URL("../assets/moving.gif", import.meta.url).href;
 
     const content = document.createElement("div");
@@ -144,6 +146,8 @@ export class ProgressBarDialogWindow {
         this.fromToEl.textContent = `Deleting from '${sourceName}'`;
       } else if (this.operation === "recycle") {
         this.fromToEl.textContent = `From '${sourceName}' to Recycle Bin`;
+      } else if (this.operation === "empty") {
+        this.fromToEl.textContent = `Emptying Recycle Bin...`;
       } else {
         let destName = destPath ? getDisplayName(destPath) : "";
         if (destName.length > 20) {

--- a/src/apps/zenexplorer/components/ProgressBarDialogWindow.js
+++ b/src/apps/zenexplorer/components/ProgressBarDialogWindow.js
@@ -25,7 +25,8 @@ export class ProgressBarDialogWindow {
       move: "Moving...",
       recycle: "Recycling...",
       delete: "Deleting...",
-      empty: "Emptying Recycle Bin..."
+      empty: "Emptying Recycle Bin...",
+      restore: "Restoring..."
     }[this.operation] || "Processing...";
 
     const gifUrl = {
@@ -33,7 +34,8 @@ export class ProgressBarDialogWindow {
       move: new URL("../assets/moving.gif", import.meta.url).href,
       recycle: new URL("../assets/moving.gif", import.meta.url).href,
       delete: new URL("../assets/copying.gif", import.meta.url).href,
-      empty: new URL("../assets/moving.gif", import.meta.url).href
+      empty: new URL("../assets/moving.gif", import.meta.url).href,
+      restore: new URL("../assets/moving.gif", import.meta.url).href
     }[this.operation] || new URL("../assets/moving.gif", import.meta.url).href;
 
     const content = document.createElement("div");
@@ -142,17 +144,20 @@ export class ProgressBarDialogWindow {
         sourceName = sourceName.substring(0, 17) + "...";
       }
 
+      let destName = destPath ? getDisplayName(destPath) : "";
+      if (destName.length > 20) {
+        destName = destName.substring(0, 17) + "...";
+      }
+
       if (this.operation === "delete") {
         this.fromToEl.textContent = `Deleting from '${sourceName}'`;
       } else if (this.operation === "recycle") {
         this.fromToEl.textContent = `From '${sourceName}' to Recycle Bin`;
       } else if (this.operation === "empty") {
         this.fromToEl.textContent = `Emptying Recycle Bin...`;
+      } else if (this.operation === "restore") {
+        this.fromToEl.textContent = `From Recycle Bin to '${destName}'`;
       } else {
-        let destName = destPath ? getDisplayName(destPath) : "";
-        if (destName.length > 20) {
-          destName = destName.substring(0, 17) + "...";
-        }
         this.fromToEl.textContent = `From '${sourceName}' to '${destName}'`;
       }
     }

--- a/src/apps/zenexplorer/utils/RecycleBinManager.js
+++ b/src/apps/zenexplorer/utils/RecycleBinManager.js
@@ -52,14 +52,16 @@ export class RecycleBinManager {
     /**
      * Move multiple items to the Recycle Bin
      * @param {string[]} paths
+     * @param {ProgressBarDialogWindow} dialog
      * @returns {Promise<string[]>} IDs of the recycled items
      */
-    static async moveItemsToRecycleBin(paths) {
+    static async moveItemsToRecycleBin(paths, dialog = null) {
         const metadata = await this.getMetadata();
         let changed = false;
         const recycledIds = [];
 
         for (const path of paths) {
+            if (dialog && dialog.cancelled) break;
             if (this.isRecycledItemPath(path)) continue;
 
             const id = (typeof crypto.randomUUID === 'function')
@@ -69,11 +71,21 @@ export class RecycleBinManager {
             const name = getPathName(path);
             const targetPath = joinPath(RECYCLE_PATH, id);
 
+            const sourceDir = getParentPath(path);
+            if (dialog) {
+                dialog.update(path, sourceDir, RECYCLE_PATH, 0);
+            }
+
             try {
                 await fs.promises.rename(path, targetPath);
+                if (dialog) {
+                    const stats = await fs.promises.stat(targetPath);
+                    dialog.finishItem(stats.isDirectory() ? 0 : stats.size);
+                    dialog.update(path, sourceDir, RECYCLE_PATH, 0);
+                }
             } catch (e) {
-                await this.copyRecursive(path, targetPath);
-                await fs.promises.rm(path, { recursive: true });
+                await this.copyRecursive(path, targetPath, dialog);
+                await this.removeRecursive(path, dialog);
             }
 
             metadata[id] = {
@@ -251,17 +263,57 @@ export class RecycleBinManager {
      * Recursively copy a file or directory
      * @private
      */
-    static async copyRecursive(src, dest) {
+    static async copyRecursive(src, dest, dialog = null) {
+        if (dialog && dialog.cancelled) return;
+
         const stats = await fs.promises.stat(src);
+        const sourceDir = getParentPath(src);
+        const destDir = getParentPath(dest);
+
         if (stats.isDirectory()) {
             await fs.promises.mkdir(dest, { recursive: true });
             const files = await fs.promises.readdir(src);
             for (const file of files) {
-                await this.copyRecursive(joinPath(src, file), joinPath(dest, file));
+                if (dialog && dialog.cancelled) return;
+                await this.copyRecursive(joinPath(src, file), joinPath(dest, file), dialog);
             }
         } else {
+            if (dialog) {
+                dialog.update(src, sourceDir, destDir, 0);
+            }
             const data = await fs.promises.readFile(src);
             await fs.promises.writeFile(dest, data);
+            if (dialog) {
+                dialog.finishItem(stats.size);
+                dialog.update(src, sourceDir, destDir, 0);
+            }
+        }
+    }
+
+    /**
+     * Recursively remove a file or directory
+     * @private
+     */
+    static async removeRecursive(path, dialog = null) {
+        if (dialog && dialog.cancelled) return;
+
+        let stats;
+        try {
+            stats = await fs.promises.stat(path);
+        } catch (e) {
+            return;
+        }
+
+        if (stats.isDirectory()) {
+            const files = await fs.promises.readdir(path);
+            for (const file of files) {
+                if (dialog && dialog.cancelled) return;
+                await this.removeRecursive(joinPath(path, file), dialog);
+            }
+            if (dialog && dialog.cancelled) return;
+            await fs.promises.rmdir(path);
+        } else {
+            await fs.promises.unlink(path);
         }
     }
 }

--- a/src/apps/zenexplorer/utils/RecycleBinManager.js
+++ b/src/apps/zenexplorer/utils/RecycleBinManager.js
@@ -85,7 +85,7 @@ export class RecycleBinManager {
                 }
             } catch (e) {
                 await this.copyRecursive(path, targetPath, dialog);
-                await this.removeRecursive(path, dialog);
+                await this.removeRecursive(path, dialog, false); // Don't report progress twice
             }
 
             metadata[id] = {
@@ -117,18 +117,24 @@ export class RecycleBinManager {
     /**
      * Restore multiple items from the Recycle Bin
      * @param {string[]} ids
+     * @param {ProgressBarDialogWindow} dialog
      */
-    static async restoreItems(ids) {
+    static async restoreItems(ids, dialog = null) {
         const metadata = await this.getMetadata();
         let changed = false;
 
         for (const id of ids) {
+            if (dialog && dialog.cancelled) break;
             const entry = metadata[id];
             if (!entry) continue;
 
             const srcPath = joinPath(RECYCLE_PATH, id);
             let destPath = entry.originalPath;
             const parentPath = getParentPath(destPath);
+
+            if (dialog) {
+                dialog.update(entry.originalName, RECYCLE_PATH, parentPath, 0);
+            }
 
             try {
                 await fs.promises.stat(parentPath);
@@ -140,9 +146,14 @@ export class RecycleBinManager {
 
             try {
                 await fs.promises.rename(srcPath, destPath);
+                if (dialog) {
+                    const stats = await fs.promises.stat(destPath);
+                    dialog.finishItem(stats.isDirectory() ? 0 : stats.size);
+                    dialog.update(entry.originalName, RECYCLE_PATH, parentPath, 0);
+                }
             } catch (e) {
-                await this.copyRecursive(srcPath, destPath);
-                await fs.promises.rm(srcPath, { recursive: true });
+                await this.copyRecursive(srcPath, destPath, dialog);
+                await this.removeRecursive(srcPath, dialog, false); // Don't report progress twice
             }
 
             delete metadata[id];
@@ -314,7 +325,7 @@ export class RecycleBinManager {
      * Recursively remove a file or directory
      * @private
      */
-    static async removeRecursive(path, dialog = null) {
+    static async removeRecursive(path, dialog = null, reportProgress = true) {
         if (dialog && dialog.cancelled) return;
 
         let stats;
@@ -328,18 +339,20 @@ export class RecycleBinManager {
             const files = await fs.promises.readdir(path);
             for (const file of files) {
                 if (dialog && dialog.cancelled) return;
-                await this.removeRecursive(joinPath(path, file), dialog);
+                await this.removeRecursive(joinPath(path, file), dialog, reportProgress);
             }
             if (dialog && dialog.cancelled) return;
             await fs.promises.rmdir(path);
         } else {
-            if (dialog) {
+            if (dialog && reportProgress) {
                 const sourceDir = getParentPath(path);
                 dialog.update(path, sourceDir, null, 0);
             }
             await fs.promises.unlink(path);
-            if (dialog) {
+            if (dialog && reportProgress) {
                 dialog.finishItem(stats.size);
+                const sourceDir = getParentPath(path);
+                dialog.update(path, sourceDir, null, 0);
             }
         }
     }

--- a/src/apps/zenexplorer/utils/RecycleBinManager.js
+++ b/src/apps/zenexplorer/utils/RecycleBinManager.js
@@ -165,21 +165,41 @@ export class RecycleBinManager {
 
     /**
      * Empty the Recycle Bin
+     * @param {ProgressBarDialogWindow} dialog
      */
-    static async emptyRecycleBin() {
+    static async emptyRecycleBin(dialog = null) {
         const metadata = await this.getMetadata();
         const ids = Object.keys(metadata);
 
         for (const id of ids) {
+            if (dialog && dialog.cancelled) break;
             const path = joinPath(RECYCLE_PATH, id);
             try {
-                await fs.promises.rm(path, { recursive: true });
+                if (dialog) {
+                    await this.removeRecursive(path, dialog);
+                } else {
+                    await fs.promises.rm(path, { recursive: true });
+                }
             } catch (e) {
                 console.error(`Failed to delete recycled item ${id}`, e);
             }
         }
 
-        await this.saveMetadata({});
+        if (dialog && dialog.cancelled) {
+            // Re-sync metadata if cancelled
+            const remainingMetadata = {};
+            for (const id in metadata) {
+                try {
+                    await fs.promises.stat(joinPath(RECYCLE_PATH, id));
+                    remainingMetadata[id] = metadata[id];
+                } catch (e) {
+                    // Item was deleted
+                }
+            }
+            await this.saveMetadata(remainingMetadata);
+        } else {
+            await this.saveMetadata({});
+        }
         document.dispatchEvent(new CustomEvent("zen-recycle-bin-change"));
     }
 
@@ -313,7 +333,14 @@ export class RecycleBinManager {
             if (dialog && dialog.cancelled) return;
             await fs.promises.rmdir(path);
         } else {
+            if (dialog) {
+                const sourceDir = getParentPath(path);
+                dialog.update(path, sourceDir, null, 0);
+            }
             await fs.promises.unlink(path);
+            if (dialog) {
+                dialog.finishItem(stats.size);
+            }
         }
     }
 }

--- a/src/apps/zenexplorer/utils/ZenContextMenuBuilder.js
+++ b/src/apps/zenexplorer/utils/ZenContextMenuBuilder.js
@@ -92,35 +92,7 @@ export class ZenContextMenuBuilder {
       if (isRecycleBin) {
         menuItems.push({
           label: "Empty Recycle Bin",
-          action: async () => {
-            const isEmpty = await RecycleBinManager.isEmpty();
-            if (isEmpty) return;
-
-            ShowDialogWindow({
-              title: "Confirm Empty Recycle Bin",
-              text: "Are you sure you want to permanently delete all items in the Recycle Bin?",
-              buttons: [
-                {
-                  label: "Yes",
-                  isDefault: true,
-                  action: async () => {
-                    const busyId = `empty-recycle-${Math.random()}`;
-                    requestBusyState(busyId, this.app.win.element);
-                    try {
-                      await RecycleBinManager.emptyRecycleBin();
-                      playSound("EmptyRecycleBin");
-                      if (this.app.currentPath === path) {
-                        await this.app.navigateTo(path, true, true);
-                      }
-                    } finally {
-                      releaseBusyState(busyId, this.app.win.element);
-                    }
-                  },
-                },
-                { label: "No" },
-              ],
-            });
-          },
+          action: () => this.app.fileOps.emptyRecycleBin(),
         });
       }
 

--- a/src/apps/zenexplorer/utils/ZenContextMenuBuilder.js
+++ b/src/apps/zenexplorer/utils/ZenContextMenuBuilder.js
@@ -40,16 +40,7 @@ export class ZenContextMenuBuilder {
       menuItems = [
         {
           label: "Restore",
-          action: async () => {
-            const busyId = `restore-${Math.random()}`;
-            requestBusyState(busyId, this.app.win.element);
-            try {
-              const ids = selectedPaths.map((p) => getPathName(p));
-              await RecycleBinManager.restoreItems(ids);
-            } finally {
-              releaseBusyState(busyId, this.app.win.element);
-            }
-          },
+          action: () => this.app.fileOps.restoreItems(selectedPaths),
           default: true,
         },
         "MENU_DIVIDER",

--- a/src/apps/zenexplorer/utils/ZenDragDropManager.js
+++ b/src/apps/zenexplorer/utils/ZenDragDropManager.js
@@ -1,5 +1,6 @@
 import { openApps } from "../../Application.js";
 import { getParentPath } from "./PathUtils.js";
+import { RecycleBinManager } from "./RecycleBinManager.js";
 
 /**
  * ZenDragDropManager - Handles custom drag and drop for ZenExplorer
@@ -223,6 +224,25 @@ export class ZenDragDropManager {
         // Prevent moving/copying root items to other folders
         if (sourceDir === "/") {
             console.warn("Cannot move or copy root items to other folders.");
+            return;
+        }
+
+        // Special handling for Recycle Bin source (Restore)
+        if (sourcePaths.some(p => RecycleBinManager.isRecycledItemPath(p))) {
+            await sourceApp.fileOps.restoreItems(sourcePaths);
+            return;
+        }
+
+        // Special handling for Recycle Bin destination (Recycle)
+        if (RecycleBinManager.isRecycleBinPath(destinationPath)) {
+            const { ProgressBarDialogWindow } = await import("../components/ProgressBarDialogWindow.js");
+            const totalSize = await sourceApp.fileOps.getTotalSize(sourcePaths);
+            const dialog = new ProgressBarDialogWindow("recycle", sourcePaths.length, totalSize);
+            try {
+                await RecycleBinManager.moveItemsToRecycleBin(sourcePaths, dialog);
+            } finally {
+                dialog.close();
+            }
             return;
         }
 

--- a/src/apps/zenexplorer/utils/ZenDragDropManager.js
+++ b/src/apps/zenexplorer/utils/ZenDragDropManager.js
@@ -225,14 +225,20 @@ export class ZenDragDropManager {
             return;
         }
 
+        const { ProgressBarDialogWindow } = await import("../components/ProgressBarDialogWindow.js");
+        const totalSize = await this.sourceApp.fileOps.getTotalSize(sourcePaths);
+        const dialog = new ProgressBarDialogWindow(isCopy ? "copy" : "move", sourcePaths.length, totalSize);
+
         try {
             if (isCopy) {
-                await this.sourceApp.fileOps.copyItemsDirect(sourcePaths, destinationPath, { dropX, dropY, offsets });
+                await this.sourceApp.fileOps.copyItemsDirect(sourcePaths, destinationPath, { dropX, dropY, offsets }, dialog);
             } else {
-                await this.sourceApp.fileOps.moveItemsDirect(sourcePaths, destinationPath, { dropX, dropY, offsets });
+                await this.sourceApp.fileOps.moveItemsDirect(sourcePaths, destinationPath, { dropX, dropY, offsets }, dialog);
             }
         } catch (err) {
             console.error('Drop failed:', err);
+        } finally {
+            dialog.close();
         }
     }
 

--- a/src/apps/zenexplorer/utils/ZenDragDropManager.js
+++ b/src/apps/zenexplorer/utils/ZenDragDropManager.js
@@ -179,7 +179,8 @@ export class ZenDragDropManager {
      * @private
      */
     async _performDrop(e, isCopy) {
-        if (!this.dropTarget) return;
+        const sourceApp = this.sourceApp;
+        if (!this.dropTarget || !sourceApp) return;
 
         let destinationPath = null;
         let targetWindow = this.dropTarget.closest('.window');
@@ -213,8 +214,8 @@ export class ZenDragDropManager {
         const sourceDir = sourcePaths[0].substring(0, sourcePaths[0].lastIndexOf('/')) || '/';
         if (!isCopy && destinationPath === sourceDir) {
             // Handle rearrangement
-            if (this.sourceApp.handleRearrange) {
-                await this.sourceApp.handleRearrange(sourcePaths, dropX, dropY, offsets);
+            if (sourceApp.handleRearrange) {
+                await sourceApp.handleRearrange(sourcePaths, dropX, dropY, offsets);
             }
             return;
         }
@@ -226,14 +227,14 @@ export class ZenDragDropManager {
         }
 
         const { ProgressBarDialogWindow } = await import("../components/ProgressBarDialogWindow.js");
-        const totalSize = await this.sourceApp.fileOps.getTotalSize(sourcePaths);
+        const totalSize = await sourceApp.fileOps.getTotalSize(sourcePaths);
         const dialog = new ProgressBarDialogWindow(isCopy ? "copy" : "move", sourcePaths.length, totalSize);
 
         try {
             if (isCopy) {
-                await this.sourceApp.fileOps.copyItemsDirect(sourcePaths, destinationPath, { dropX, dropY, offsets }, dialog);
+                await sourceApp.fileOps.copyItemsDirect(sourcePaths, destinationPath, { dropX, dropY, offsets }, dialog);
             } else {
-                await this.sourceApp.fileOps.moveItemsDirect(sourcePaths, destinationPath, { dropX, dropY, offsets }, dialog);
+                await sourceApp.fileOps.moveItemsDirect(sourcePaths, destinationPath, { dropX, dropY, offsets }, dialog);
             }
         } catch (err) {
             console.error('Drop failed:', err);


### PR DESCRIPTION
This change implements the progress bar dialog window for several file operations in ZenExplorer that previously lacked it. Specifically:
- **Drag and Drop**: Both move and copy operations now show a progress bar.
- **Deletion**: Both permanent deletion and moving to the Recycle Bin now show a progress bar.
- **Distinct Visuals**: Recycle Bin deletion uses the 'moving' animation, while permanent deletion uses the 'copying' animation (as placeholders, per requirements).
- **Progress Logic**: Implemented recursive size calculation and progress reporting for deletions and recycling.
- **Cancellation**: Users can now cancel these operations from the progress dialog, matching Windows behavior.

---
*PR created automatically by Jules for task [18431940989577603605](https://jules.google.com/task/18431940989577603605) started by @azayrahmad*