### PR TITLE
Add Desktop Shell Extension to ZenExplorer

### DIFF
--- a/src/apps/zenexplorer/ZenExplorerApp.js
+++ b/src/apps/zenexplorer/ZenExplorerApp.js
@@ -30,9 +30,11 @@ import { joinPath } from "./navigation/PathUtils.js";
 import { getToolbarItems } from "./interface/ToolbarBuilder.js";
 import { sortFileInfos } from "./fileoperations/SortUtils.js";
 import { ControlPanelExtension } from "./extensions/ControlPanelExtension.js";
+import { DesktopExtension } from "./extensions/DesktopExtension.js";
 
 // Initialize Shell Extensions
 ShellManager.registerExtension(new ControlPanelExtension());
+ShellManager.registerExtension(new DesktopExtension());
 
 export class ZenExplorerApp extends Application {
   static config = {

--- a/src/apps/zenexplorer/extensions/DesktopExtension.js
+++ b/src/apps/zenexplorer/extensions/DesktopExtension.js
@@ -1,0 +1,112 @@
+import { fs } from "@zenfs/core";
+import { ICONS } from "../../../config/icons.js";
+import { VirtualStats } from "./ShellManager.js";
+import { getPathName } from "../navigation/PathUtils.js";
+
+/**
+ * DesktopExtension - Shell extension for the Desktop folder in C:\WINDOWS
+ */
+export class DesktopExtension {
+  constructor() {
+    this.path = "/C:/WINDOWS/Desktop";
+  }
+
+  /**
+   * Check if this extension handles the given path
+   * @param {string} path
+   * @returns {boolean}
+   */
+  handlesPath(path) {
+    if (!path) return false;
+    const p = path.replace(/\/$/, "");
+    return p === this.path || p === this.path + "/My Computer";
+  }
+
+  /**
+   * Get virtual stats for a path
+   * @param {string} path
+   * @returns {Promise<Object>}
+   */
+  async stat(path) {
+    const p = path.replace(/\/$/, "");
+    if (p === this.path) {
+      return fs.promises.stat(this.path);
+    }
+    if (p === this.path + "/My Computer") {
+      return new VirtualStats({ isDirectory: false });
+    }
+    return fs.promises.stat(path);
+  }
+
+  /**
+   * Read virtual directory contents
+   * @param {string} path
+   * @returns {Promise<string[]|null>}
+   */
+  async readdir(path) {
+    if (path && path.replace(/\/$/, "") === this.path) {
+      return ["My Computer"];
+    }
+    return null;
+  }
+
+  /**
+   * Get custom icon object for a path
+   * @param {string} path
+   * @returns {Object|null}
+   */
+  getIconObj(path) {
+    const p = path.replace(/\/$/, "");
+    if (p === this.path) {
+      return ICONS.desktop;
+    }
+    if (p === this.path + "/My Computer") {
+      return ICONS.computer;
+    }
+    return null;
+  }
+
+  /**
+   * Get custom icon for a path
+   * @param {string} path
+   * @param {number} size
+   * @returns {string|null}
+   */
+  getIcon(path, size = 32) {
+    const iconObj = this.getIconObj(path);
+    return iconObj ? iconObj[size] : null;
+  }
+
+  /**
+   * Handle opening a path
+   * @param {string} path
+   * @param {Object} app - ZenExplorerApp instance
+   * @returns {Promise<boolean>}
+   */
+  async onOpen(path, app) {
+    const p = path.replace(/\/$/, "");
+    if (p === this.path) {
+      app.navigateTo(this.path);
+      return true;
+    }
+    if (p === this.path + "/My Computer") {
+      app.navigateTo("/");
+      return true;
+    }
+    return false;
+  }
+
+  /**
+   * Get column value for Desktop items
+   * @param {string} fullPath
+   * @param {string} columnKey
+   * @returns {string|null}
+   */
+  getColumnValue(fullPath, columnKey) {
+    const name = getPathName(fullPath);
+    if (name === "My Computer" && columnKey === "type") {
+      return "System Folder";
+    }
+    return null;
+  }
+}

--- a/src/config/icons.js
+++ b/src/config/icons.js
@@ -133,6 +133,10 @@ export const ICONS = {
     16: new URL("../assets/icons/desktop_old-4.png", import.meta.url).href,
     32: new URL("../assets/icons/desktop_old-4.png", import.meta.url).href,
   },
+  desktop: {
+    16: new URL("../assets/icons/desktop_old-4.png", import.meta.url).href,
+    32: new URL("../assets/icons/desktop_old-4.png", import.meta.url).href,
+  },
   themetocss: {
     16: new URL("../assets/icons/word_001-16.png", import.meta.url).href,
     32: new URL("../assets/icons/word_001-32.png", import.meta.url).href,

--- a/src/utils/zenfs-init.js
+++ b/src/utils/zenfs-init.js
@@ -30,6 +30,10 @@ export async function initFileSystem() {
             await fs.promises.mkdir('/C:/WINDOWS');
         }
 
+        if (!fs.existsSync('/C:/WINDOWS/Desktop')) {
+            await fs.promises.mkdir('/C:/WINDOWS/Desktop');
+        }
+
         isInitialized = true;
         console.log("ZenFS initialized successfully.");
     } catch (error) {


### PR DESCRIPTION
This PR implements a new shell extension for ZenExplorer that manages the Desktop folder located at `C:\WINDOWS\Desktop`.

Key features:
1. **Hybrid Folder**: The extension augments a real directory on the persistent `C:` drive. This means any files or folders created there are saved to disk.
2. **Virtual Items**: A "My Computer" icon is added to the folder view. Double-clicking it navigates ZenExplorer back to the root directory (`/`).
3. **Iconography**: The `Desktop` folder itself now uses the appropriate Windows 98 desktop icon when viewed in ZenExplorer.
4. **Full Functionality**: Standard file operations (New Folder, Text Document, Rename, Delete) are fully supported within this folder.

Changes:
- Modified `src/utils/zenfs-init.js` to create the `/C:/WINDOWS/Desktop` directory on startup.
- Added `ICONS.desktop` alias in `src/config/icons.js`.
- Implemented `DesktopExtension.js` in `src/apps/zenexplorer/extensions/`.
- Registered the new extension in `ZenExplorerApp.js`.

---
*PR created automatically by Jules for task [18108985562752545348](https://jules.google.com/task/18108985562752545348) started by @azayrahmad*