### PR TITLE
Modernize Desktop with ZenExplorer Integration

### DIFF
--- a/e2e/desktop_component.spec.js
+++ b/e2e/desktop_component.spec.js
@@ -1,0 +1,70 @@
+import { test, expect } from '@playwright/test';
+
+test.describe('Desktop Component', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('http://localhost:5173/win98-web/');
+    // Wait for the OS to initialize (azOS Ready!)
+    await page.waitForSelector('text=azOS Ready!', { timeout: 30000 });
+    // Wait for splash screen to hide
+    await page.waitForSelector('#splash-screen', { state: 'hidden' });
+  });
+
+  test('should show My Computer on the desktop', async ({ page }) => {
+    const myComputerIcon = page.locator('.desktop .explorer-icon[data-name="My Computer"]');
+    await expect(myComputerIcon).toBeVisible();
+    await expect(myComputerIcon).toHaveAttribute('data-is-virtual', 'true');
+  });
+
+  test('should open My Computer from the desktop', async ({ page }) => {
+    const myComputerIcon = page.locator('.desktop .explorer-icon[data-name="My Computer"]');
+    await myComputerIcon.dblclick();
+
+    // It should launch ZenExplorer at /
+    await page.waitForSelector('.window[data-app-id="zenexplorer"]');
+    const addressBar = page.locator('.window[data-app-id="zenexplorer"] .address-bar input');
+    await expect(addressBar).toHaveValue('My Computer');
+  });
+
+  test('should show background context menu with system items', async ({ page }) => {
+    await page.click('.desktop', { button: 'right' });
+
+    // Verify system items in context menu
+    await expect(page.locator('.menu-item:has-text("Wallpaper")').first()).toBeVisible();
+    await expect(page.locator('.menu-item:has-text("Theme")').first()).toBeVisible();
+    await expect(page.locator('.menu-item:has-text("Monitor Type")').first()).toBeVisible();
+    await expect(page.locator('.menu-item:has-text("Properties")').last()).toBeVisible();
+  });
+
+  test('should allow creating and renaming a folder on the desktop', async ({ page }) => {
+    // Right click desktop and create folder
+    await page.click('.desktop', { button: 'right' });
+
+    const newMenuItem = page.locator('.menu-item:has-text("New")');
+    await newMenuItem.dispatchEvent('pointerenter');
+    await page.locator('.menu-item:has-text("Folder")').click();
+
+    // Wait for icon
+    const folderIcon = page.locator('.desktop .explorer-icon[data-name="New Folder"]');
+    await expect(folderIcon).toBeVisible();
+
+    // Rename
+    await folderIcon.click({ button: 'right' });
+    await page.locator('.menu-item:has-text("Rename")').last().click();
+
+    const renameInput = page.locator('.icon-label-input');
+    await renameInput.fill('DesktopFolder');
+    await renameInput.press('Enter');
+
+    await expect(page.locator('.desktop .explorer-icon[data-name="DesktopFolder"]')).toBeVisible();
+
+    // Cleanup
+    await page.locator('.desktop .explorer-icon[data-name="DesktopFolder"]').click({ button: 'right' });
+    await page.locator('.menu-item:has-text("Delete")').last().click();
+
+    const dialog = page.locator('.window:has-text("Confirm File Delete")');
+    await expect(dialog).toBeVisible();
+    await dialog.locator('button:has-text("Yes")').click();
+
+    await expect(page.locator('.desktop .explorer-icon[data-name="DesktopFolder"]')).not.toBeVisible({ timeout: 15000 });
+  });
+});

