### PR TITLE
Implement drive-specific recycle bins in ZenExplorer

### DIFF
--- a/src/apps/zenexplorer/ZenExplorerApp.js
+++ b/src/apps/zenexplorer/ZenExplorerApp.js
@@ -127,7 +127,6 @@ export class ZenExplorerApp extends Application {
 
     // 1. Initialize File System
     await initFileSystem();
-    await RecycleBinManager.init();
 
     // 2. Setup Window
     const win = new window.$Window({

--- a/src/apps/zenexplorer/fileoperations/FileOperations.js
+++ b/src/apps/zenexplorer/fileoperations/FileOperations.js
@@ -276,21 +276,24 @@ export class FileOperations {
                                     await this.removeRecursiveWithProgress(path, dialog);
                                 }
                                 if (alreadyInRecycle && !dialog.cancelled) {
-                                    const metadata = await RecycleBinManager.getMetadata();
-                                    let changed = false;
-                                    for (const path of paths) {
-                                        const id = getPathName(path);
-                                        if (metadata[id]) { delete metadata[id]; changed = true; }
-                                    }
-                                    if (changed) {
-                                        await RecycleBinManager.saveMetadata(metadata);
-                                        document.dispatchEvent(new CustomEvent("recycle-bin-change"));
+                                    const recyclePath = RecycleBinManager.getRecyclePath(paths[0]);
+                                    if (recyclePath) {
+                                        const metadata = await RecycleBinManager.getMetadata(recyclePath);
+                                        let changed = false;
+                                        for (const path of paths) {
+                                            const id = getPathName(path);
+                                            if (metadata[id]) { delete metadata[id]; changed = true; }
+                                        }
+                                        if (changed) {
+                                            await RecycleBinManager.saveMetadata(recyclePath, metadata);
+                                            document.dispatchEvent(new CustomEvent("recycle-bin-change"));
+                                        }
                                     }
                                 }
                             } else {
-                                const recycledIds = await RecycleBinManager.moveItemsToRecycleBin(paths, dialog);
-                                if (recycledIds.length > 0) {
-                                    UndoManager.push({ type: 'delete', data: { recycledIds } });
+                                const recycledPaths = await RecycleBinManager.moveItemsToRecycleBin(paths, dialog);
+                                if (recycledPaths.length > 0) {
+                                    UndoManager.push({ type: 'delete', data: { recycledPaths } });
                                 }
                             }
                             if (isPermanent && !alreadyInRecycle) {
@@ -392,8 +395,7 @@ export class FileOperations {
         const totalSize = await this.getTotalSize(paths);
         const dialog = new ProgressBarDialogWindow("restore", paths.length, totalSize);
         try {
-            const ids = paths.map(p => getPathName(p));
-            await RecycleBinManager.restoreItems(ids, dialog);
+            await RecycleBinManager.restoreItems(paths, dialog);
         } catch (e) {
             handleFileSystemError("restore", e, "items");
         } finally {
@@ -405,7 +407,10 @@ export class FileOperations {
     }
 
     async emptyRecycleBin() {
-        const isEmpty = await RecycleBinManager.isEmpty();
+        const recyclePath = RecycleBinManager.getRecyclePath(this.app.currentPath) || this.app.currentPath;
+        if (!RecycleBinManager.isRecycleBinPath(recyclePath)) return;
+
+        const isEmpty = await RecycleBinManager.isEmpty(recyclePath);
         if (isEmpty) return;
         ShowDialogWindow({
             title: "Confirm Empty Recycle Bin",
@@ -419,14 +424,14 @@ export class FileOperations {
                     action: async () => {
                         const busyId = `empty-recycle-${Math.random()}`;
                         requestBusyState(busyId, this.app.win.element);
-                        const metadata = await RecycleBinManager.getMetadata();
+                        const metadata = await RecycleBinManager.getMetadata(recyclePath);
                         const ids = Object.keys(metadata);
-                        const paths = ids.map(id => joinPath("/C:/Recycled", id));
+                        const paths = ids.map(id => joinPath(recyclePath, id));
                         const { ProgressBarDialogWindow } = await import("../interface/ProgressBarDialogWindow.js");
                         const totalSize = await this.getTotalSize(paths);
                         const dialog = new ProgressBarDialogWindow("empty", ids.length, totalSize);
                         try {
-                            await RecycleBinManager.emptyRecycleBin(dialog);
+                            await RecycleBinManager.emptyRecycleBin(recyclePath, dialog);
                             const { playSound } = await import("../../../utils/soundManager.js");
                             playSound("EmptyRecycleBin");
                         } catch (e) {
@@ -496,7 +501,7 @@ export class FileOperations {
         }
     }
 
-    async _undoDelete(data) { await RecycleBinManager.restoreItems(data.recycledIds); }
+    async _undoDelete(data) { await RecycleBinManager.restoreItems(data.recycledPaths || data.recycledIds); }
 
     async _undoCreate(data) {
         try { await fs.promises.rm(data.path, { recursive: true }); }

--- a/src/apps/zenexplorer/fileoperations/PropertiesManager.js
+++ b/src/apps/zenexplorer/fileoperations/PropertiesManager.js
@@ -54,7 +54,8 @@ export class PropertiesManager {
     let iconUrl = getIconForFile(name, isDir);
 
     if (isRecycled) {
-      const metadata = await RecycleBinManager.getMetadata();
+      const recyclePath = RecycleBinManager.getRecyclePath(path);
+      const metadata = recyclePath ? await RecycleBinManager.getMetadata(recyclePath) : {};
       const entry = metadata[name]; // name is the ID
       if (entry) {
         name = entry.originalName;

--- a/src/apps/zenexplorer/fileoperations/RecycleBinManager.js
+++ b/src/apps/zenexplorer/fileoperations/RecycleBinManager.js
@@ -1,154 +1,198 @@
 import { fs } from "@zenfs/core";
 import { joinPath, getPathName, getParentPath } from "../navigation/PathUtils.js";
 
-const RECYCLE_PATH = "/C:/Recycled";
-const METADATA_FILE = joinPath(RECYCLE_PATH, ".metadata.json");
-
 export class RecycleBinManager {
     static async init() {
-        try {
-            const stats = await fs.promises.stat(RECYCLE_PATH);
-            if (!stats.isDirectory()) {
-                await fs.promises.mkdir(RECYCLE_PATH, { recursive: true });
-            }
-        } catch (e) {
-            await fs.promises.mkdir(RECYCLE_PATH, { recursive: true });
-        }
-
-        try {
-            await fs.promises.stat(METADATA_FILE);
-        } catch (e) {
-            await fs.promises.writeFile(METADATA_FILE, JSON.stringify({}));
-        }
+        // No longer creates /C:/Recycled by default.
+        // Recycle bins are created on-demand per drive.
     }
 
-    static async getMetadata() {
+    static getDriveRoot(path) {
+        const match = path.match(/^(\/[A-Z]:)/i);
+        return match ? match[1] : "/";
+    }
+
+    static getRecyclePath(path) {
+        const driveRoot = this.getDriveRoot(path);
+        if (driveRoot === "/" || driveRoot.toUpperCase() === "/E:") return null;
+        return joinPath(driveRoot, "Recycled");
+    }
+
+    static async getMetadata(recyclePath) {
+        const metadataFile = joinPath(recyclePath, ".metadata.json");
         try {
-            const content = await fs.promises.readFile(METADATA_FILE, 'utf8');
+            const content = await fs.promises.readFile(metadataFile, 'utf8');
             return JSON.parse(content);
         } catch (e) {
             return {};
         }
     }
 
-    static async saveMetadata(metadata) {
-        await fs.promises.writeFile(METADATA_FILE, JSON.stringify(metadata, null, 2));
+    static async saveMetadata(recyclePath, metadata) {
+        const metadataFile = joinPath(recyclePath, ".metadata.json");
+        await fs.promises.writeFile(metadataFile, JSON.stringify(metadata, null, 2));
     }
 
     static async moveItemsToRecycleBin(paths, dialog = null) {
-        const metadata = await this.getMetadata();
-        let changed = false;
-        const recycledIds = [];
-
+        const groups = {};
         for (const path of paths) {
-            if (dialog && dialog.cancelled) break;
-            if (this.isRecycledItemPath(path)) continue;
+            const recyclePath = this.getRecyclePath(path);
+            if (!recyclePath) continue;
+            if (!groups[recyclePath]) groups[recyclePath] = [];
+            groups[recyclePath].push(path);
+        }
 
-            const id = (typeof crypto.randomUUID === 'function')
-                ? crypto.randomUUID()
-                : Date.now().toString(36) + Math.random().toString(36).substring(2);
+        const allRecycledPaths = [];
+        for (const recyclePath in groups) {
+            const items = groups[recyclePath];
+            const metadataFile = joinPath(recyclePath, ".metadata.json");
 
-            const name = getPathName(path);
-            const targetPath = joinPath(RECYCLE_PATH, id);
-
-            const sourceDir = getParentPath(path);
-            if (dialog) {
-                dialog.update(path, sourceDir, RECYCLE_PATH, 0);
+            try {
+                await fs.promises.stat(recyclePath);
+            } catch (e) {
+                await fs.promises.mkdir(recyclePath, { recursive: true });
             }
 
             try {
-                await fs.promises.rename(path, targetPath);
-                if (dialog) {
-                    const stats = await fs.promises.stat(targetPath);
-                    dialog.finishItem(stats.isDirectory() ? 0 : stats.size);
-                    dialog.update(path, sourceDir, RECYCLE_PATH, 0);
-                }
+                await fs.promises.stat(metadataFile);
             } catch (e) {
-                await this.copyRecursive(path, targetPath, dialog);
-                await this.removeRecursive(path, dialog, false);
+                await fs.promises.writeFile(metadataFile, JSON.stringify({}));
             }
 
-            metadata[id] = {
-                id,
-                originalPath: path,
-                originalName: name,
-                deletionDate: new Date().toISOString()
-            };
-            recycledIds.push(id);
-            changed = true;
+            const metadata = await this.getMetadata(recyclePath);
+            let changed = false;
+
+            for (const path of items) {
+                if (dialog && dialog.cancelled) break;
+                if (this.isRecycledItemPath(path)) continue;
+
+                const id = (typeof crypto.randomUUID === 'function')
+                    ? crypto.randomUUID()
+                    : Date.now().toString(36) + Math.random().toString(36).substring(2);
+
+                const name = getPathName(path);
+                const targetPath = joinPath(recyclePath, id);
+
+                const sourceDir = getParentPath(path);
+                if (dialog) {
+                    dialog.update(path, sourceDir, recyclePath, 0);
+                }
+
+                try {
+                    await fs.promises.rename(path, targetPath);
+                    if (dialog) {
+                        const stats = await fs.promises.stat(targetPath);
+                        dialog.finishItem(stats.isDirectory() ? 0 : stats.size);
+                        dialog.update(path, sourceDir, recyclePath, 0);
+                    }
+                } catch (e) {
+                    await this.copyRecursive(path, targetPath, dialog);
+                    await this.removeRecursive(path, dialog, false);
+                }
+
+                metadata[id] = {
+                    id,
+                    originalPath: path,
+                    originalName: name,
+                    deletionDate: new Date().toISOString()
+                };
+                allRecycledPaths.push(targetPath);
+                changed = true;
+            }
+
+            if (changed) {
+                await this.saveMetadata(recyclePath, metadata);
+            }
         }
 
-        if (changed) {
-            await this.saveMetadata(metadata);
+        if (allRecycledPaths.length > 0) {
             document.dispatchEvent(new CustomEvent("recycle-bin-change"));
         }
 
-        return recycledIds;
+        return allRecycledPaths;
     }
 
     static async moveToRecycleBin(path) {
         await this.moveItemsToRecycleBin([path]);
     }
 
-    static async restoreItems(ids, dialog = null) {
-        const metadata = await this.getMetadata();
-        let changed = false;
-
-        for (const id of ids) {
-            if (dialog && dialog.cancelled) break;
-            const entry = metadata[id];
-            if (!entry) continue;
-
-            const srcPath = joinPath(RECYCLE_PATH, id);
-            let destPath = entry.originalPath;
-            const parentPath = getParentPath(destPath);
-
-            if (dialog) {
-                dialog.update(entry.originalName, RECYCLE_PATH, parentPath, 0);
-            }
-
-            try {
-                await fs.promises.stat(parentPath);
-            } catch (e) {
-                await fs.promises.mkdir(parentPath, { recursive: true });
-            }
-
-            destPath = await this._getUniqueRestorePath(destPath);
-
-            try {
-                await fs.promises.rename(srcPath, destPath);
-                if (dialog) {
-                    const stats = await fs.promises.stat(destPath);
-                    dialog.finishItem(stats.isDirectory() ? 0 : stats.size);
-                    dialog.update(entry.originalName, RECYCLE_PATH, parentPath, 0);
-                }
-            } catch (e) {
-                await this.copyRecursive(srcPath, destPath, dialog);
-                // BUG FIX: pass dialog, not destPath
-                await this.removeRecursive(srcPath, dialog, false);
-            }
-
-            delete metadata[id];
-            changed = true;
+    static async restoreItems(itemPaths, dialog = null) {
+        const groups = {};
+        for (const itemPath of itemPaths) {
+            const match = itemPath.match(/^(\/[A-Z]:\/Recycled)\/([^/]+)$/i);
+            if (!match) continue;
+            const recyclePath = match[1];
+            const id = match[2];
+            if (id === ".metadata.json") continue;
+            if (!groups[recyclePath]) groups[recyclePath] = [];
+            groups[recyclePath].push(id);
         }
 
-        if (changed) {
-            await this.saveMetadata(metadata);
+        let anyChanged = false;
+        for (const recyclePath in groups) {
+            const ids = groups[recyclePath];
+            const metadata = await this.getMetadata(recyclePath);
+            let changed = false;
+
+            for (const id of ids) {
+                if (dialog && dialog.cancelled) break;
+                const entry = metadata[id];
+                if (!entry) continue;
+
+                const srcPath = joinPath(recyclePath, id);
+                let destPath = entry.originalPath;
+                const parentPath = getParentPath(destPath);
+
+                if (dialog) {
+                    dialog.update(entry.originalName, recyclePath, parentPath, 0);
+                }
+
+                try {
+                    await fs.promises.stat(parentPath);
+                } catch (e) {
+                    await fs.promises.mkdir(parentPath, { recursive: true });
+                }
+
+                destPath = await this._getUniqueRestorePath(destPath);
+
+                try {
+                    await fs.promises.rename(srcPath, destPath);
+                    if (dialog) {
+                        const stats = await fs.promises.stat(destPath);
+                        dialog.finishItem(stats.isDirectory() ? 0 : stats.size);
+                        dialog.update(entry.originalName, recyclePath, parentPath, 0);
+                    }
+                } catch (e) {
+                    await this.copyRecursive(srcPath, destPath, dialog);
+                    await this.removeRecursive(srcPath, dialog, false);
+                }
+
+                delete metadata[id];
+                changed = true;
+                anyChanged = true;
+            }
+
+            if (changed) {
+                await this.saveMetadata(recyclePath, metadata);
+            }
+        }
+
+        if (anyChanged) {
             document.dispatchEvent(new CustomEvent("recycle-bin-change"));
         }
     }
 
-    static async restoreItem(id) {
-        await this.restoreItems([id]);
+    static async restoreItem(path) {
+        await this.restoreItems([path]);
     }
 
-    static async emptyRecycleBin(dialog = null) {
-        const metadata = await this.getMetadata();
+    static async emptyRecycleBin(recyclePath, dialog = null) {
+        const metadata = await this.getMetadata(recyclePath);
         const ids = Object.keys(metadata);
 
         for (const id of ids) {
             if (dialog && dialog.cancelled) break;
-            const path = joinPath(RECYCLE_PATH, id);
+            const path = joinPath(recyclePath, id);
             try {
                 if (dialog) {
                     await this.removeRecursive(path, dialog);
@@ -164,28 +208,30 @@ export class RecycleBinManager {
             const remainingMetadata = {};
             for (const id in metadata) {
                 try {
-                    await fs.promises.stat(joinPath(RECYCLE_PATH, id));
+                    await fs.promises.stat(joinPath(recyclePath, id));
                     remainingMetadata[id] = metadata[id];
                 } catch (e) {}
             }
-            await this.saveMetadata(remainingMetadata);
+            await this.saveMetadata(recyclePath, remainingMetadata);
         } else {
-            await this.saveMetadata({});
+            await this.saveMetadata(recyclePath, {});
         }
         document.dispatchEvent(new CustomEvent("recycle-bin-change"));
     }
 
-    static async isEmpty() {
-        const metadata = await this.getMetadata();
+    static async isEmpty(recyclePath) {
+        const metadata = await this.getMetadata(recyclePath);
         return Object.keys(metadata).length === 0;
     }
 
     static isRecycleBinPath(path) {
-        return path === RECYCLE_PATH;
+        return !!path.match(/^\/[A-Z]:\/Recycled$/i);
     }
 
     static isRecycledItemPath(path) {
-        return path.startsWith(RECYCLE_PATH + "/") && path !== METADATA_FILE;
+        const match = path.match(/^(\/[A-Z]:\/Recycled)\/([^/]+)$/i);
+        if (!match) return false;
+        return match[2] !== ".metadata.json";
     }
 
     static async _getUniqueRestorePath(path) {

--- a/src/apps/zenexplorer/interface/ContextMenuBuilder.js
+++ b/src/apps/zenexplorer/interface/ContextMenuBuilder.js
@@ -24,6 +24,7 @@ export class ContextMenuBuilder {
       i.getAttribute("data-path"),
     );
     const isRootItem = selectedPaths.some((p) => getParentPath(p) === "/");
+    const isOnReadOnlyDrive = selectedPaths.some(p => p.startsWith("/E:"));
     const isFloppy = path === "/A:";
     const isFloppyMounted = mounts.has("/A:");
     const isCD = path === "/E:";
@@ -79,13 +80,6 @@ export class ContextMenuBuilder {
           default: true,
         },
       ];
-
-      if (isRecycleBin) {
-        menuItems.push({
-          label: "Empty Recycle Bin",
-          action: () => this.app.fileOps.emptyRecycleBin(),
-        });
-      }
 
       if (isFloppy) {
         if (isFloppyMounted) {
@@ -144,7 +138,7 @@ export class ContextMenuBuilder {
         {
           label: "Delete",
           action: () => this.app.fileOps.deleteItems(selectedPaths),
-          enabled: () => !isRootItem && !isRecycleBin,
+          enabled: () => !isRootItem && !isRecycleBin && !isOnReadOnlyDrive,
         },
         {
           label: "Rename",

--- a/src/apps/zenexplorer/interface/DirectoryView.js
+++ b/src/apps/zenexplorer/interface/DirectoryView.js
@@ -48,7 +48,7 @@ export class DirectoryView {
       icon = ICONS.disketteDrive;
     }
     if (RecycleBinManager.isRecycleBinPath(path)) {
-      const isEmpty = await RecycleBinManager.isEmpty();
+      const isEmpty = await RecycleBinManager.isEmpty(path);
       icon = isEmpty ? ICONS.recycleBinEmpty : ICONS.recycleBinFull;
     }
 
@@ -108,8 +108,8 @@ export class DirectoryView {
     this.app.iconManager.clearSelection();
 
     const isRecycleBin = RecycleBinManager.isRecycleBinPath(path);
-    const metadata = isRecycleBin ? await RecycleBinManager.getMetadata() : null;
-    const recycleBinEmpty = await RecycleBinManager.isEmpty();
+    const metadata = isRecycleBin ? await RecycleBinManager.getMetadata(path) : null;
+    const recycleBinEmpty = isRecycleBin ? await RecycleBinManager.isEmpty(path) : true;
 
     if (this.app.viewMode === "details") {
       const columns = ShellManager.getColumns(path);

--- a/src/apps/zenexplorer/interface/FileIconRenderer.js
+++ b/src/apps/zenexplorer/interface/FileIconRenderer.js
@@ -78,13 +78,14 @@ export async function renderFileIcon(fileName, fullPath, isDir, options = {}) {
     const isEmpty =
       options.recycleBinEmpty !== undefined
         ? options.recycleBinEmpty
-        : await RecycleBinManager.isEmpty();
+        : await RecycleBinManager.isEmpty(fullPath);
     iconObj = isEmpty ? ICONS.recycleBinEmpty : ICONS.recycleBinFull;
   }
   // Special handling for items INSIDE Recycle Bin
   else if (RecycleBinManager.isRecycledItemPath(fullPath)) {
+    const recyclePath = RecycleBinManager.getRecyclePath(fullPath);
     const metadata =
-      options.metadata || (await RecycleBinManager.getMetadata());
+      options.metadata || (recyclePath ? await RecycleBinManager.getMetadata(recyclePath) : {});
     const entry = metadata[fileName]; // fileName is the ID
     if (entry) {
       iconObj = getIconObjForFile(entry.originalName, isDir);


### PR DESCRIPTION
This change transitions ZenExplorer's recycle bin logic from a single global folder to a drive-specific model. Each mounted drive (e.g., C:, A:) now gets its own `Recycled` folder when a file is deleted from it. Deletion is explicitly disallowed for the read-only CD-ROM drive (E:) and the root directory. The "Empty Recycle Bin" option has been removed from the context menu for now. All related components, including icon rendering and properties calculation, have been updated to support this new architecture.

---
*PR created automatically by Jules for task [2091085403729859087](https://jules.google.com/task/2091085403729859087) started by @azayrahmad*