### PR TITLE
Fix Desktop: Grid Flow, Themed Icons, and Navigation

### DIFF
--- a/src/apps/zenexplorer/ZenDesktopApp.js
+++ b/src/apps/zenexplorer/ZenDesktopApp.js
@@ -50,34 +50,60 @@ export class ZenDesktopApp {
         });
 
         // Setup event listeners
-        this.iconContainer.addEventListener('dblclick', (e) => {
+        this._dblClickListener = (e) => {
             const icon = e.target.closest('.explorer-icon');
             if (icon) {
                 this.openFile(icon);
             }
-        });
+        };
+        this.iconContainer.addEventListener('dblclick', this._dblClickListener);
 
         // FS change listener
-        document.addEventListener('zen-fs-change', (e) => {
+        this._fsChangeListener = (e) => {
             if (e.detail?.path === this.currentPath || e.detail?.path === '/') {
                 this.refresh();
             }
-        });
+        };
+        document.addEventListener('zen-fs-change', this._fsChangeListener);
 
         // Layout change listener
-        document.addEventListener('zen-layout-change', (e) => {
+        this._layoutChangeListener = (e) => {
             if (e.detail.path === this.currentPath) {
                 this.refresh();
             }
-        });
+        };
+        document.addEventListener('zen-layout-change', this._layoutChangeListener);
 
         // Wallpaper listener
-        document.addEventListener('wallpaper-changed', () => {
+        this._wallpaperListener = () => {
             this.applyWallpaper();
-        });
+        };
+        document.addEventListener('wallpaper-changed', this._wallpaperListener);
 
         await this.refresh();
         this.applyWallpaper();
+
+        // Theme change listener
+        this._themeChangeListener = () => this.refresh();
+        document.addEventListener('theme-changed', this._themeChangeListener);
+    }
+
+    destroy() {
+        if (this.iconContainer && this._dblClickListener) {
+            this.iconContainer.removeEventListener('dblclick', this._dblClickListener);
+        }
+        if (this._fsChangeListener) {
+            document.removeEventListener('zen-fs-change', this._fsChangeListener);
+        }
+        if (this._layoutChangeListener) {
+            document.removeEventListener('zen-layout-change', this._layoutChangeListener);
+        }
+        if (this._wallpaperListener) {
+            document.removeEventListener('wallpaper-changed', this._wallpaperListener);
+        }
+        if (this._themeChangeListener) {
+            document.removeEventListener('theme-changed', this._themeChangeListener);
+        }
     }
 
     applyWallpaper() {

--- a/src/apps/zenexplorer/components/FileIconRenderer.js
+++ b/src/apps/zenexplorer/components/FileIconRenderer.js
@@ -72,6 +72,42 @@ export async function renderFileIcon(fileName, fullPath, isDir, options = {}) {
   iconWrapper.className = "icon-wrapper";
 
   let iconObj = shellIcon || getIconObjForFile(fileName, isDir);
+
+  // Special handling for My Documents
+  if (fullPath === "/C:/My Documents" || fileName === "My Documents") {
+    iconObj = ICONS.documents;
+  }
+
+  // Theme icons support for desktop
+  if (options.useThemeIcons) {
+    try {
+      const { getIconSchemeName } = await import(
+        "../../../utils/themeManager.js"
+      );
+      const { iconSchemes } = await import("../../../config/icon-schemes.js");
+      const schemeName = getIconSchemeName();
+      const scheme = iconSchemes[schemeName] || iconSchemes.default;
+
+      if (fullPath.endsWith("/My Computer") || fullPath === "/") {
+        iconObj = scheme.myComputer;
+      } else if (fullPath === "/C:/My Documents" || fileName === "My Documents") {
+        if (scheme.myDocuments) {
+          iconObj = scheme.myDocuments;
+        }
+      } else if (fullPath.endsWith("/Recycle Bin")) {
+        const isEmpty =
+          options.recycleBinEmpty !== undefined
+            ? options.recycleBinEmpty
+            : await RecycleBinManager.isEmpty();
+        iconObj = isEmpty ? scheme.recycleBinEmpty : scheme.recycleBinFull;
+      } else if (fullPath.endsWith("/Network Neighborhood")) {
+        iconObj = scheme.networkNeighborhood;
+      }
+    } catch (e) {
+      console.error("Failed to load theme icons", e);
+    }
+  }
+
   let displayName = getDisplayName(fileName);
   let isShortcut = fileName.toLowerCase().endsWith(".lnk");
 


### PR DESCRIPTION
This PR addresses multiple desktop-related issues in the ZenExplorer environment:

1. **Grid Flow**: The desktop icon grid now fills top-to-bottom before moving left-to-right, matching Windows behavior.
2. **Themed Icons**: Desktop icons (My Computer, My Documents, etc.) now respect the active system theme when available.
3. **Properties Redirection**: Right-clicking the desktop background and selecting 'Properties' now launches the 'displayproperties' application.
4. **Immediate Updates**: Desktop icons now refresh immediately when files are created/deleted in the Desktop folder or when the system theme changes.
5. **Virtual Item Navigation**: Virtual items on the desktop like 'My Computer' and 'My Documents' now correctly redirect to their respective system roots (e.g., / for My Computer) when opened from either the desktop or the Desktop folder in ZenExplorer.
6. **Code Hygiene**: Added event listener cleanup to ZenDesktopApp and refined icon selection logic for specialized folders.

---
*PR created automatically by Jules for task [5464925277528726684](https://jules.google.com/task/5464925277528726684) started by @azayrahmad*