--- a/src/apps/explorer/ExplorerApp.js
+++ b/src/apps/explorer/ExplorerApp.js
@@ -7,7 +7,6 @@ import { launchApp } from "../../utils/appManager.js";
 import {
   getAssociation,
   findItemByPath,
-  getDesktopContents,
 } from "../../utils/directory.js";
 import {
   convertInternalPathToWindows,
@@ -761,32 +760,15 @@ export class ExplorerApp extends Application {
         return;
       }
 
-      if (path === SPECIAL_FOLDER_PATHS.desktop) {
-        const desktopContents = getDesktopContents();
-        const desktopApps = desktopContents.apps.map((appId) => {
-          const app = apps.find((a) => a.id === appId);
-          return { ...app, appId: app.id, isStatic: true };
-        });
-        const allDroppedFiles = getItem(LOCAL_STORAGE_KEYS.DROPPED_FILES) || [];
-        const desktopFiles = allDroppedFiles.filter(
-          (file) => file.path === SPECIAL_FOLDER_PATHS.desktop,
-        );
-        const staticFiles = desktopContents.files.map((file) => ({
-          ...file,
-          isStatic: true,
-        }));
-        children = [...desktopApps, ...staticFiles, ...desktopFiles];
-      } else {
-        const staticChildren = (item.children || []).map((child) => ({
-          ...child,
-          isStatic: true,
-        }));
-        const allDroppedFiles = getItem(LOCAL_STORAGE_KEYS.DROPPED_FILES) || [];
-        const droppedFilesInThisFolder = allDroppedFiles.filter(
-          (file) => file.path === path,
-        );
-        children = [...staticChildren, ...droppedFilesInThisFolder];
-      }
+      const staticChildren = (item.children || []).map((child) => ({
+        ...child,
+        isStatic: true,
+      }));
+      const allDroppedFiles = getItem(LOCAL_STORAGE_KEYS.DROPPED_FILES) || [];
+      const droppedFilesInThisFolder = allDroppedFiles.filter(
+        (file) => file.path === path,
+      );
+      children = [...staticChildren, ...droppedFilesInThisFolder];
 
       // Sort children alphabetically by name, but only for subfolders
       if (path !== "/") {

--- a/src/apps/zenexplorer/fileoperations/FileOperations.js
+++ b/src/apps/zenexplorer/fileoperations/FileOperations.js
@@ -260,10 +260,13 @@ export class FileOperations {
         const message = isPermanent
             ? (paths.length === 1 ? `Are you sure you want to permanently delete '${getPathName(paths[0])}'?` : `Are you sure you want to permanently delete these ${paths.length} items?`)
             : (paths.length === 1 ? `Are you sure you want to send '${getPathName(paths[0])}' to the Recycle Bin?` : `Are you sure you want to send these ${paths.length} items to the Recycle Bin?`);
+
+        const parentWindow = (this.app.win && this.app.win.id !== 'desktop') ? this.app.win : null;
+
         ShowDialogWindow({
             title: "Confirm File Delete",
             text: message,
-            parentWindow: this.app.win,
+            parentWindow: parentWindow,
             modal: true,
             buttons: [
                 {
@@ -419,10 +422,13 @@ export class FileOperations {
 
         const isEmpty = await RecycleBinManager.isEmpty(recyclePath);
         if (isEmpty) return;
+
+        const parentWindow = (this.app.win && this.app.win.id !== 'desktop') ? this.app.win : null;
+
         ShowDialogWindow({
             title: "Confirm Empty Recycle Bin",
             text: "Are you sure you want to permanently delete all items in the Recycle Bin?",
-            parentWindow: this.app.win,
+            parentWindow: parentWindow,
             modal: true,
             buttons: [
                 {
@@ -472,10 +478,11 @@ export class FileOperations {
             await this.app.navigateTo(this.app.currentPath, true, true);
             document.dispatchEvent(new CustomEvent("fs-change", { detail: { sourceAppId: this.app.win.element.id } }));
         } catch (e) {
+            const parentWindow = (this.app.win && this.app.win.id !== 'desktop') ? this.app.win : null;
             ShowDialogWindow({
                 title: "Undo",
                 text: `Could not undo operation: ${e.message}`,
-                parentWindow: this.app.win,
+                parentWindow: parentWindow,
                 modal: true,
                 buttons: [{ label: "OK" }]
             });

--- a/src/apps/zenexplorer/interface/DesktopContextMenuBuilder.js
+++ b/src/apps/zenexplorer/interface/DesktopContextMenuBuilder.js
@@ -1,0 +1,241 @@
+import { ContextMenuBuilder } from "./ContextMenuBuilder.js";
+import {
+  getThemes,
+  getCurrentTheme,
+  setTheme,
+} from "../../../utils/themeManager.js";
+import {
+  setColorMode,
+  getCurrentColorMode,
+  getColorModes,
+} from "../../../utils/colorModeManager.js";
+import screensaver from "../../../utils/screensaverUtils.js";
+import {
+  getAvailableResolutions,
+  setResolution,
+  getCurrentResolutionId,
+} from "../../../utils/screenManager.js";
+import {
+  getItem,
+  setItem,
+  removeItem,
+  LOCAL_STORAGE_KEYS,
+} from "../../../utils/localStorage.js";
+import { launchApp } from "../../../utils/appManager.js";
+import ClipboardManager from "../fileoperations/ClipboardManager.js";
+
+export class DesktopContextMenuBuilder extends ContextMenuBuilder {
+  buildBackgroundMenu(e) {
+    const themes = getThemes();
+
+    const setWallpaper = () => {
+        const input = document.createElement("input");
+        input.type = "file";
+        input.accept = "image/*";
+        input.onchange = (e) => {
+            const file = e.target.files[0];
+            if (file) {
+                const reader = new FileReader();
+                reader.onload = (readerEvent) => {
+                    const dataUrl = readerEvent.target.result;
+                    setItem(LOCAL_STORAGE_KEYS.WALLPAPER, dataUrl);
+                    document.dispatchEvent(new CustomEvent("wallpaper-changed"));
+                };
+                reader.readAsDataURL(file);
+            }
+        };
+        input.click();
+    };
+
+    const removeWallpaper = () => {
+        removeItem(LOCAL_STORAGE_KEYS.WALLPAPER);
+        document.dispatchEvent(new CustomEvent("wallpaper-changed"));
+    };
+
+    const getWallpaperMode = () => getItem(LOCAL_STORAGE_KEYS.WALLPAPER_MODE) || "tile";
+    const setWallpaperMode = (mode) => {
+        setItem(LOCAL_STORAGE_KEYS.WALLPAPER_MODE, mode);
+        document.dispatchEvent(new CustomEvent("wallpaper-changed"));
+    };
+
+    const getMonitorType = () => getItem(LOCAL_STORAGE_KEYS.MONITOR_TYPE) || "TFT";
+    const setMonitorType = (type) => {
+        setItem(LOCAL_STORAGE_KEYS.MONITOR_TYPE, type);
+        if (type === "CRT") {
+            document.body.classList.add("scanlines");
+        } else {
+            document.body.classList.remove("scanlines");
+        }
+    };
+
+    const menuItems = [
+      {
+        label: "Arrange Icons",
+        submenu: [
+          { label: "by Name", action: () => this.app.sortIcons("name") },
+          { label: "by Size", action: () => this.app.sortIcons("size") },
+          { label: "by Type", action: () => this.app.sortIcons("type") },
+          { label: "by Date", action: () => this.app.sortIcons("date") },
+          "MENU_DIVIDER",
+          {
+            label: "Auto Arrange",
+            checkbox: {
+              check: () => this.app.autoArrange,
+              toggle: () => this.app.toggleAutoArrange(),
+            },
+          },
+        ],
+      },
+      "MENU_DIVIDER",
+      {
+        label: "Paste",
+        action: () => this.app.fileOps.pasteItems(this.app.currentPath),
+        enabled: () => !ClipboardManager.isEmpty(),
+      },
+      "MENU_DIVIDER",
+      {
+        label: "New",
+        submenu: [
+          {
+            label: "Folder",
+            action: () => this.app.fileOps.createNewFolder(),
+          },
+          {
+            label: "Text Document",
+            action: () => this.app.fileOps.createNewTextFile(),
+          },
+        ],
+      },
+      "MENU_DIVIDER",
+      {
+        label: "Wallpaper",
+        submenu: [
+          {
+            label: "Set Wallpaper...",
+            action: setWallpaper,
+          },
+          {
+            label: "Remove Wallpaper",
+            action: removeWallpaper,
+          },
+          "MENU_DIVIDER",
+          {
+            radioItems: [
+              { label: "Center", value: "center" },
+              { label: "Tile", value: "tile" },
+              { label: "Stretch", value: "stretch" },
+            ],
+            getValue: () => getWallpaperMode(),
+            setValue: (value) => setWallpaperMode(value),
+            ariaLabel: "Wallpaper Mode",
+          },
+        ],
+      },
+      {
+        label: "Color Mode",
+        submenu: [
+          {
+            radioItems: Object.entries(getColorModes()).map(([id, mode]) => ({
+              label: mode.name,
+              value: id,
+            })),
+            getValue: () => getCurrentColorMode(),
+            setValue: (value) => setColorMode(value),
+            ariaLabel: "Color Mode",
+          },
+        ],
+      },
+      "MENU_DIVIDER",
+      {
+        label: "Theme",
+        submenu: [
+          {
+            radioItems: Object.values(themes).map((theme) => ({
+              label: theme.name,
+              value: theme.id,
+            })),
+            getValue: () => getCurrentTheme(),
+            setValue: (value) => {
+              setTheme(value);
+            },
+            ariaLabel: "Desktop Theme",
+          },
+        ],
+      },
+      {
+        label: "Monitor Type",
+        submenu: [
+          {
+            radioItems: [
+              { label: "TFT", value: "TFT" },
+              { label: "CRT", value: "CRT" },
+            ],
+            getValue: () => getMonitorType(),
+            setValue: (value) => setMonitorType(value),
+            ariaLabel: "Monitor Type",
+          },
+        ],
+      },
+      "MENU_DIVIDER",
+      {
+        label: "Screen Resolution",
+        submenu: [
+          {
+            radioItems: getAvailableResolutions().map((res) => ({
+              label: res === "fit" ? "Fit Screen" : res,
+              value: res,
+            })),
+            getValue: () => getCurrentResolutionId(),
+            setValue: (value) => setResolution(value),
+            ariaLabel: "Screen Resolution",
+          },
+        ],
+      },
+      "MENU_DIVIDER",
+      {
+        label: "Screen Saver",
+        submenu: [
+          {
+            radioItems: [
+              { label: "None", value: "none" },
+              { label: "FlowerBox", value: "flowerbox" },
+              { label: "3D Maze", value: "maze" },
+            ],
+            getValue: () => screensaver.getCurrentScreensaver(),
+            setValue: (value) => {
+              screensaver.setCurrentScreensaver(value);
+            },
+            ariaLabel: "Select Screensaver",
+          },
+          "MENU_DIVIDER",
+          {
+            label: "Wait Time",
+            submenu: [
+              {
+                radioItems: [
+                  { label: "1 minute", value: 60000 },
+                  { label: "5 minutes", value: 300000 },
+                  { label: "30 minutes", value: 1800000 },
+                  { label: "1 hour", value: 3600000 },
+                ],
+                getValue: () =>
+                  getItem(LOCAL_STORAGE_KEYS.SCREENSAVER_TIMEOUT) || 300000,
+                setValue: (value) => {
+                  setItem(LOCAL_STORAGE_KEYS.SCREENSAVER_TIMEOUT, value);
+                },
+                ariaLabel: "Screen Saver Wait Time",
+              },
+            ],
+          },
+        ],
+      },
+      "MENU_DIVIDER",
+      {
+        label: "Properties",
+        action: () => launchApp("displayproperties"),
+      },
+    ];
+
+    return menuItems;
+  }
+}

--- a/src/components/desktop.js
+++ b/src/components/desktop.js
@@ -1,366 +1,410 @@
 /**
- * Win98DesktopManager - Handles desktop icons and desktop interactions
+ * Win98DesktopManager - Handles desktop icons and desktop interactions using ZenExplorer logic
  */
-import { init } from "./taskbar.js";
-import { fileAssociations } from "../config/fileAssociations.js";
-import { apps } from "../config/apps.js";
+import { init as initTaskbar } from "./taskbar.js";
+import { launchApp } from "../utils/appManager.js";
 import {
   getItem,
   setItem,
   removeItem,
   LOCAL_STORAGE_KEYS,
 } from "../utils/localStorage.js";
-import {
-  getDesktopContents,
-  getAssociation,
-  findItemByPath,
-} from "../utils/directory.js";
-import { launchApp, handleAppAction } from "../utils/appManager.js";
-import {
-  getThemes,
-  getCurrentTheme,
-  setTheme,
-  applyTheme,
-  getActiveTheme,
-} from "../utils/themeManager.js";
-import { ICONS, SHORTCUT_OVERLAY } from "../config/icons.js";
-import { playSound } from "../utils/soundManager.js";
-import { ShowDialogWindow } from "./DialogWindow.js";
+import { getActiveTheme, applyTheme } from "../utils/themeManager.js";
 import { IconManager } from "./IconManager.js";
-import clipboardManager from "../utils/clipboardManager.js";
-import { pasteItems } from "../utils/fileOperations.js";
-import { getItemFromIcon } from "../utils/iconUtils.js";
-import { createDragGhost } from "../utils/dragDropManager.js";
-import {
-  getRecycleBinItems,
-  emptyRecycleBin,
-  addToRecycleBin,
-} from "../utils/recycleBinManager.js";
-import { getStartupApps } from "../utils/startupManager.js";
-import {
-  setColorMode,
-  getCurrentColorMode,
-  getColorModes,
-} from "../utils/colorModeManager.js";
+import { fs } from "@zenfs/core";
+import { ShellManager } from "../apps/zenexplorer/extensions/ShellManager.js";
+import { renderFileIcon } from "../apps/zenexplorer/interface/FileIconRenderer.js";
+import { FileOperations } from "../apps/zenexplorer/fileoperations/FileOperations.js";
+import { DesktopContextMenuBuilder } from "../apps/zenexplorer/interface/DesktopContextMenuBuilder.js";
+import DragDropManager from "../apps/zenexplorer/fileoperations/DragDropManager.js";
+import LayoutManager from "../apps/zenexplorer/interface/LayoutManager.js";
+import { sortFileInfos } from "../apps/zenexplorer/fileoperations/SortUtils.js";
+import { joinPath } from "../apps/zenexplorer/navigation/PathUtils.js";
+import ClipboardManager from "../apps/zenexplorer/fileoperations/ClipboardManager.js";
 import screensaver from "../utils/screensaverUtils.js";
-import {
-  getAvailableResolutions,
-  setResolution,
-  getCurrentResolutionId,
-} from "../utils/screenManager.js";
-import { handleDroppedFiles } from "../utils/dragDropManager.js";
-import { downloadFile } from "../utils/fileDownloader.js";
-import { truncateName } from "../utils/stringUtils.js";
-import { SPECIAL_FOLDER_PATHS } from "../config/special-folders.js";
+import { getStartupApps } from "../utils/startupManager.js";
 
-function getIconId(app, item = null) {
-  if (typeof item === "string") {
-    // virtual file path
-    return `file-${item.replace(/[^a-zA-Z0-9]/g, "-")}`;
-  }
-  if (item && typeof item === "object" && item.id) {
-    // dropped file object
-    return item.id;
-  }
-  // app
-  return `app-${app.id}`;
-}
+let desktopController;
 
-function isAutoArrangeEnabled() {
-  const autoArrange = getItem(LOCAL_STORAGE_KEYS.AUTO_ARRANGE_ICONS);
-  // Default to true if the setting is not present
-  return autoArrange === null ? true : !!autoArrange;
-}
-
-function createDesktopIcon(item, isFile = false, isFolder = false) {
-  const app = isFile || isFolder ? apps.find((a) => a.id === item.app) : item;
-  if (!app) return null;
-
-  const iconDiv = document.createElement("div");
-  iconDiv.className = "desktop-icon";
-  iconDiv.setAttribute(
-    "title",
-    isFile || isFolder ? item.filename : app.description || app.title,
-  );
-
-  const iconId = getIconId(app, isFile || isFolder ? item.path : null);
-  iconDiv.setAttribute("data-icon-id", iconId);
-
-  iconDiv.setAttribute("data-app-id", app.id);
-  if (isFile || isFolder) {
-    iconDiv.setAttribute("data-file-path", item.path);
-    if (item.type) {
-      iconDiv.setAttribute("data-item-type", item.type);
-    }
+class DesktopController {
+  constructor(desktopElement) {
+    this.currentPath = "/Desktop";
+    this.iconContainer = desktopElement;
+    this.win = {
+      element: desktopElement,
+      title: () => "Desktop",
+      setMenuBar: () => {},
+      setIcons: () => {},
+      id: "desktop",
+    };
+    this.fileOps = new FileOperations(this);
+    this.contextMenuBuilder = new DesktopContextMenuBuilder(this);
+    this.viewMode = "large";
+    this._isRenaming = false;
+    this.lastSelectedIcon = null;
+    this.selectionTimestamp = 0;
   }
 
-  const iconInner = document.createElement("div");
-  iconInner.className = "icon";
-
-  const iconWrapper = document.createElement("div");
-  iconWrapper.className = "icon-wrapper";
-
-  const iconImg = document.createElement("img");
-  iconImg.draggable = false;
-  if (isFolder) {
-    iconImg.src = ICONS.folder[32];
-  } else if (isFile) {
-    const association = getAssociation(item.filename);
-    iconImg.src = item.icon?.[32] || association.icon[32];
-  } else {
-    iconImg.src = app.icon[32];
-  }
-  iconWrapper.appendChild(iconImg);
-
-  if (isFile && item.type === "shortcut") {
-    const overlayImg = document.createElement("img");
-    overlayImg.className = "shortcut-overlay shortcut-overlay-32";
-    overlayImg.src = SHORTCUT_OVERLAY[32];
-    iconWrapper.appendChild(overlayImg);
-  }
-  iconInner.appendChild(iconWrapper);
-
-  const iconLabel = document.createElement("div");
-  iconLabel.className = "icon-label";
-  iconLabel.textContent = truncateName(
-    isFile || isFolder ? item.filename : app.title,
-  );
-
-  iconDiv.appendChild(iconInner);
-  iconDiv.appendChild(iconLabel);
-
-  return iconDiv;
-}
-
-function createDesktopIconForDroppedFile(file) {
-  const association = getAssociation(file.name || file.title);
-  const app = apps.find((a) => a.id === association.appId);
-  if (!app) return null;
-
-  const iconDiv = document.createElement("div");
-  iconDiv.className = "desktop-icon";
-  iconDiv.setAttribute("title", file.name);
-
-  const iconId = getIconId(app, file);
-  iconDiv.setAttribute("data-icon-id", iconId);
-  iconDiv.setAttribute("data-app-id", app.id);
-  iconDiv.setAttribute("data-file-id", file.id); // Store the unique file ID
-
-  const iconInner = document.createElement("div");
-  iconInner.className = "icon";
-
-  const iconImg = document.createElement("img");
-  iconImg.draggable = false;
-  iconImg.src = association.icon[32];
-  iconInner.appendChild(iconImg);
-
-  const iconLabel = document.createElement("div");
-  iconLabel.className = "icon-label";
-  iconLabel.textContent = truncateName(file.name);
-
-  iconDiv.appendChild(iconInner);
-  iconDiv.appendChild(iconLabel);
-
-  return iconDiv;
-}
-
-function handlePaste(destinationPath) {
-  const { items, operation } = clipboardManager.get();
-  pasteItems(destinationPath, items, operation);
-  clipboardManager.clear();
-}
-
-function showIconContextMenu(event, app, fileId = null, iconManager) {
-  let menuItems;
-  const appConfig = apps.find((a) => a.id === app.id);
-  const contextMenu = appConfig.contextMenu;
-  const clickedIcon = event.target.closest(".desktop-icon");
-
-  if (clickedIcon && !iconManager.selectedIcons.has(clickedIcon)) {
-    iconManager.clearSelection();
-    iconManager.selectIcon(clickedIcon);
+  async navigateTo(path, isHistoryNav = false, skipMRU = false) {
+    await refreshIcons();
   }
 
-  const itemsToOperateOn = [...iconManager.selectedIcons]
-    .map(getItemFromIcon)
-    .filter(Boolean);
+  async sortIcons(method) {
+    const layout = await LayoutManager.getLayout(this.currentPath);
+    layout.sortBy = null;
 
-  const copyItem = {
-    label: "C&opy",
-    action: () => {
-      clipboardManager.set(itemsToOperateOn, "copy");
-    },
-  };
-
-  const cutItem = {
-    label: "Cu&t",
-    action: () => {
-      clipboardManager.set(itemsToOperateOn, "cut");
-    },
-    enabled: !itemsToOperateOn.some(
-      (item) => item.itemType === "app" || item.itemType === "virtual-file",
-    ),
-  };
-
-  const downloadItem = {
-    label: "&Download",
-    action: () => {
-      itemsToOperateOn.forEach((item) => {
-        let fileToDownload;
-        let filename;
-        let content;
-
-        if (item.itemType === "dropped-file") {
-          const droppedFiles = getItem(LOCAL_STORAGE_KEYS.DROPPED_FILES) || [];
-          fileToDownload = droppedFiles.find((f) => f.id === item.id);
-          if (!fileToDownload) return;
-          filename = fileToDownload.name;
-          content = fileToDownload.contentUrl || fileToDownload.content;
-        } else if (item.itemType === "virtual-file") {
-          fileToDownload = findItemByPath(item.path);
-          if (!fileToDownload || !fileToDownload.content) return;
-          filename = fileToDownload.filename;
-          content = fileToDownload.content;
-        } else {
-          return; // Not a downloadable file
-        }
-
-        if (content) {
-          downloadFile(filename, content);
-        }
-      });
-    },
-    enabled:
-      itemsToOperateOn.length > 0 &&
-      itemsToOperateOn.every(
-        (item) =>
-          item.itemType === "dropped-file" || item.itemType === "virtual-file",
-      ),
-  };
-
-  if (app.id === "recycle-bin" || app.id === "network") {
-    copyItem.enabled = false;
-    cutItem.enabled = false;
-  }
-
-  if (fileId) {
-    const droppedFiles = getItem(LOCAL_STORAGE_KEYS.DROPPED_FILES) || [];
-    const file = droppedFiles.find((f) => f.id === fileId);
-
-    menuItems = [
-      {
-        label: "&Open",
-        default: true,
-        action: () => {
-          if (file) {
-            launchApp(app.id, file);
-          }
-        },
-      },
-    ];
-
-    if (file) {
-      const association = getAssociation(file.name);
-      if (association.appId === "media-player") {
-        menuItems.push({
-          label: "Play in Winamp",
-          action: () => launchApp("webamp", file),
+    const files = await ShellManager.readdir(this.currentPath);
+    const fileInfos = [];
+    for (const file of files) {
+      const fullPath = joinPath(this.currentPath, file);
+      try {
+        const stat = await ShellManager.stat(fullPath);
+        fileInfos.push({ name: file, stat, isDirectory: stat.isDirectory() });
+      } catch (e) {
+        fileInfos.push({
+          name: file,
+          stat: { size: 0, mtime: new Date(0) },
+          isDirectory: false,
         });
       }
     }
 
-    menuItems.push(
-      copyItem,
-      cutItem,
-      downloadItem,
-      {
-        label: "&Delete",
-        action: () => deleteDroppedFile(fileId),
-      },
-      "MENU_DIVIDER",
-      {
-        label: "&Properties",
-        action: () => showProperties(app),
-      },
-    );
-  } else if (contextMenu) {
-    const openItemIndex = contextMenu.findIndex(
-      (item) =>
-        item.action === "open" || (item.label && item.label.includes("Open")),
-    );
+    const sortedInfos = sortFileInfos(fileInfos, method, this.currentPath, []);
 
-    menuItems = contextMenu.map((item) => {
-      if (typeof item === "string") {
-        return item;
-      }
-      const newItem = { ...item };
-      if (typeof newItem.action === "string") {
-        switch (newItem.action) {
-          case "open":
-            newItem.action = () => launchApp(app.id);
-            newItem.default = true;
-            break;
-          case "properties":
-            newItem.action = () => showProperties(app);
-            break;
-          default:
-            newItem.action = () => {};
-            break;
-        }
-      }
-      return newItem;
-    });
+    if (this.autoArrange) {
+      layout.order = sortedInfos.map((info) => info.name);
+      layout.positions = {};
+    } else {
+      const gridX = 75;
+      const gridY = 75;
+      const containerHeight = this.iconContainer.clientHeight || 600;
+      const rows = Math.floor(containerHeight / gridY) || 1;
 
-    if (openItemIndex !== -1) {
-      menuItems.splice(openItemIndex + 1, 0, copyItem, cutItem);
+      layout.positions = {};
+      sortedInfos.forEach((info, index) => {
+        const x = Math.floor(index / rows) * gridX + 5;
+        const y = (index % rows) * gridY + 5;
+        layout.positions[info.name] = { x, y };
+      });
+      layout.order = sortedInfos.map((info) => info.name);
     }
-  } else {
-    menuItems = [
-      {
-        label: "&Open",
-        default: true,
-        action: () => handleAppAction(app),
-      },
-      copyItem,
-      cutItem,
-      "MENU_DIVIDER",
-      {
-        label: "&Properties",
-        action: () => showProperties(app),
-      },
-    ];
+
+    await LayoutManager.saveLayout(
+      this.currentPath,
+      layout,
+      this.win.element.id,
+    );
+    await refreshIcons();
   }
 
-  new window.ContextMenu(menuItems, event);
+  get autoArrange() {
+    return this._autoArrange;
+  }
+
+  set autoArrange(value) {
+    this._autoArrange = value;
+  }
+
+  async toggleAutoArrange() {
+    this.autoArrange = !this.autoArrange;
+    const layout = await LayoutManager.getLayout(this.currentPath);
+    layout.autoArrange = this.autoArrange;
+    if (layout.autoArrange) {
+      layout.positions = {};
+    } else {
+      const icons = this.iconContainer.querySelectorAll(".explorer-icon");
+      icons.forEach((icon) => {
+        const name = icon.getAttribute("data-name");
+        layout.positions[name] = {
+          x: icon.offsetLeft,
+          y: icon.offsetTop,
+        };
+      });
+    }
+    await LayoutManager.saveLayout(
+      this.currentPath,
+      layout,
+      this.win.element.id,
+    );
+    await refreshIcons();
+  }
+
+  async handleRearrange(sourcePaths, x, y, offsets) {
+    const layout = await LayoutManager.getLayout(this.currentPath);
+    layout.sortBy = null;
+
+    if (!layout.autoArrange) {
+      sourcePaths.forEach((path, index) => {
+        const name = path.split("/").pop();
+        const offset = offsets ? offsets[index] : { x: 0, y: 0 };
+        layout.positions[name] = {
+          x: x + offset.x,
+          y: y + offset.y,
+        };
+      });
+    } else {
+      const icons = [...this.iconContainer.querySelectorAll(".explorer-icon")];
+      let targetIcon = null;
+
+      for (const icon of icons) {
+        if (
+          x >= icon.offsetLeft &&
+          x <= icon.offsetLeft + icon.offsetWidth &&
+          y >= icon.offsetTop &&
+          y <= icon.offsetTop + icon.offsetHeight
+        ) {
+          targetIcon = icon;
+          break;
+        }
+      }
+
+      const draggedNames = sourcePaths.map((p) => p.split("/").pop());
+      const currentOrder =
+        layout.order && layout.order.length > 0
+          ? [...layout.order]
+          : icons.map((i) => i.getAttribute("data-name"));
+
+      let newOrder = currentOrder.filter(
+        (name) => !draggedNames.includes(name),
+      );
+
+      if (targetIcon) {
+        const targetName = targetIcon.getAttribute("data-name");
+        const targetIndex = newOrder.indexOf(targetName);
+        if (targetIndex !== -1) {
+          newOrder.splice(targetIndex, 0, ...draggedNames);
+        } else {
+          newOrder.push(...draggedNames);
+        }
+      } else {
+        newOrder.push(...draggedNames);
+      }
+      layout.order = newOrder;
+    }
+
+    await LayoutManager.saveLayout(
+      this.currentPath,
+      layout,
+      this.win.element.id,
+    );
+    await refreshIcons();
+  }
+
+  handleSelectionChange() {
+    const selectedIcons = this.iconManager.selectedIcons;
+    if (selectedIcons.size === 1) {
+      const icon = [...selectedIcons][0];
+      if (this.lastSelectedIcon !== icon) {
+        this.lastSelectedIcon = icon;
+        this.selectionTimestamp = Date.now();
+      }
+    } else {
+      this.lastSelectedIcon = null;
+      this.selectionTimestamp = 0;
+    }
+  }
+
+  enterRenameModeByPath(path) {
+    const icon = this.iconContainer.querySelector(
+      `.explorer-icon[data-path="${path}"]`,
+    );
+    if (icon) {
+      this.iconManager.setSelection(new Set([icon]));
+      this.enterRenameMode(icon);
+    }
+  }
+
+  async enterRenameMode(icon) {
+    if (this._isRenaming) return;
+    const path = icon.getAttribute("data-path");
+    const isVirtual = icon.getAttribute("data-is-virtual") === "true";
+    if (isVirtual) return;
+
+    this._isRenaming = true;
+    const label = icon.querySelector(".icon-label");
+    const fullPath = path;
+    const oldName = fullPath.split("/").pop();
+    const textarea = document.createElement("textarea");
+    textarea.className = "icon-label-input";
+    textarea.value = oldName;
+    textarea.spellcheck = false;
+    label.innerHTML = "";
+    label.appendChild(textarea);
+
+    const adjustTextareaHeight = (ta) => {
+      ta.style.height = "auto";
+      ta.style.height = `${ta.scrollHeight}px`;
+    };
+    adjustTextareaHeight(textarea);
+
+    const dotIndex = oldName.lastIndexOf(".");
+    if (dotIndex > 0 && icon.getAttribute("data-type") !== "directory")
+      textarea.setSelectionRange(0, dotIndex);
+    else textarea.select();
+    textarea.focus();
+
+    textarea.addEventListener("input", () => adjustTextareaHeight(textarea));
+    const finishRename = async (save) => {
+      if (!this._isRenaming) return;
+      this._isRenaming = false;
+      const newName = textarea.value.trim();
+      if (save && newName && newName !== oldName) {
+        try {
+          const parentPath =
+            fullPath.substring(0, fullPath.lastIndexOf("/")) || "/";
+          const newPath = joinPath(parentPath, newName);
+          await fs.promises.rename(
+            ShellManager.getRealPath(fullPath),
+            ShellManager.getRealPath(newPath),
+          );
+        } catch (e) {
+          alert(`Error renaming: ${e.message}`);
+        } finally {
+          await refreshIcons();
+          document.dispatchEvent(
+            new CustomEvent("fs-change", { detail: { sourceAppId: "desktop" } }),
+          );
+        }
+      } else {
+        await refreshIcons();
+      }
+    };
+    textarea.onkeydown = (e) => {
+      e.stopPropagation();
+      if (e.key === "Enter") {
+        e.preventDefault();
+        finishRename(true);
+      } else if (e.key === "Escape") finishRename(false);
+    };
+    textarea.onblur = () => finishRename(true);
+    textarea.onclick = (e) => e.stopPropagation();
+    textarea.ondblclick = (e) => e.stopPropagation();
+  }
+
+  async onOpen(path) {
+    const handled = await ShellManager.onOpen(path, {
+      navigateTo: (p) => launchApp("zenexplorer", p),
+    });
+    if (handled) return;
+
+    const stat = await ShellManager.stat(path);
+    if (stat.isDirectory()) {
+      launchApp("zenexplorer", path);
+    } else {
+      const { getAssociation } = await import("../utils/directory.js");
+      const association = getAssociation(path.split("/").pop());
+      if (association.appId) {
+        launchApp(association.appId, path);
+      }
+    }
+  }
 }
 
-function setWallpaper() {
-  const input = document.createElement("input");
-  input.type = "file";
-  input.accept = "image/*";
-  input.onchange = (e) => {
-    const file = e.target.files[0];
-    if (file) {
-      const reader = new FileReader();
-      reader.onload = (readerEvent) => {
-        const dataUrl = readerEvent.target.result;
-        setItem(LOCAL_STORAGE_KEYS.WALLPAPER, dataUrl);
-        applyWallpaper();
-      };
-      reader.readAsDataURL(file);
+export async function setupIcons() {
+  await refreshIcons();
+}
+
+async function refreshIcons() {
+  const desktop = document.querySelector(".desktop");
+  const path = "/Desktop";
+  const layout = await LayoutManager.getLayout(path);
+  desktopController.autoArrange = layout.autoArrange;
+
+  let rawFiles = await ShellManager.readdir(path);
+  rawFiles = rawFiles.filter((f) => f !== ".zen_layout.json");
+
+  const fileInfos = [];
+  for (const file of rawFiles) {
+    const fullPath = joinPath(path, file);
+    try {
+      const fileStat = await ShellManager.stat(fullPath);
+      fileInfos.push({
+        name: file,
+        fullPath,
+        stat: fileStat,
+        isDirectory: fileStat.isDirectory(),
+      });
+    } catch (e) {
+      fileInfos.push({
+        name: file,
+        fullPath,
+        stat: { size: 0, mtime: new Date(0) },
+        isDirectory: false,
+      });
     }
-  };
-  input.click();
+  }
+
+  const sortBy = layout.sortBy || null;
+  const order = layout.order || [];
+  const sortedInfos = sortFileInfos(fileInfos, sortBy, path, order);
+
+  desktop.innerHTML = "";
+  desktopController.iconManager.clearSelection();
+
+  if (layout.autoArrange) {
+    desktop.classList.remove("has-absolute-icons");
+  } else {
+    desktop.classList.add("has-absolute-icons");
+  }
+
+  const icons = [];
+  for (const info of sortedInfos) {
+    const { name: file, fullPath, stat: fileStat, isDirectory: isDir } = info;
+    try {
+      const iconDiv = await renderFileIcon(file, fullPath, isDir, {
+        stat: fileStat,
+      });
+      desktopController.iconManager.configureIcon(iconDiv);
+
+      iconDiv.addEventListener("click", (e) => {
+        if (desktopController._isRenaming) return;
+        if (
+          desktopController.lastSelectedIcon === iconDiv &&
+          Date.now() - desktopController.selectionTimestamp > 500
+        ) {
+          desktopController.enterRenameMode(iconDiv);
+          e.stopPropagation();
+        }
+      });
+
+      if (!layout.autoArrange) {
+        iconDiv.style.position = "absolute";
+        if (layout.positions && layout.positions[file]) {
+          iconDiv.style.left = `${layout.positions[file].x}px`;
+          iconDiv.style.top = `${layout.positions[file].y}px`;
+        } else {
+          const gridX = 75;
+          const gridY = 75;
+          const containerHeight = desktop.clientHeight || 600;
+          const rows = Math.floor(containerHeight / gridY) || 1;
+          const index = icons.length;
+          const x = Math.floor(index / rows) * gridX + 5;
+          const y = (index % rows) * gridY + 5;
+          iconDiv.style.left = `${x}px`;
+          iconDiv.style.top = `${y}px`;
+        }
+      }
+      icons.push(iconDiv);
+      desktop.appendChild(iconDiv);
+    } catch (e) {
+      console.error(e);
+    }
+  }
+}
+
+function updateCutIcons() {
+  const { items, operation } = ClipboardManager.get();
+  const cutPaths = operation === "cut" ? new Set(items) : new Set();
+  const icons = document.querySelectorAll(".desktop .explorer-icon");
+  icons.forEach((icon) => {
+    const path = icon.getAttribute("data-path");
+    if (cutPaths.has(path)) icon.classList.add("cut");
+    else icon.classList.remove("cut");
+  });
 }
 
 function getWallpaperMode() {
   return getItem(LOCAL_STORAGE_KEYS.WALLPAPER_MODE) || "tile";
-}
-
-function setWallpaperMode(mode) {
-  setItem(LOCAL_STORAGE_KEYS.WALLPAPER_MODE, mode);
-  applyWallpaper();
-  document.dispatchEvent(new CustomEvent("wallpaper-changed"));
 }
 
 function applyWallpaper() {
@@ -383,29 +427,15 @@ function applyWallpaper() {
       desktop.style.backgroundRepeat = "repeat";
       desktop.style.backgroundSize = "auto";
     }
-    desktop.style.backgroundColor = ""; // Remove solid color
+    desktop.style.backgroundColor = "";
   } else {
     desktop.style.backgroundImage = "";
-    desktop.style.backgroundColor = "var(--Background)"; // Restore solid color
+    desktop.style.backgroundColor = "var(--Background)";
   }
-}
-
-function removeWallpaper() {
-  removeItem(LOCAL_STORAGE_KEYS.WALLPAPER);
-  applyWallpaper();
 }
 
 function getMonitorType() {
   return getItem(LOCAL_STORAGE_KEYS.MONITOR_TYPE) || "TFT";
-}
-
-function setMonitorType(type) {
-  setItem(LOCAL_STORAGE_KEYS.MONITOR_TYPE, type);
-  if (type === "CRT") {
-    document.body.classList.add("scanlines");
-  } else {
-    document.body.classList.remove("scanlines");
-  }
 }
 
 function applyMonitorType() {
@@ -417,742 +447,76 @@ function applyMonitorType() {
   }
 }
 
-function captureGridIconPositions() {
-  const desktop = document.querySelector(".desktop");
-  if (desktop.classList.contains("has-absolute-icons")) {
-    // Already in manual mode, no need to capture.
-    return;
-  }
-  const desktopRect = desktop.getBoundingClientRect();
-  const allIcons = Array.from(desktop.querySelectorAll(".desktop-icon"));
-  const iconPositions = {};
-
-  // Force browser reflow to ensure accurate position values
-  desktop.offsetHeight;
-
-  allIcons.forEach((icon) => {
-    const id = icon.getAttribute("data-icon-id");
-    const rect = icon.getBoundingClientRect();
-    const x = `${rect.left - desktopRect.left}px`;
-    const y = `${rect.top - desktopRect.top}px`;
-    iconPositions[id] = { x, y };
-  });
-
-  setItem(LOCAL_STORAGE_KEYS.ICON_POSITIONS, iconPositions);
-}
-
-function sortDesktopIcons(sortBy) {
-  const desktopItems = getDesktopContents();
-
-  const typeOrder = {
-    app: 1,
-    folder: 2,
-    shortcut: 3,
-    file: 4,
-  };
-
-  const systemIconOrder = [
-    "my-computer",
-    "my-documents",
-    "internet-explorer",
-    "recycle-bin",
-    "my-briefcase",
-    "network-neighborhood",
-  ];
-
-  desktopItems.sort((a, b) => {
-    const aIsSystem = a.isSystemIcon;
-    const bIsSystem = b.isSystemIcon;
-
-    if (aIsSystem && !bIsSystem) return -1;
-    if (!aIsSystem && bIsSystem) return 1;
-
-    if (aIsSystem && bIsSystem) {
-      return systemIconOrder.indexOf(a.id) - systemIconOrder.indexOf(b.id);
-    }
-
-    if (sortBy === "name") {
-      return a.name.localeCompare(b.name);
-    } else if (sortBy === "type") {
-      const typeA = typeOrder[a.type] || 5;
-      const typeB = typeOrder[b.type] || 5;
-      if (typeA !== typeB) {
-        return typeA - typeB;
-      }
-      return a.name.localeCompare(b.name);
-    }
-    return 0;
-  });
-
-  // When sorting, we clear any manual positioning and revert to a grid layout.
-  removeItem(LOCAL_STORAGE_KEYS.ICON_POSITIONS);
-
-  // This will cause setupIcons to re-render in grid mode.
-  document.querySelector(".desktop").refreshIcons(desktopItems, true);
-}
-
-function showDesktopContextMenu(event, { selectedIcons, clearSelection }) {
-  const themes = getThemes();
-
-  const toggleAutoArrange = () => {
-    const newSetting = !isAutoArrangeEnabled();
-    setItem(LOCAL_STORAGE_KEYS.AUTO_ARRANGE_ICONS, newSetting);
-
-    if (newSetting) {
-      // Turning ON: clear saved positions
-      removeItem(LOCAL_STORAGE_KEYS.ICON_POSITIONS);
-    } else {
-      // Turning OFF: capture current grid positions and save them
-      captureGridIconPositions();
-    }
-    document.querySelector(".desktop").refreshIcons();
-  };
-
-  const pasteItem = {
-    label: "Paste",
-    action: () => {
-      handlePaste(SPECIAL_FOLDER_PATHS.desktop);
-    },
-    enabled: !clipboardManager.isEmpty(),
-  };
-
-  const menuItems = [
-    {
-      label: "Arrange Icons",
-      submenu: [
-        {
-          label: "by Name",
-          action: () => sortDesktopIcons("name"),
-        },
-        {
-          label: "by Type",
-          action: () => sortDesktopIcons("type"),
-        },
-        {
-          label: "by Size",
-          action: () => {},
-          enabled: false,
-        },
-        {
-          label: "by Date",
-          action: () => {},
-          enabled: false,
-        },
-        "MENU_DIVIDER",
-        {
-          label: "Auto Arrange",
-          checkbox: {
-            check: isAutoArrangeEnabled,
-            toggle: toggleAutoArrange,
-          },
-        },
-      ],
-    },
-    pasteItem,
-    "MENU_DIVIDER",
-    {
-      label: "Wallpaper",
-      submenu: [
-        {
-          label: "Set Wallpaper...",
-          action: setWallpaper,
-        },
-        {
-          label: "Remove Wallpaper",
-          action: removeWallpaper,
-        },
-        "MENU_DIVIDER",
-        {
-          radioItems: [
-            { label: "Center", value: "center" },
-            { label: "Tile", value: "tile" },
-            { label: "Stretch", value: "stretch" },
-          ],
-          getValue: () => getWallpaperMode(),
-          setValue: (value) => setWallpaperMode(value),
-          ariaLabel: "Wallpaper Mode",
-        },
-      ],
-    },
-    {
-      label: "Color Mode",
-      submenu: [
-        {
-          radioItems: Object.entries(getColorModes()).map(([id, mode]) => ({
-            label: mode.name,
-            value: id,
-          })),
-          getValue: () => getCurrentColorMode(),
-          setValue: (value) => setColorMode(value),
-          ariaLabel: "Color Mode",
-        },
-      ],
-    },
-    "MENU_DIVIDER",
-    {
-      label: "Theme",
-      submenu: [
-        {
-          radioItems: Object.values(themes).map((theme) => ({
-            label: theme.name,
-            value: theme.id,
-          })),
-          getValue: () => getCurrentTheme(),
-          setValue: (value) => {
-            setTheme(value);
-          },
-          ariaLabel: "Desktop Theme",
-        },
-      ],
-    },
-    {
-      label: "Monitor Type",
-      submenu: [
-        {
-          radioItems: [
-            { label: "TFT", value: "TFT" },
-            { label: "CRT", value: "CRT" },
-          ],
-          getValue: () => getMonitorType(),
-          setValue: (value) => setMonitorType(value),
-          ariaLabel: "Monitor Type",
-        },
-      ],
-    },
-    "MENU_DIVIDER",
-    {
-      label: "Screen Resolution",
-      submenu: [
-        {
-          radioItems: getAvailableResolutions().map((res) => ({
-            label: res === "fit" ? "Fit Screen" : res,
-            value: res,
-          })),
-          getValue: () => getCurrentResolutionId(),
-          setValue: (value) => setResolution(value),
-          ariaLabel: "Screen Resolution",
-        },
-      ],
-    },
-    "MENU_DIVIDER",
-    {
-      label: "Screen Saver",
-      submenu: [
-        {
-          radioItems: [
-            { label: "None", value: "none" },
-            { label: "FlowerBox", value: "flowerbox" },
-            { label: "3D Maze", value: "maze" },
-          ],
-          getValue: () => screensaver.getCurrentScreensaver(),
-          setValue: (value) => {
-            screensaver.setCurrentScreensaver(value);
-          },
-          ariaLabel: "Select Screensaver",
-        },
-        "MENU_DIVIDER",
-        {
-          label: "Wait Time",
-          submenu: [
-            {
-              radioItems: [
-                { label: "1 minute", value: 60000 },
-                { label: "5 minutes", value: 300000 },
-                { label: "30 minutes", value: 1800000 },
-                { label: "1 hour", value: 3600000 },
-              ],
-              getValue: () =>
-                getItem(LOCAL_STORAGE_KEYS.SCREENSAVER_TIMEOUT) || 300000,
-              setValue: (value) => {
-                setItem(LOCAL_STORAGE_KEYS.SCREENSAVER_TIMEOUT, value);
-              },
-              ariaLabel: "Screen Saver Wait Time",
-            },
-          ],
-        },
-      ],
-    },
-  ];
-
-  menuItems.push({
-    label: "Properties",
-    action: () => launchApp("displayproperties"),
-  });
-
-  const menu = new window.ContextMenu(menuItems, event);
-  const handleThemeChange = () => {
-    if (menu.activeSubmenu) {
-      menu.activeSubmenu.element.dispatchEvent(new CustomEvent("update", {}));
-    }
-  };
-  const handleWallpaperChange = handleThemeChange; // Same logic
-
-  document.addEventListener("theme-changed", handleThemeChange);
-  document.addEventListener("wallpaper-changed", handleWallpaperChange);
-}
-
-function deleteDroppedFile(fileId) {
-  const fileIds = Array.isArray(fileId) ? fileId : [fileId];
-  if (fileIds.length === 0) return;
-
-  const dialogText =
-    fileIds.length > 1
-      ? `Are you sure you want to send these ${fileIds.length} items to the Recycle Bin?`
-      : "Are you sure you want to send this item to the Recycle Bin?";
-
-  ShowDialogWindow({
-    title: "Confirm File Delete",
-    text: dialogText,
-    contentIconUrl: ICONS.warning[32],
-    soundEvent: "SystemHand",
-    buttons: [
-      {
-        label: "Yes",
-        action: () => {
-          let droppedFiles = getItem(LOCAL_STORAGE_KEYS.DROPPED_FILES) || [];
-          const filesToDelete = droppedFiles.filter((f) =>
-            fileIds.includes(f.id),
-          );
-
-          if (filesToDelete.length > 0) {
-            filesToDelete.forEach((file) => addToRecycleBin(file));
-            const newDroppedFiles = droppedFiles.filter(
-              (f) => !fileIds.includes(f.id),
-            );
-            setItem(LOCAL_STORAGE_KEYS.DROPPED_FILES, newDroppedFiles);
-            document.querySelector(".desktop").refreshIcons();
-            document.dispatchEvent(new CustomEvent("explorer-refresh"));
-          }
-        },
-      },
-      {
-        label: "No",
-        isDefault: true,
-        action: () => {},
-      },
-    ],
-    modal: true,
-  });
-}
-
-function showProperties(app) {
-  // The 'app' object here is the configuration from apps.js.
-  // We can create a temporary, "headless" instance of the application
-  // to call the generic showProperties method. This works because the method
-  // only depends on the configuration data, not a live window.
-  if (app.appClass) {
-    const tempAppInstance = new app.appClass(app);
-    tempAppInstance.showProperties();
-  } else {
-    // Fallback for older apps or configs without a class
-    let text = `<b>${app.title}</b>`;
-    if (app.description) {
-      text += `<br><br>${app.description}`;
-    }
-    if (app.summary) {
-      text += `<br><br>${app.summary}`;
-    }
-
-    ShowDialogWindow({
-      title: `${app.title} Properties`,
-      contentIconUrl: app.icon[32],
-      text: text,
-      buttons: [{ label: "OK", isDefault: true }],
-    });
-  }
-}
-
-export function setupIcons(
-  options,
-  desktopContents = getDesktopContents(),
-  isFromSort = false,
-) {
-  const { iconManager } = options;
-  const desktop = document.querySelector(".desktop");
-  desktop.innerHTML = ""; // Clear existing icons
-
-  let iconPositions = {};
-  if (!isAutoArrangeEnabled()) {
-    iconPositions = getItem(LOCAL_STORAGE_KEYS.ICON_POSITIONS) || {};
-  }
-
-  // Set the class based on Auto Arrange
-  if (!isAutoArrangeEnabled()) {
-    desktop.classList.add("has-absolute-icons");
-  } else {
-    desktop.classList.remove("has-absolute-icons");
-  }
-
-  const placeIcon = (icon, iconId) => {
-    if (iconPositions[iconId]) {
-      icon.style.position = "absolute";
-      icon.style.left = iconPositions[iconId].x;
-      icon.style.top = iconPositions[iconId].y;
-    } else if (desktop.classList.contains("has-absolute-icons")) {
-      // If we're in manual mode but this icon has no position, find one for it.
-      const { x, y } = findNextOpenPosition(desktop, iconPositions);
-      icon.style.position = "absolute";
-      icon.style.left = `${x}px`;
-      icon.style.top = `${y}px`;
-      // And save it for consistency
-      iconPositions[iconId] = { x: `${x}px`, y: `${y}px` };
-      setItem(LOCAL_STORAGE_KEYS.ICON_POSITIONS, iconPositions);
-    }
-    desktop.appendChild(icon);
-  };
-
-  // If auto-arranging and no positions are saved, sort by name.
-  // This becomes the default initial layout.
-  if (
-    isAutoArrangeEnabled() &&
-    Object.keys(iconPositions).length === 0 &&
-    !isFromSort
-  ) {
-    sortDesktopIcons("name");
-    return;
-  }
-
-  desktopContents.forEach((item) => {
-    let icon;
-    let iconId;
-    let appConfig;
-    let filePath = null;
-
-    switch (item.type) {
-      case "app":
-        appConfig = apps.find((a) => a.id === item.appId);
-        if (appConfig) {
-          icon = createDesktopIcon(appConfig);
-          iconId = getIconId(appConfig);
-        }
-        break;
-      case "shortcut":
-      case "file":
-        item.filename = item.name;
-        icon = createDesktopIcon(item, true, false);
-        appConfig = apps.find((a) => a.id === item.app);
-        if (appConfig) {
-          iconId = getIconId(appConfig, item.path);
-          filePath = item.path;
-        }
-        break;
-      case "folder":
-        item.filename = item.name;
-        icon = createDesktopIcon(item, false, true);
-        appConfig = apps.find((a) => a.id === item.app);
-        if (appConfig) {
-          iconId = getIconId(appConfig, item.path);
-          filePath = item.path;
-        }
-        break;
-      default:
-        break;
-    }
-
-    if (icon && iconId && appConfig) {
-      configureIcon(icon, appConfig, filePath, { iconManager });
-      placeIcon(icon, iconId);
-    }
-  });
-
-  // Load dropped files
-  const allDroppedFiles = getItem(LOCAL_STORAGE_KEYS.DROPPED_FILES) || [];
-  const desktopFiles = allDroppedFiles.filter(
-    (file) => file.path === SPECIAL_FOLDER_PATHS.desktop,
-  );
-
-  desktopFiles.forEach((file) => {
-    const icon = createDesktopIconForDroppedFile(file);
-    if (icon) {
-      const association = getAssociation(file.name || file.title);
-      const app = apps.find((a) => a.id === association.appId);
-      const iconId = getIconId(app, file);
-      configureIcon(icon, app, file, { iconManager });
-      placeIcon(icon, iconId);
-    }
-  });
-}
-
-function findNextOpenPosition(desktop, iconPositions) {
-  const desktopRect = desktop.getBoundingClientRect();
-  const iconWidth = 75; // Average icon width
-  const iconHeight = 75; // Average icon height
-  const paddingTop = 5;
-  const paddingLeft = 5;
-
-  const cols = Math.floor((desktopRect.width - paddingLeft) / iconWidth);
-  const rows = Math.floor((desktopRect.height - paddingTop) / iconHeight);
-
-  const occupiedSlots = new Set();
-  Object.values(iconPositions).forEach((pos) => {
-    const x = parseInt(pos.x, 10);
-    const y = parseInt(pos.y, 10);
-    if (!isNaN(x) && !isNaN(y)) {
-      const col = Math.round((x - paddingLeft) / iconWidth);
-      const row = Math.round((y - paddingTop) / iconHeight);
-      occupiedSlots.add(`${col},${row}`);
-    }
-  });
-
-  for (let c = 0; c < cols; c++) {
-    for (let r = 0; r < rows; r++) {
-      if (!occupiedSlots.has(`${c},${r}`)) {
-        return {
-          x: paddingLeft + c * iconWidth,
-          y: paddingTop + r * iconHeight,
-        };
-      }
-    }
-  }
-
-  // Fallback if no slot is found (e.g., desktop is full)
-  return { x: paddingLeft, y: paddingTop };
-}
-
-function configureIcon(icon, app, filePath = null, { iconManager }) {
-  let isDragging = false;
-  let wasDragged = false;
-  let dragStartX, dragStartY;
-  let dragOffsets = new Map();
-  let ghostIcons = new Map(); // Map to store original icon -> ghost icon
-  let longPressTimer;
-  let isLongPress = false;
-  let handleDragEndWrapper;
-  let isNativeDragActive = false;
-  let dragGhost = null;
-
-  const iconId = icon.getAttribute("data-icon-id");
-
-  const item = getItemFromIcon(icon);
-  if (item) {
-    icon.draggable = true;
-  }
-
-  icon.addEventListener("dragstart", (e) => {
-    // If the dragged icon is not selected, select it exclusively
-    if (!iconManager.selectedIcons.has(icon)) {
-      iconManager.clearSelection();
-      iconManager.selectIcon(icon);
-    }
-    isNativeDragActive = true;
-    e.stopPropagation();
-    const selectedItems = [...iconManager.selectedIcons]
-      .map((icon) => getItemFromIcon(icon))
-      .filter(Boolean);
-
-    const primaryIconRect = icon.getBoundingClientRect();
-    const cursorOffsetX = e.clientX - primaryIconRect.left;
-    const cursorOffsetY = e.clientY - primaryIconRect.top;
-
-    const dragOffsets = [...iconManager.selectedIcons].map((selectedIcon) => {
-      const rect = selectedIcon.getBoundingClientRect();
-      return {
-        id: selectedIcon.getAttribute("data-icon-id"),
-        offsetX: rect.left - primaryIconRect.left,
-        offsetY: rect.top - primaryIconRect.top,
-      };
-    });
-
-    e.dataTransfer.setData(
-      "application/json",
-      JSON.stringify({
-        items: selectedItems,
-        sourcePath: SPECIAL_FOLDER_PATHS.desktop,
-        cursorOffsetX,
-        cursorOffsetY,
-        dragOffsets,
-      }),
-    );
-    e.dataTransfer.effectAllowed = "move";
-    dragGhost = createDragGhost(icon, e);
-  });
-
-  icon.addEventListener("dragend", () => {
-    if (dragGhost && dragGhost.parentElement) {
-      dragGhost.parentElement.removeChild(dragGhost);
-    }
-    dragGhost = null;
-    isNativeDragActive = false;
-  });
-
-  icon.addEventListener("mousedown", (e) => {
-    if (e.button === 0) {
-      iconManager.handleIconMouseDown(e, icon);
-    }
-  });
-
-  icon.addEventListener("touchstart", (e) => {
-    iconManager.handleIconMouseDown(e, icon);
-
-    longPressTimer = setTimeout(() => {
-      isLongPress = true;
-      const touch = e.touches[0];
-      const mockEvent = {
-        pageX: touch.pageX,
-        pageY: touch.pageY,
-        preventDefault: () => e.preventDefault(),
-      };
-      showIconContextMenu(mockEvent, app, null, iconManager);
-    }, 500);
-  });
-
-  const cancelLongPress = () => {
-    clearTimeout(longPressTimer);
-  };
-
-  icon.addEventListener("touchend", cancelLongPress);
-  icon.addEventListener("touchmove", cancelLongPress);
-
-  icon.addEventListener("dragover", (e) => {
-    const targetAppId = icon.getAttribute("data-app-id");
-    if (targetAppId === "my-documents" || targetAppId === "recycle-bin") {
-      e.preventDefault();
-    }
-  });
-
-  icon.addEventListener("drop", (e) => {
-    e.preventDefault();
-    e.stopPropagation();
-
-    const targetAppId = icon.getAttribute("data-app-id");
-    const jsonData = e.dataTransfer.getData("application/json");
-
-    if (jsonData) {
-      const data = JSON.parse(jsonData);
-      const { items } = data;
-
-      if (items) {
-        if (targetAppId === "recycle-bin") {
-          const fileIds = items
-            .filter((item) => item.itemType === "dropped-file")
-            .map((item) => item.id);
-          if (fileIds.length > 0) {
-            deleteDroppedFile(fileIds);
-          }
-        } else if (targetAppId === "my-documents") {
-          pasteItems(SPECIAL_FOLDER_PATHS["my-documents"], items, "cut");
-        }
-      }
-    }
-  });
-
-  icon.addEventListener("click", function (e) {
-    if (isLongPress) {
-      e.stopPropagation();
-      e.preventDefault();
-      return;
-    }
-
-    // Icon manager now handles single click selection
-    iconManager.handleIconClick(e, icon);
-  });
-
-  icon.addEventListener("dblclick", (e) => {
-    if (wasDragged || isLongPress) {
-      e.stopPropagation();
-      e.preventDefault();
-      return;
-    }
-
-    const itemType = icon.getAttribute("data-item-type");
-    if (itemType === "shortcut") {
-      launchApp(app.id);
-      return;
-    }
-
-    // If filePath is an object, it's a dropped file. Otherwise, it's a path string.
-    const launchData =
-      typeof filePath === "object" && filePath !== null ? filePath : filePath;
-    launchApp(app.id, launchData);
-  });
-}
-
-// Initialize desktop behavior
 export async function initDesktop(profile = null) {
   console.log("Initializing Desktop Manager...");
   await applyTheme();
   applyWallpaper();
   applyMonitorType();
-  const desktop = document.querySelector(".desktop");
 
-  const iconManager = new IconManager(desktop, {
-    iconSelector: ".desktop-icon",
+  const desktop = document.querySelector(".desktop");
+  desktopController = new DesktopController(desktop);
+
+  desktopController.iconManager = new IconManager(desktop, {
+    iconSelector: ".explorer-icon",
+    onDragStart: (e, icon, selectedIcons) => {
+      DragDropManager.startDrag(
+        selectedIcons,
+        desktopController,
+        e.clientX,
+        e.clientY,
+      );
+    },
     onItemContext: (e, icon) => {
-      const appId = icon.getAttribute("data-app-id");
-      const fileId = icon.getAttribute("data-file-id");
-      const app = apps.find((a) => a.id === appId);
-      if (app) {
-        showIconContextMenu(e, app, fileId, iconManager);
-      }
+      const menuItems = desktopController.contextMenuBuilder.buildItemMenu(
+        e,
+        icon,
+      );
+      new window.ContextMenu(menuItems, e);
     },
     onBackgroundContext: (e) => {
-      showDesktopContextMenu(e, {
-        selectedIcons: iconManager.selectedIcons,
-        clearSelection: () => iconManager.clearSelection(),
-      });
+      const menuItems = desktopController.contextMenuBuilder.buildBackgroundMenu(
+        e,
+      );
+      new window.ContextMenu(menuItems, e);
+    },
+    onSelectionChange: () => {
+      desktopController.handleSelectionChange();
+      updateCutIcons();
     },
   });
 
-  // A function to refresh icons, bound to the correct scope
-  desktop.refreshIcons = (sortedContents, isFromSort = false) =>
-    setupIcons({ iconManager }, sortedContents, isFromSort);
+  desktop.addEventListener("dblclick", (e) => {
+    const icon = e.target.closest(".explorer-icon");
+    if (icon) {
+      const path = icon.getAttribute("data-path");
+      desktopController.onOpen(path);
+    }
+  });
 
-  desktop.refreshIcons();
+  // A function to refresh icons, bound to the correct scope
+  desktop.refreshIcons = () => refreshIcons();
+
+  await refreshIcons();
 
   document.addEventListener("theme-changed", () => {
-    desktop.refreshIcons();
+    refreshIcons();
     applyWallpaper();
   });
 
   document.addEventListener("desktop-refresh", () => {
-    desktop.refreshIcons();
+    refreshIcons();
   });
 
-  document.addEventListener("clipboard-change", () => {
-    const { items, operation } = clipboardManager.get();
+  document.addEventListener("clipboard-change", updateCutIcons);
 
-    // First, remove 'cut' style from all icons
-    desktop.querySelectorAll(".desktop-icon.cut").forEach((icon) => {
-      icon.classList.remove("cut");
-    });
-
-    if (operation === "cut") {
-      items.forEach((item) => {
-        let icon;
-        if (item.itemType === "dropped-file") {
-          icon = desktop.querySelector(`[data-file-id="${item.id}"]`);
-        } else if (item.itemType === "virtual-file") {
-          const iconId = getIconId(item, item.path);
-          icon = desktop.querySelector(`[data-icon-id="${iconId}"]`);
-        } else if (item.itemType === "app") {
-          const iconId = getIconId(item);
-          icon = desktop.querySelector(`[data-icon-id="${iconId}"]`);
-        }
-        if (icon) {
-          icon.classList.add("cut");
-        }
-      });
-    }
+  document.addEventListener("recycle-bin-change", () => {
+    refreshIcons();
   });
 
-  // Add click handler to desktop to deselect icons
-  desktop.addEventListener("click", (e) => {
-    if (iconManager.wasLassoing) {
-      return;
-    }
-    if (e.target === desktop && !e.target.closest(".desktop-icon")) {
-      // iconManager.clearSelection();
-      // if (clipboardManager.operation === "cut") {
-      //   clipboardManager.clear();
-      // }
-    }
-  });
-
-  init(); // Initialize the taskbar manager
+  initTaskbar();
 
   const launchStartupApps = async () => {
     if (profile) {
-      // Launch apps from profile
       if (profile.startup && profile.startup.length > 0) {
         profile.startup.forEach((app) => {
           const appId = typeof app === "string" ? app : app.appId;
@@ -1161,7 +525,6 @@ export async function initDesktop(profile = null) {
         });
       }
     } else {
-      // Launch startup apps from storage
       const startupApps = await getStartupApps();
       if (startupApps && startupApps.length > 0) {
         startupApps.forEach((appId) => {
@@ -1177,55 +540,21 @@ export async function initDesktop(profile = null) {
 
   document.addEventListener("wallpaper-changed", applyWallpaper);
 
-  // Drag and drop functionality
-  desktop.addEventListener("dragover", (e) => {
-    e.preventDefault(); // Allow drop
+  // FS change listener
+  document.addEventListener("fs-change", (e) => {
+    if (e.detail?.sourceAppId === "desktop") return;
+    refreshIcons();
   });
 
+  // Layout change listener
+  document.addEventListener("layout-change", (e) => {
+    if (e.detail.sourceAppId === "desktop") return;
+    if (e.detail.path === "/Desktop") refreshIcons();
+  });
+
+  // Native drop handler
+  desktop.addEventListener("dragover", (e) => e.preventDefault());
   desktop.addEventListener("drop", (e) => {
     e.preventDefault();
-
-    // Handle files dragged from within the app
-    const jsonData = e.dataTransfer.getData("application/json");
-    if (jsonData) {
-      const data = JSON.parse(jsonData);
-      const { items, cursorOffsetX, cursorOffsetY, dragOffsets, sourcePath } =
-        data;
-      if (sourcePath === SPECIAL_FOLDER_PATHS.desktop) {
-        if (isAutoArrangeEnabled()) {
-          // When auto-arranging, dropping an icon should just snap it back to the grid.
-          // The same logic that runs when toggling the option on.
-          removeItem(LOCAL_STORAGE_KEYS.ICON_POSITIONS);
-          desktop.refreshIcons();
-        } else {
-          // This is a manual rearrange operation
-          const desktopRect = desktop.getBoundingClientRect();
-          const primaryIconX = e.clientX - desktopRect.left - cursorOffsetX;
-          const primaryIconY = e.clientY - desktopRect.top - cursorOffsetY;
-
-          const iconPositions =
-            getItem(LOCAL_STORAGE_KEYS.ICON_POSITIONS) || {};
-          (dragOffsets || []).forEach((offset) => {
-            iconPositions[offset.id] = {
-              x: `${primaryIconX + offset.offsetX}px`,
-              y: `${primaryIconY + offset.offsetY}px`,
-            };
-          });
-
-          setItem(LOCAL_STORAGE_KEYS.ICON_POSITIONS, iconPositions);
-          desktop.refreshIcons();
-        }
-        return;
-      }
-      pasteItems("/drive-c/folder-user/folder-desktop", items, "cut");
-      return; // Stop processing
-    }
-
-    // Handle files dragged from the user's OS
-    const files = e.dataTransfer.files;
-    if (files.length > 0) {
-      // File drops on the desktop are disabled.
-      // Users should use "My Briefcase".
-    }
   });
 }

--- a/src/styles/desktop.css
+++ b/src/styles/desktop.css
@@ -79,10 +79,11 @@ html {
     overflow: hidden;
     display: grid;
     grid-auto-flow: column;
-    grid-template-rows: repeat(auto-fill, 60px);
-    grid-auto-columns: 60px;
-    gap: 5px;
+    grid-template-rows: repeat(auto-fill, 80px);
+    grid-auto-columns: 75px;
+    gap: 0;
     align-content: start;
+    padding: 5px;
 }
 
 /* When dragging, disable grid so icons stay put */
@@ -90,30 +91,14 @@ html {
     display: block;
 }
 
-.desktop-icon {
-    width: 70px;
-    text-align: center;
-    color: var(--HilightText);
-    margin: 3px;
-    /*z-index: 1; /* Ensure icons are on top of other elements */
+.desktop .explorer-icon {
+    color: white;
+    text-shadow: 1px 1px 1px black;
 }
 
-.desktop-icon .icon {
-    display: block;
-    /* width: 32px;
-    height: 32px; */
-    margin: auto;
-}
-
-.desktop-icon .icon img {
-    width: 32px;
-    height: 32px;
-}
-
-.desktop-icon .icon-label {
-    font-family: var(--font-family-menu);
-    font-size: var(--font-size-menu);
-    overflow-wrap: break-word;
+.desktop .explorer-icon .icon-label {
+    white-space: normal;
+    word-break: break-word;
 }
 
 .highlighted-icon {
@@ -125,14 +110,8 @@ html {
     color: var(--highlight-text);
 }
 
-.icon-label.selected {
-    border: 1px dotted var(--HilightText);
-    height: auto; /* Allow height to be controlled by content/JS */
-    min-height: 1.2em; /* Ensure at least one line is visible */
-    white-space: normal !important; /* Allow text to wrap */
-    word-break: break-word; /* Ensure long words break */
-    line-height: 1.2; /* Adjust line height for better appearance */
-    padding: 2px; /* Add some padding for better text visibility */
+.desktop .explorer-icon.selected .icon-label {
+    text-shadow: none;
 }
 
 .lasso {

--- a/src/utils/customAppManager.js
+++ b/src/utils/customAppManager.js
@@ -4,7 +4,7 @@ import { renderHTML } from './domUtils.js';
 import { Application } from '../apps/Application.js';
 import { apps, appClasses } from '../config/apps.js';
 import { ICONS } from '../config/icons.js';
-import { addDesktopShortcut, removeDesktopShortcut } from './directory.js';
+import { addDesktopShortcut, removeDesktopShortcut } from './zenfs-utils.js';
 import { launchApp } from './appManager.js';
 import { addToRecycleBin } from './recycleBinManager.js';
 

--- a/src/utils/directory.js
+++ b/src/utils/directory.js
@@ -25,88 +25,12 @@ function findNodeById(nodes, id) {
   return null;
 }
 
-function findDesktopFolder() {
-  const driveC = directory.find((d) => d.id === "drive-c");
-  if (driveC && driveC.children) {
-    const userFolder = driveC.children.find((f) => f.id === "folder-user");
-    if (userFolder && userFolder.children) {
-      return userFolder.children.find((f) => f.id === "folder-desktop");
-    }
-  }
-  return null;
-}
-
 function findProgramFilesFolder() {
   const driveC = directory.find((d) => d.id === "drive-c");
   if (driveC && driveC.children) {
     return driveC.children.find((f) => f.id === "folder-program-files");
   }
   return null;
-}
-
-export function getDesktopContents() {
-  const desktopFolder = findDesktopFolder();
-  if (!desktopFolder || !desktopFolder.children) {
-    return [];
-  }
-
-  const systemIcons = new Set([
-    "my-computer",
-    "my-documents",
-    "recycle-bin",
-    "network-neighborhood",
-    "my-briefcase",
-  ]);
-
-  const desktopItems = desktopFolder.children.map((item) => {
-    if (item.type === "app") {
-      const appConfig = apps.find((a) => a.id === item.appId);
-      if (appConfig) {
-        return {
-          id: appConfig.id,
-          name: appConfig.title,
-          type: "app",
-          isSystemIcon: systemIcons.has(appConfig.id),
-          appId: appConfig.id, // Keep appId for setupIcons
-        };
-      }
-    } else if (item.type === "shortcut") {
-      const targetNode = findNodeById(directory, item.targetId);
-      if (targetNode && targetNode.type === "app") {
-        const appConfig = apps.find((a) => a.id === targetNode.appId);
-        if (appConfig) {
-          return {
-            id: item.id,
-            name: item.name,
-            type: "shortcut",
-            app: appConfig.id,
-            path: `/${item.id}`,
-            icon: appConfig.icon,
-          };
-        }
-      }
-    } else if (item.type === "file") {
-      const association = getAssociation(item.name);
-      return {
-        id: item.id,
-        name: item.name,
-        type: "file",
-        app: association.appId,
-        path: item.contentUrl,
-      };
-    } else if (item.type === "folder") {
-      return {
-        id: item.id,
-        name: item.name,
-        type: "folder",
-        app: "explorer",
-        path: `/drive-c/folder-user/folder-desktop/${item.id}`,
-      };
-    }
-    return null;
-  });
-
-  return desktopItems.filter(Boolean);
 }
 
 export function addAppDefinition(appId) {
@@ -207,32 +131,3 @@ export function findItemByPath(path) {
   return currentItem;
 }
 
-export function addDesktopShortcut(appId, appTitle) {
-  const targetId = addAppDefinition(appId); // Ensure app def exists
-  const desktopFolder = findDesktopFolder();
-
-  if (desktopFolder && desktopFolder.children && targetId) {
-    const shortcut = {
-      id: `shortcut-to-${appId}`,
-      type: "shortcut",
-      targetId: targetId,
-      name: appTitle,
-    };
-    const exists = desktopFolder.children.some((c) => c.id === shortcut.id);
-    if (!exists) {
-      desktopFolder.children.push(shortcut);
-    }
-  }
-}
-
-export function removeDesktopShortcut(appId) {
-  removeAppDefinition(appId); // Also remove the app def
-  const desktopFolder = findDesktopFolder();
-  if (desktopFolder && desktopFolder.children) {
-    const shortcutId = `shortcut-to-${appId}`;
-    const index = desktopFolder.children.findIndex((c) => c.id === shortcutId);
-    if (index > -1) {
-      desktopFolder.children.splice(index, 1);
-    }
-  }
-}

--- a/src/utils/iconUtils.js
+++ b/src/utils/iconUtils.js
@@ -1,10 +1,9 @@
 import { getItem, LOCAL_STORAGE_KEYS } from "./localStorage.js";
-import { getDesktopContents } from "./directory.js";
 import { apps } from "../config/apps.js";
 
 export function getItemFromIcon(icon) {
   const fileId = icon.getAttribute("data-file-id");
-  const filePath = icon.getAttribute("data-file-path");
+  // const filePath = icon.getAttribute("data-file-path");
   const appId = icon.getAttribute("data-app-id");
 
   if (fileId) {
@@ -13,22 +12,9 @@ export function getItemFromIcon(icon) {
     return { ...file, itemType: "dropped-file", source: "desktop" };
   }
 
-  const desktopContents = getDesktopContents();
-
-  if (filePath) {
-    const file = desktopContents.find(
-      (item) => item.path === filePath && item.type !== "app",
-    );
-    if (file) {
-      return { ...file, itemType: "virtual-file", source: "desktop" };
-    }
-  }
-
+  // getDesktopContents removed, this utility is legacy
   const appItem = apps.find((a) => a.id === appId);
-  const isDesktopApp = desktopContents.some(
-    (item) => item.id === appId && item.type === "app",
-  );
-  if (appItem && isDesktopApp) {
+  if (appItem) {
     return { ...appItem, itemType: "app", source: "desktop" };
   }
 

--- a/src/utils/zenfs-utils.js
+++ b/src/utils/zenfs-utils.js
@@ -107,3 +107,55 @@ export async function existsAsync(path) {
         return false;
     }
 }
+
+/**
+ * Adds a shortcut to the desktop (/C:/WINDOWS/Desktop).
+ * @param {string} appId The ID of the app to add.
+ * @param {string} appTitle The title of the shortcut.
+ */
+export async function addDesktopShortcut(appId, appTitle) {
+  const desktopPath = "/C:/WINDOWS/Desktop";
+  try {
+    if (!(await existsAsync(desktopPath))) {
+      await fs.promises.mkdir(desktopPath, { recursive: true });
+    }
+    const lnkPath = `${desktopPath}/${appTitle}.lnk`;
+
+    if (!(await existsAsync(lnkPath))) {
+      await fs.promises.writeFile(lnkPath, JSON.stringify({
+        type: "shortcut",
+        appId: appId,
+      }, null, 2));
+      document.dispatchEvent(new CustomEvent("fs-change", { detail: { path: lnkPath } }));
+    }
+  } catch (error) {
+    console.error("Failed to add desktop shortcut to ZenFS", error);
+  }
+}
+
+/**
+ * Removes a shortcut from the desktop (/C:/WINDOWS/Desktop).
+ * @param {string} appId The ID of the app to remove.
+ */
+export async function removeDesktopShortcut(appId) {
+  const desktopPath = "/C:/WINDOWS/Desktop";
+  try {
+    if (await existsAsync(desktopPath)) {
+      const files = await fs.promises.readdir(desktopPath);
+      for (const file of files) {
+        if (file.endsWith(".lnk")) {
+          const content = await fs.promises.readFile(`${desktopPath}/${file}`, "utf8");
+          try {
+            const data = JSON.parse(content);
+            if (data.appId === appId) {
+              await fs.promises.unlink(`${desktopPath}/${file}`);
+            }
+          } catch (e) {}
+        }
+      }
+      document.dispatchEvent(new CustomEvent("fs-change", { detail: { path: desktopPath } }));
+    }
+  } catch (error) {
+    console.error("Failed to remove desktop shortcut from ZenFS", error);
+  }
+}


### PR DESCRIPTION
This change modernizes the desktop component by unifying its logic with the ZenExplorer ecosystem. The desktop now reads its content from the ZenFS `/Desktop` virtual path (mapped to `/C:/WINDOWS/Desktop`), renders icons using the same logic as ZenExplorer, and integrates with `DragDropManager` for file management. 

A specialized `DesktopContextMenuBuilder` has been created to provide both file-level operations and system-wide settings like Wallpaper and Screen Resolution in the desktop background menu. 

Legacy code in `directory.js` that managed the desktop via static configuration has been removed, and custom application management has been updated to use ZenFS shortcuts. 

Automated E2E tests have been added to ensure the desktop remains functional and correctly integrates with ZenExplorer features.

---
*PR created automatically by Jules for task [11141645742278982716](https://jules.google.com/task/11141645742278982716) started by @azayrahmad*