### PR TITLE
Fix ZenExplorer Windowing System

### DIFF
--- a/src/apps/Application.js
+++ b/src/apps/Application.js
@@ -47,6 +47,7 @@ export class Application {
 
     const windowId = windowIdOverride || this._getWindowId(filePath);
     const instanceKey = this.isSingleton ? this.id : windowId;
+    this.instanceKey = instanceKey;
 
     if (openApps.has(instanceKey)) {
       const existingApp = openApps.get(instanceKey);
@@ -78,6 +79,7 @@ export class Application {
 
     await this._onLaunch(filePath);
     openApps.set(instanceKey, this);
+    appManager.runningApps[instanceKey] = this;
   }
 
   _getWindowId(filePath) {
@@ -115,22 +117,7 @@ export class Application {
         }
       }
       openWindows.delete(windowId);
-      openApps.delete(instanceKey);
-
-      // Check if this was the last instance of this application type
-      let isLastInstance = true;
-      if (!this.isSingleton) {
-        // For non-singletons, check if any other instances are still in openApps
-        for (const key of openApps.keys()) {
-          if (key.startsWith(this.id)) {
-            isLastInstance = false;
-            break;
-          }
-        }
-      }
-      // For singletons, isLastInstance remains true, as the only instance was just removed.
-      //
-      appManager.closeApp(this.id);
+      appManager.closeApp(instanceKey);
     });
 
     if (this.hasTaskbarButton) {

--- a/src/apps/taskmanager/TaskManagerApp.js
+++ b/src/apps/taskmanager/TaskManagerApp.js
@@ -30,20 +30,20 @@ export class TaskManagerApp extends Application {
     const taskList = this.win.$content.find(".task-list");
     const selectedAppId = this.win.$content
       .find(".task-list tr.highlighted")
-      .data("appId");
+      .data("instanceKey");
     const tableBody = $("<tbody></tbody>");
 
     const runningApps = appManager.getRunningApps();
 
-    for (const [appId, appInstance] of Object.entries(runningApps)) {
-      if (appId === "taskmanager") continue;
+    for (const [instanceKey, appInstance] of Object.entries(runningApps)) {
+      if (appInstance.id === "taskmanager") continue;
 
-      const appConfig = appManager.getAppConfig(appId);
+      const appConfig = appManager.getAppConfig(appInstance.id);
       const title = appInstance.win ? appInstance.win.title() : appConfig.title;
 
       const tableRow = $(`<tr><td>${title}</td></tr>`);
-      tableRow.data("appId", appId);
-      if (selectedAppId && appId === selectedAppId) {
+      tableRow.data("instanceKey", instanceKey);
+      if (selectedAppId && instanceKey === selectedAppId) {
         tableRow.addClass("highlighted");
       }
       tableBody.append(tableRow);
@@ -72,8 +72,8 @@ export class TaskManagerApp extends Application {
     content.on("click", ".end-task-btn", () => {
       const selectedItem = content.find(".task-list tr.highlighted");
       if (selectedItem.length) {
-        const appId = selectedItem.data("appId");
-        appManager.closeApp(appId);
+        const instanceKey = selectedItem.data("instanceKey");
+        appManager.closeApp(instanceKey);
       }
     });
 

--- a/src/utils/appManager.js
+++ b/src/utils/appManager.js
@@ -17,14 +17,14 @@ const appManager = {
         return apps.find((a) => a.id === appId);
     },
 
-    closeApp(appId) {
-        const appInstance = this.runningApps[appId];
+    closeApp(instanceKey) {
+        const appInstance = this.runningApps[instanceKey];
         if (appInstance) {
             playSound("Close");
             // Remove the app from the registries first to prevent re-entry.
-            delete this.runningApps[appId];
-            openApps.delete(appId);
-            document.dispatchEvent(new CustomEvent('app-closed', { detail: { appId } }));
+            delete this.runningApps[instanceKey];
+            openApps.delete(instanceKey);
+            document.dispatchEvent(new CustomEvent('app-closed', { detail: { appId: appInstance.id, instanceKey } }));
 
             // Now, perform the app-specific cleanup.
             if (appInstance.win) {
@@ -59,7 +59,7 @@ export async function launchApp(appId, data = null) {
     try {
         if (appConfig.appClass) {
             const appInstance = new appConfig.appClass({ ...appConfig, id: appId });
-            appManager.runningApps[appId] = appInstance;
+            // The instance will register itself in runningApps during launch using its unique instanceKey
             await appInstance.launch(data);
             document.dispatchEvent(new CustomEvent('app-launched', { detail: { appId } }));
             return appInstance;


### PR DESCRIPTION
This change fixes a bug in the windowing system where multiple instances of the same application (specifically ZenExplorer) were not handled independently. Previously, launching a new ZenExplorer window would overwrite the reference to the previous one in the `appManager`, and closing any window would trigger a global close that affected other instances.

The fix involves:
1. Using a unique `instanceKey` (based on window ID for non-singleton apps) to track instances in `appManager.runningApps`.
2. Updating the `Application` base class to register itself with this unique key.
3. Updating the Task Manager to iterate over all instances and display them as individual entries, allowing for granular control.

This ensures that closing one folder window doesn't close others, and that the Task Manager provides a correct overview of all open windows.

---
*PR created automatically by Jules for task [2354695396257819424](https://jules.google.com/task/2354695396257819424) started by @azayrahmad*