### PR TITLE
Implement .lnk shortcut creation and handling

### DIFF
--- a/src/apps/zenexplorer/ZenExplorerApp.js
+++ b/src/apps/zenexplorer/ZenExplorerApp.js
@@ -321,6 +321,36 @@ export class ZenExplorerApp extends Application {
     const handled = await ShellManager.onOpen(fullPath, this);
     if (handled) return;
 
+    // Handle .lnk files
+    if (name.endsWith(".lnk")) {
+      try {
+        const content = await fs.promises.readFile(ShellManager.getRealPath(fullPath), "utf8");
+        const data = JSON.parse(content);
+        if (data.type === "shortcut") {
+          if (data.appId) {
+            launchApp(data.appId, data.args);
+            return;
+          } else if (data.targetPath) {
+            const stats = await ShellManager.stat(data.targetPath);
+            if (stats.isDirectory()) {
+              this.navigateTo(data.targetPath);
+            } else {
+              const targetName = data.targetPath.split("/").pop();
+              const association = getAssociation(targetName);
+              if (association.appId) {
+                launchApp(association.appId, data.targetPath);
+              } else {
+                alert(`Cannot open file: ${targetName} (No association)`);
+              }
+            }
+            return;
+          }
+        }
+      } catch (e) {
+        console.error("Failed to open shortcut", e);
+      }
+    }
+
     const association = getAssociation(name);
     if (association.appId) {
       launchApp(association.appId, fullPath);

--- a/src/apps/zenexplorer/extensions/DesktopExtension.js
+++ b/src/apps/zenexplorer/extensions/DesktopExtension.js
@@ -164,6 +164,8 @@ export class DesktopExtension {
 
       const stats = await fs.promises.stat(realFullPath);
       if (!stats.isDirectory()) {
+        if (name.endsWith(".lnk")) return false; // Let the app handle shortcuts
+
         const { getAssociation } = await import("../../../utils/directory.js");
         const { launchApp } = await import("../../../utils/appManager.js");
         const association = getAssociation(name);

--- a/src/apps/zenexplorer/fileoperations/FileOperations.js
+++ b/src/apps/zenexplorer/fileoperations/FileOperations.js
@@ -28,6 +28,46 @@ export class FileOperations {
         ClipboardManager.set(paths, "copy");
     }
 
+    async createShortcuts(paths, destinationPath = null) {
+        const dest = destinationPath || this.app.currentPath;
+        const targetPaths = [];
+        try {
+            for (const itemPath of paths) {
+                const itemName = getPathName(itemPath);
+                const targetLnkPath = await this.getUniquePastePath(dest, itemName, "shortcut");
+
+                let lnkData = { type: "shortcut" };
+
+                // Check if it's already a shortcut with an appId
+                const stats = await ShellManager.stat(itemPath).catch(() => ({}));
+                if (stats.isFile && stats.isFile() && itemPath.endsWith(".lnk")) {
+                    try {
+                        const content = await fs.promises.readFile(ShellManager.getRealPath(itemPath), "utf8");
+                        const data = JSON.parse(content);
+                        if (data.appId) {
+                            lnkData.appId = data.appId;
+                            lnkData.args = data.args;
+                        } else {
+                            lnkData.targetPath = data.targetPath || itemPath;
+                        }
+                    } catch (e) {
+                        lnkData.targetPath = itemPath;
+                    }
+                } else {
+                    lnkData.targetPath = itemPath;
+                }
+
+                await fs.promises.writeFile(ShellManager.getRealPath(targetLnkPath), JSON.stringify(lnkData, null, 2));
+                targetPaths.push(targetLnkPath);
+            }
+
+            await this.app.navigateTo(this.app.currentPath, true, true);
+            document.dispatchEvent(new CustomEvent("fs-change", { detail: { sourceAppId: this.app.win.element.id } }));
+        } catch (e) {
+            handleFileSystemError("create", e, "shortcut");
+        }
+    }
+
     async pasteItems(destinationPath) {
         const { items, operation } = ClipboardManager.get();
         if (items.length === 0) return;
@@ -153,6 +193,21 @@ export class FileOperations {
                     counter++;
                 } catch (e) { return checkPath; }
             }
+        } else if (operation === "shortcut") {
+            let candidateName = `Shortcut to ${originalName}.lnk`;
+            checkPath = normalizePath(joinPath(destPath, candidateName));
+            try {
+                await fs.promises.stat(ShellManager.getRealPath(checkPath));
+                let counter = 2;
+                while (true) {
+                    candidateName = `Shortcut (${counter}) to ${originalName}.lnk`;
+                    checkPath = normalizePath(joinPath(destPath, candidateName));
+                    try {
+                        await fs.promises.stat(ShellManager.getRealPath(checkPath));
+                        counter++;
+                    } catch (e) { return checkPath; }
+                }
+            } catch (e) { return checkPath; }
         } else {
             const copyNOfRegex = /^Copy \((\d+)\) of (.*)$/;
             const copyOfRegex = /^Copy of (.*)$/;

--- a/src/apps/zenexplorer/fileoperations/FileOperations.js
+++ b/src/apps/zenexplorer/fileoperations/FileOperations.js
@@ -172,6 +172,23 @@ export class FileOperations {
     }
 
     async getUniquePastePath(destPath, originalName, operation) {
+        if (operation === "shortcut") {
+            let candidateName = `Shortcut to ${originalName}.lnk`;
+            let checkPath = normalizePath(joinPath(destPath, candidateName));
+            try {
+                await fs.promises.stat(ShellManager.getRealPath(checkPath));
+                let counter = 2;
+                while (true) {
+                    candidateName = `Shortcut (${counter}) to ${originalName}.lnk`;
+                    checkPath = normalizePath(joinPath(destPath, candidateName));
+                    try {
+                        await fs.promises.stat(ShellManager.getRealPath(checkPath));
+                        counter++;
+                    } catch (e) { return checkPath; }
+                }
+            } catch (e) { return checkPath; }
+        }
+
         let checkPath = normalizePath(joinPath(destPath, originalName));
         try {
             await fs.promises.stat(ShellManager.getRealPath(checkPath));
@@ -193,21 +210,6 @@ export class FileOperations {
                     counter++;
                 } catch (e) { return checkPath; }
             }
-        } else if (operation === "shortcut") {
-            let candidateName = `Shortcut to ${originalName}.lnk`;
-            checkPath = normalizePath(joinPath(destPath, candidateName));
-            try {
-                await fs.promises.stat(ShellManager.getRealPath(checkPath));
-                let counter = 2;
-                while (true) {
-                    candidateName = `Shortcut (${counter}) to ${originalName}.lnk`;
-                    checkPath = normalizePath(joinPath(destPath, candidateName));
-                    try {
-                        await fs.promises.stat(ShellManager.getRealPath(checkPath));
-                        counter++;
-                    } catch (e) { return checkPath; }
-                }
-            } catch (e) { return checkPath; }
         } else {
             const copyNOfRegex = /^Copy \((\d+)\) of (.*)$/;
             const copyOfRegex = /^Copy of (.*)$/;

--- a/src/apps/zenexplorer/interface/ContextMenuBuilder.js
+++ b/src/apps/zenexplorer/interface/ContextMenuBuilder.js
@@ -1,4 +1,5 @@
 import { mounts } from "@zenfs/core";
+import { ICONS } from "../../../config/icons.js";
 import {
   requestBusyState,
   releaseBusyState,
@@ -135,6 +136,18 @@ export class ContextMenuBuilder {
       menuItems.push(
         "MENU_DIVIDER",
         {
+          label: "Send to",
+          enabled: () => !isRootItem && !isRecycleBin && !anyVirtual,
+          submenu: [
+            {
+              label: "Desktop (create shortcut)",
+              icon: ICONS.desktop_old[16],
+              action: () => this.app.fileOps.createShortcuts(selectedPaths, "/C:/WINDOWS/Desktop"),
+            },
+          ],
+        },
+        "MENU_DIVIDER",
+        {
           label: "Cut",
           action: () => this.app.fileOps.cutItems(selectedPaths),
           enabled: () => !isRootItem && !isRecycleBin && !anyVirtual,
@@ -149,6 +162,11 @@ export class ContextMenuBuilder {
           action: () => this.app.fileOps.pasteItems(path),
           enabled: () =>
             !ClipboardManager.isEmpty() && type === "directory",
+        },
+        {
+          label: "Create Shortcut",
+          action: () => this.app.fileOps.createShortcuts(selectedPaths),
+          enabled: () => !isRootItem && !isRecycleBin && !anyVirtual,
         },
         "MENU_DIVIDER",
         {

--- a/src/apps/zenexplorer/interface/FileIconRenderer.js
+++ b/src/apps/zenexplorer/interface/FileIconRenderer.js
@@ -1,6 +1,6 @@
 import { ICONS, SHORTCUT_OVERLAY } from "../../../config/icons.js";
 import { getAssociation } from "../../../utils/directory.js";
-import { getDisplayName } from "../navigation/PathUtils.js";
+import { getDisplayName, getPathName } from "../navigation/PathUtils.js";
 import { RecycleBinManager } from "../fileoperations/RecycleBinManager.js";
 import { ShellManager } from "../extensions/ShellManager.js";
 import { fs } from "@zenfs/core";
@@ -97,11 +97,14 @@ export async function renderFileIcon(fileName, fullPath, isDir, options = {}) {
             iconObj = app.icon;
           }
         } else if (data.targetPath) {
-          try {
-            const targetStats = await ShellManager.stat(data.targetPath);
-            iconObj = getIconObjForFile(getPathName(data.targetPath), targetStats.isDirectory());
-          } catch (e) {
-            iconObj = ICONS.file;
+          iconObj = ShellManager.getIconObj(data.targetPath);
+          if (!iconObj) {
+            try {
+              const targetStats = await ShellManager.stat(data.targetPath);
+              iconObj = getIconObjForFile(getPathName(data.targetPath), targetStats.isDirectory());
+            } catch (e) {
+              iconObj = ICONS.file;
+            }
           }
         }
       }

--- a/src/apps/zenexplorer/interface/FileIconRenderer.js
+++ b/src/apps/zenexplorer/interface/FileIconRenderer.js
@@ -88,7 +88,7 @@ export async function renderFileIcon(fileName, fullPath, isDir, options = {}) {
   if (!isDir && fileName.endsWith(".lnk")) {
     isShortcut = true;
     try {
-      const content = await fs.promises.readFile(fullPath, "utf8");
+      const content = await fs.promises.readFile(ShellManager.getRealPath(fullPath), "utf8");
       const data = JSON.parse(content);
       if (data.type === "shortcut") {
         if (data.appId) {

--- a/src/apps/zenexplorer/interface/FileIconRenderer.js
+++ b/src/apps/zenexplorer/interface/FileIconRenderer.js
@@ -90,10 +90,19 @@ export async function renderFileIcon(fileName, fullPath, isDir, options = {}) {
     try {
       const content = await fs.promises.readFile(fullPath, "utf8");
       const data = JSON.parse(content);
-      if (data.type === "shortcut" && data.appId) {
-        const app = apps.find((a) => a.id === data.appId);
-        if (app) {
-          iconObj = app.icon;
+      if (data.type === "shortcut") {
+        if (data.appId) {
+          const app = apps.find((a) => a.id === data.appId);
+          if (app) {
+            iconObj = app.icon;
+          }
+        } else if (data.targetPath) {
+          try {
+            const targetStats = await ShellManager.stat(data.targetPath);
+            iconObj = getIconObjForFile(getPathName(data.targetPath), targetStats.isDirectory());
+          } catch (e) {
+            iconObj = ICONS.file;
+          }
         }
       }
     } catch (e) {

--- a/src/components/desktop.js
+++ b/src/components/desktop.js
@@ -287,6 +287,37 @@ class DesktopController {
     });
     if (handled) return;
 
+    const name = path.split("/").pop();
+    if (name.endsWith(".lnk")) {
+      try {
+        const content = await fs.promises.readFile(ShellManager.getRealPath(path), "utf8");
+        const data = JSON.parse(content);
+        if (data.type === "shortcut") {
+          if (data.appId) {
+            launchApp(data.appId, data.args);
+            return;
+          } else if (data.targetPath) {
+            const stats = await ShellManager.stat(data.targetPath);
+            if (stats.isDirectory()) {
+              launchApp("zenexplorer", data.targetPath);
+            } else {
+              const targetName = data.targetPath.split("/").pop();
+              const { getAssociation } = await import("../utils/directory.js");
+              const association = getAssociation(targetName);
+              if (association.appId) {
+                launchApp(association.appId, data.targetPath);
+              } else {
+                alert(`Cannot open file: ${targetName} (No association)`);
+              }
+            }
+            return;
+          }
+        }
+      } catch (e) {
+        console.error("Failed to open shortcut", e);
+      }
+    }
+
     const stat = await ShellManager.stat(path);
     if (stat.isDirectory()) {
       launchApp("zenexplorer", path);

--- a/src/utils/startMenuUtils.js
+++ b/src/utils/startMenuUtils.js
@@ -59,13 +59,46 @@ export async function loadLnk(path, iconSize = 16) {
     const label = filename.replace(".lnk", "");
     const content = await fs.promises.readFile(path, "utf8");
     const data = JSON.parse(content);
-    const app = apps.find((a) => a.id === data.appId);
 
-    return {
-      label: label,
-      icon: app ? app.icon[iconSize] : ICONS.file[iconSize],
-      action: () => launchApp(data.appId, data.args),
-    };
+    if (data.appId) {
+      const app = apps.find((a) => a.id === data.appId);
+      return {
+        label: label,
+        icon: app ? app.icon[iconSize] : ICONS.file[iconSize],
+        action: () => launchApp(data.appId, data.args),
+      };
+    } else if (data.targetPath) {
+      const targetName = data.targetPath.split("/").pop();
+      let icon = ICONS.file[iconSize];
+      let action = () => {};
+
+      try {
+        const stats = await fs.promises.stat(data.targetPath);
+        if (stats.isDirectory()) {
+          icon = ICONS.folderClosed[iconSize];
+          action = () => launchApp("zenexplorer", data.targetPath);
+        } else {
+          const association = getAssociation(targetName);
+          if (association) {
+            icon = association.icon[iconSize];
+            action = () => launchApp(association.appId, data.targetPath);
+          } else {
+            icon = ICONS.file[iconSize];
+            action = () => launchApp("notepad", data.targetPath);
+          }
+        }
+      } catch (e) {
+        console.warn(`Shortcut target not found: ${data.targetPath}`);
+      }
+
+      return {
+        label: label,
+        icon: icon,
+        action: action,
+      };
+    }
+
+    return null;
   } catch (error) {
     console.error(`Failed to load shortcut: ${path}`, error);
     return null;


### PR DESCRIPTION
This change implements a comprehensive system for creating and handling `.lnk` shortcut files in ZenExplorer and on the Desktop. 

Key features:
1. **Shortcut Creation**: Users can now create shortcuts in the same directory or send them to the Desktop via the context menu.
2. **Naming Convention**: Implements the requested `Shortcut to [Name].lnk` pattern, including a counter system for duplicates (e.g., `Shortcut (2) to [Name].lnk`).
3. **Smart Handling**: Shortcuts automatically use `appId` for registered applications and `targetPath` for regular files and folders.
4. **Visual Feedback**: Shortcuts are rendered with the correct target icon and a shortcut overlay.
5. **Functional Opening**: Double-clicking a shortcut correctly navigates to folders or launches files with their associated applications.
6. **Start Menu Support**: Consistency is maintained by updating the shared `loadLnk` utility used by the Start Menu.

Verified with Playwright E2E tests.

---
*PR created automatically by Jules for task [2983070499108458892](https://jules.google.com/task/2983070499108458892) started by @azayrahmad*