### PR TITLE
Fix Zen Explorer responsive title and sidebar width

### DIFF
--- a/src/apps/explorer/explorer.css
+++ b/src/apps/explorer/explorer.css
@@ -20,6 +20,7 @@
 .explorer-sidebar {
     display: none; /* Hidden by default */
     width: 30%;
+    max-width: 250px;
     box-sizing: border-box;
     flex-shrink: 0;
     word-wrap: break-word;

--- a/src/apps/zenexplorer/ZenExplorerApp.js
+++ b/src/apps/zenexplorer/ZenExplorerApp.js
@@ -174,14 +174,20 @@ export class ZenExplorerApp extends Application {
     this.sidebar = new Sidebar();
     content.appendChild(this.sidebar.element);
 
-    // 4b. Icon View
+    // 4b. Title (for small width)
+    this.titleElement = document.createElement("h1");
+    this.titleElement.className = "explorer-title";
+    this.titleElement.style.fontFamily = "Verdana, sans-serif";
+    content.appendChild(this.titleElement);
+
+    // 4c. Icon View
     this.iconContainer = document.createElement("div");
     this.iconContainer.className = `explorer-icon-view ${this.viewMode}-icons`;
     content.appendChild(this.iconContainer);
 
     win.$content.append(content);
 
-    // 4c. Resize Observer for responsive layout
+    // 4d. Resize Observer for responsive layout
     this._setupResizeObserver();
 
     // 5. Status Bar

--- a/src/apps/zenexplorer/interface/DirectoryView.js
+++ b/src/apps/zenexplorer/interface/DirectoryView.js
@@ -55,6 +55,7 @@ export class DirectoryView {
     this.app.addressBar.setValue(formatPathForDisplay(path));
     this.app.win.title(name);
     this.app.sidebar.update(name, icon[32]);
+    this.app.titleElement.textContent = name;
     this.app.win.setIcons(icon);
   }
 


### PR DESCRIPTION
This PR fixes two issues in Zen Explorer:
1. On smaller window sizes, the sidebar is hidden but the folder title was not being shown. I added an `explorer-title` element to `ZenExplorerApp` and ensured it's updated in `DirectoryView`.
2. The sidebar now has a `max-width` of 250px while maintaining its 30% relative width.

Verified with Playwright screenshots for both large and small window modes.

---
*PR created automatically by Jules for task [10605514643454432556](https://jules.google.com/task/10605514643454432556) started by @azayrahmad*