### PR TITLE
Add Desktop Shell Extension to ZenExplorer

### DIFF
--- a/e2e/desktop_extension.spec.js
+++ b/e2e/desktop_extension.spec.js
@@ -1,0 +1,115 @@
+import { test, expect } from '@playwright/test';
+
+test.describe('Desktop Shell Extension', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('http://localhost:5173/win98-web/');
+    // Wait for the OS to initialize (azOS Ready!)
+    await page.waitForSelector('text=azOS Ready!', { timeout: 30000 });
+    // Wait for splash screen to hide
+    await page.waitForSelector('#splash-screen', { state: 'hidden' });
+  });
+
+  test('should show My Computer in C:\\WINDOWS\\Desktop and navigate to root', async ({ page }) => {
+    // Launch ZenExplorer
+    await page.evaluate(() => window.System.launchApp('zenexplorer'));
+    await page.waitForSelector('.window[data-app-id="zenexplorer"]');
+
+    // Navigate to C:\WINDOWS\Desktop
+    const addressBar = page.locator('.window[data-app-id="zenexplorer"] .address-bar input');
+    await addressBar.fill('C:\\WINDOWS\\Desktop');
+    await addressBar.press('Enter');
+
+    // Wait for directory contents to render
+    await page.waitForSelector('.window[data-app-id="zenexplorer"] .explorer-icon[data-name="My Computer"]');
+
+    // Verify "My Computer" icon exists and has the computer icon
+    const myComputerIcon = page.locator('.window[data-app-id="zenexplorer"] .explorer-icon[data-name="My Computer"]');
+    await expect(myComputerIcon).toBeVisible();
+    await expect(myComputerIcon).toHaveAttribute('data-is-virtual', 'true');
+
+    // Double click My Computer
+    await myComputerIcon.dblclick();
+
+    // Verify we navigated to root (My Computer)
+    await expect(addressBar).toHaveValue('My Computer');
+    await expect(page.locator('.window[data-app-id="zenexplorer"] .explorer-icon[data-name="C:"]')).toBeVisible();
+  });
+
+  test('should show Desktop folder with correct icon in C:\\WINDOWS', async ({ page }) => {
+    // Launch ZenExplorer
+    await page.evaluate(() => window.System.launchApp('zenexplorer'));
+    await page.waitForSelector('.window[data-app-id="zenexplorer"]');
+
+    // Navigate to C:\WINDOWS
+    const addressBar = page.locator('.window[data-app-id="zenexplorer"] .address-bar input');
+    await addressBar.fill('C:\\WINDOWS');
+    await addressBar.press('Enter');
+
+    // Wait for directory contents
+    await page.waitForSelector('.window[data-app-id="zenexplorer"] .explorer-icon[data-name="Desktop"]');
+    const desktopFolder = page.locator('.window[data-app-id="zenexplorer"] .explorer-icon[data-name="Desktop"]');
+
+    // Verify it's a directory
+    await expect(desktopFolder).toHaveAttribute('data-type', 'directory');
+
+    // Verify it's not virtual (the folder itself is a real directory)
+    await expect(desktopFolder).toHaveAttribute('data-is-virtual', 'false');
+  });
+
+  test('should not allow deleting virtual My Computer', async ({ page }) => {
+    // Launch ZenExplorer and go to C:\WINDOWS\Desktop
+    await page.evaluate(() => window.System.launchApp('zenexplorer'));
+    await page.waitForSelector('.window[data-app-id="zenexplorer"]');
+    const addressBar = page.locator('.window[data-app-id="zenexplorer"] .address-bar input');
+    await addressBar.fill('C:\\WINDOWS\\Desktop');
+    await addressBar.press('Enter');
+
+    await page.waitForSelector('.window[data-app-id="zenexplorer"] .explorer-icon[data-name="My Computer"]');
+    const myComputerIcon = page.locator('.window[data-app-id="zenexplorer"] .explorer-icon[data-name="My Computer"]');
+
+    // Right click to open context menu
+    await myComputerIcon.click({ button: 'right' });
+
+    // Wait for context menu
+    await page.waitForSelector('.menu-popup');
+
+    // Verify Delete, Rename and Cut are disabled
+    const deleteItem = page.locator('.menu-item:has-text("Delete")');
+    await expect(deleteItem).toHaveAttribute('disabled', '');
+
+    const renameItem = page.locator('.menu-item:has-text("Rename")');
+    await expect(renameItem).toHaveAttribute('disabled', '');
+
+    const cutItem = page.locator('.menu-item:has-text("Cut")');
+    await expect(cutItem).toHaveAttribute('disabled', '');
+  });
+
+  test('should show real files created in C:\\WINDOWS\\Desktop alongside My Computer', async ({ page }) => {
+    // Create a real file via evaluate
+    await page.evaluate(async () => {
+      await window.fs.promises.writeFile('/C:/WINDOWS/Desktop/RealFile.txt', 'Hello world');
+    });
+
+    // Launch ZenExplorer and go to C:\WINDOWS\Desktop
+    await page.evaluate(() => window.System.launchApp('zenexplorer'));
+    await page.waitForSelector('.window[data-app-id="zenexplorer"]');
+    const addressBar = page.locator('.window[data-app-id="zenexplorer"] .address-bar input');
+    await addressBar.fill('C:\\WINDOWS\\Desktop');
+    await addressBar.press('Enter');
+
+    // Wait for directory contents
+    await page.waitForSelector('.window[data-app-id="zenexplorer"] .explorer-icon[data-name="My Computer"]');
+    await page.waitForSelector('.window[data-app-id="zenexplorer"] .explorer-icon[data-name="RealFile.txt"]');
+
+    // Verify both are visible
+    const myComputerIcon = page.locator('.window[data-app-id="zenexplorer"] .explorer-icon[data-name="My Computer"]');
+    const realFileIcon = page.locator('.window[data-app-id="zenexplorer"] .explorer-icon[data-name="RealFile.txt"]');
+
+    await expect(myComputerIcon).toBeVisible();
+    await expect(realFileIcon).toBeVisible();
+
+    // Verify data-is-virtual
+    await expect(myComputerIcon).toHaveAttribute('data-is-virtual', 'true');
+    await expect(realFileIcon).toHaveAttribute('data-is-virtual', 'false');
+  });
+});

--- a/src/apps/zenexplorer/ZenExplorerApp.js
+++ b/src/apps/zenexplorer/ZenExplorerApp.js
@@ -29,9 +29,11 @@ import { joinPath } from "./navigation/PathUtils.js";
 import { getToolbarItems } from "./interface/ToolbarBuilder.js";
 import { sortFileInfos } from "./fileoperations/SortUtils.js";
 import { ControlPanelExtension } from "./extensions/ControlPanelExtension.js";
+import { DesktopExtension } from "./extensions/DesktopExtension.js";
 
 // Initialize Shell Extensions
 ShellManager.registerExtension(new ControlPanelExtension());
+ShellManager.registerExtension(new DesktopExtension());
 
 export class ZenExplorerApp extends Application {
   static config = {

--- a/src/apps/zenexplorer/extensions/DesktopExtension.js
+++ b/src/apps/zenexplorer/extensions/DesktopExtension.js
@@ -1,0 +1,113 @@
+import { fs } from "@zenfs/core";
+import { ICONS } from "../../../config/icons.js";
+import { VirtualStats } from "./ShellManager.js";
+import { getPathName } from "../navigation/PathUtils.js";
+
+/**
+ * DesktopExtension - Shell extension for the Desktop folder
+ */
+export class DesktopExtension {
+  constructor() {
+    this.path = "/C:/WINDOWS/Desktop";
+    this.virtualItems = [
+      {
+        name: "My Computer",
+        icon: ICONS.computer,
+        target: "/",
+      },
+    ];
+  }
+
+  /**
+   * Check if this extension handles the given path
+   * @param {string} path
+   * @returns {boolean}
+   */
+  handlesPath(path) {
+    return path === this.path || path.startsWith(this.path + "/");
+  }
+
+  /**
+   * Get virtual stats for a path
+   * @param {string} path
+   * @returns {Promise<VirtualStats>}
+   */
+  async stat(path) {
+    if (path === this.path) {
+      return new VirtualStats({ isDirectory: true });
+    }
+
+    const name = getPathName(path);
+    const item = this.virtualItems.find((i) => i.name === name);
+    if (item) {
+      return new VirtualStats({ isDirectory: false, isVirtual: true });
+    }
+
+    // Fallback to real filesystem for other items in this folder
+    return fs.promises.stat(path);
+  }
+
+  /**
+   * Read virtual directory contents
+   * @param {string} path
+   * @returns {Promise<string[]|null>}
+   */
+  async readdir(path) {
+    // If we are in the parent directory, ensure Desktop shows up
+    if (path === "/C:/WINDOWS") {
+      return ["Desktop"];
+    }
+    // If we are in the Desktop directory, show virtual items
+    if (path === this.path) {
+      return this.virtualItems.map((i) => i.name);
+    }
+    return null;
+  }
+
+  /**
+   * Get custom icon object for a path
+   * @param {string} path
+   * @returns {Object|null}
+   */
+  getIconObj(path) {
+    if (path === this.path) {
+      return ICONS.desktop_old;
+    }
+
+    const name = getPathName(path);
+    const item = this.virtualItems.find((i) => i.name === name);
+    if (item) {
+      return item.icon;
+    }
+
+    return null;
+  }
+
+  /**
+   * Get custom icon for a path
+   * @param {string} path
+   * @param {number} size
+   * @returns {string|null}
+   */
+  getIcon(path, size = 32) {
+    const iconObj = this.getIconObj(path);
+    return iconObj ? iconObj[size] : null;
+  }
+
+  /**
+   * Handle opening a path
+   * @param {string} path
+   * @param {Object} app - ZenExplorerApp instance
+   * @returns {Promise<boolean>}
+   */
+  async onOpen(path, app) {
+    const name = getPathName(path);
+    const item = this.virtualItems.find((i) => i.name === name);
+    if (item) {
+      app.navigateTo(item.target);
+      return true;
+    }
+
+    return false;
+  }
+}

--- a/src/apps/zenexplorer/extensions/ShellManager.js
+++ b/src/apps/zenexplorer/extensions/ShellManager.js
@@ -7,6 +7,7 @@ import { getParentPath } from "../navigation/PathUtils.js";
 export class VirtualStats {
   constructor(options = {}) {
     this._isDirectory = !!options.isDirectory;
+    this.isVirtual = !!options.isVirtual;
     this.size = options.size || 0;
     this.atime = options.atime || new Date();
     this.mtime = options.mtime || new Date();

--- a/src/apps/zenexplorer/interface/ContextMenuBuilder.js
+++ b/src/apps/zenexplorer/interface/ContextMenuBuilder.js
@@ -20,10 +20,12 @@ export class ContextMenuBuilder {
   buildItemMenu(e, icon) {
     const path = icon.getAttribute("data-path");
     const type = icon.getAttribute("data-type");
-    const selectedPaths = [...this.app.iconManager.selectedIcons].map((i) =>
+    const selectedIcons = [...this.app.iconManager.selectedIcons];
+    const selectedPaths = selectedIcons.map((i) =>
       i.getAttribute("data-path"),
     );
     const isRootItem = selectedPaths.some((p) => getParentPath(p) === "/");
+    const anyVirtual = selectedIcons.some(i => i.getAttribute("data-is-virtual") === "true");
     const isOnReadOnlyDrive = selectedPaths.some(p => p.startsWith("/E:"));
     const isFloppy = path === "/A:";
     const isFloppyMounted = mounts.has("/A:");
@@ -121,7 +123,7 @@ export class ContextMenuBuilder {
         {
           label: "Cut",
           action: () => this.app.fileOps.cutItems(selectedPaths),
-          enabled: () => !isRootItem && !isRecycleBin,
+          enabled: () => !isRootItem && !isRecycleBin && !anyVirtual,
         },
         {
           label: "Copy",
@@ -138,13 +140,13 @@ export class ContextMenuBuilder {
         {
           label: "Delete",
           action: () => this.app.fileOps.deleteItems(selectedPaths),
-          enabled: () => !isRootItem && !isRecycleBin && !isOnReadOnlyDrive,
+          enabled: () => !isRootItem && !isRecycleBin && !isOnReadOnlyDrive && !anyVirtual,
         },
         {
           label: "Rename",
           action: () => this.app.fileOps.renameItem(path),
           enabled: () =>
-            !isRootItem && selectedPaths.length === 1 && !isRecycleBin,
+            !isRootItem && selectedPaths.length === 1 && !isRecycleBin && !anyVirtual,
         },
         "MENU_DIVIDER",
         {

--- a/src/apps/zenexplorer/interface/DirectoryView.js
+++ b/src/apps/zenexplorer/interface/DirectoryView.js
@@ -142,7 +142,7 @@ export class DirectoryView {
             const td = document.createElement("td");
             if (i === 0) {
               td.className = "name-cell";
-              const iconObj = await renderFileIcon(file, fullPath, isDir, { metadata, recycleBinEmpty });
+              const iconObj = await renderFileIcon(file, fullPath, isDir, { metadata, recycleBinEmpty, stat: fileStat });
               const iconPart = iconObj.querySelector(".icon");
               const labelPart = iconObj.querySelector(".icon-label");
               if (iconPart) td.appendChild(iconPart);
@@ -177,9 +177,9 @@ export class DirectoryView {
 
     const icons = [];
     for (const info of sortedInfos) {
-      const { name: file, fullPath, isDirectory: isDir } = info;
+      const { name: file, fullPath, stat: fileStat, isDirectory: isDir } = info;
       try {
-        const iconDiv = await renderFileIcon(file, fullPath, isDir, { metadata, recycleBinEmpty });
+        const iconDiv = await renderFileIcon(file, fullPath, isDir, { metadata, recycleBinEmpty, stat: fileStat });
         this.app.iconManager.configureIcon(iconDiv);
         iconDiv.addEventListener("click", (e) => {
           if (this._isRenaming) return;

--- a/src/apps/zenexplorer/interface/FileIconRenderer.js
+++ b/src/apps/zenexplorer/interface/FileIconRenderer.js
@@ -56,6 +56,7 @@ export function getIconForFile(fileName, isDir) {
 export async function renderFileIcon(fileName, fullPath, isDir, options = {}) {
   // Check shell extension icon first
   const shellIcon = ShellManager.getIconObj(fullPath);
+  const fileStat = options.stat || await ShellManager.stat(fullPath).catch(() => ({}));
 
   const iconDiv = document.createElement("div");
   iconDiv.className = "explorer-icon";
@@ -63,6 +64,7 @@ export async function renderFileIcon(fileName, fullPath, isDir, options = {}) {
   iconDiv.setAttribute("data-path", fullPath);
   iconDiv.setAttribute("data-type", isDir ? "directory" : "file");
   iconDiv.setAttribute("data-name", fileName);
+  iconDiv.setAttribute("data-is-virtual", fileStat.isVirtual ? "true" : "false");
 
   const iconInner = document.createElement("div");
   iconInner.className = "icon";

--- a/src/utils/zenfs-init.js
+++ b/src/utils/zenfs-init.js
@@ -44,6 +44,11 @@ export async function initFileSystem(onProgress) {
             await fs.promises.mkdir('/C:/WINDOWS');
         }
 
+        // Ensure WINDOWS/Desktop directory exists for the Desktop shell extension
+        if (!fs.existsSync('/C:/WINDOWS/Desktop')) {
+            await fs.promises.mkdir('/C:/WINDOWS/Desktop');
+        }
+
         isInitialized = true;
         console.log("ZenFS initialized successfully.");
     } catch (error) {


### PR DESCRIPTION
Implemented a new Desktop shell extension for ZenExplorer at C:\WINDOWS\Desktop. The extension features hybrid functionality, allowing both real file persistence and virtual item display. A virtual "My Computer" icon is included, which correctly navigates to the root (/) when opened.

Key changes:
1.  **DesktopExtension.js**: A new shell extension that handles `/C:/WINDOWS/Desktop`, providing the "My Computer" virtual item and the distinct `desktop_old` icon.
2.  **ShellManager.js**: Updated `VirtualStats` to include an `isVirtual` flag.
3.  **ZenExplorerApp.js**: Registered the new extension.
4.  **zenfs-init.js**: Added logic to create the physical directory at boot.
5.  **UI Components**: Updated `FileIconRenderer`, `DirectoryView`, and `ContextMenuBuilder` to support the `isVirtual` flag, ensuring that virtual items cannot be cut, deleted, or renamed in the explorer UI.
6.  **E2E Tests**: Added comprehensive tests to verify navigation, visuals, and locking behavior.

---
*PR created automatically by Jules for task [10782445180061370711](https://jules.google.com/task/10782445180061370711) started by @azayrahmad*