### PR TITLE
Add support for hosting C: drive in a local folder

### DIFF
--- a/src/apps/zenexplorer/fileoperations/PropertiesManager.js
+++ b/src/apps/zenexplorer/fileoperations/PropertiesManager.js
@@ -353,47 +353,53 @@ export class PropertiesManager {
    * @private
    */
   static async _addStorageSection(container) {
-      const separator = document.createElement("div");
-      separator.style.borderBottom = "1px solid #808080";
-      separator.style.margin = "15px 0 10px 0";
-      container.appendChild(separator);
+    const fieldset = document.createElement("fieldset");
+    fieldset.style.marginTop = "15px";
+    fieldset.style.padding = "10px";
+    fieldset.style.border = "1px solid #808080";
 
-      const title = document.createElement("div");
-      title.textContent = "Storage Settings";
-      title.style.fontWeight = "bold";
-      title.style.marginBottom = "10px";
-      title.style.fontSize = "11px";
-      container.appendChild(title);
+    const legend = document.createElement("legend");
+    legend.textContent = "Storage Settings";
+    legend.style.fontSize = "11px";
+    fieldset.appendChild(legend);
 
-      const storageInfo = document.createElement("div");
-      storageInfo.style.fontSize = "11px";
-      storageInfo.style.marginBottom = "10px";
+    const storageInfo = document.createElement("div");
+    storageInfo.style.fontSize = "11px";
+    storageInfo.style.marginBottom = "10px";
 
-      const handle = await getLocalFolderHandle();
-      const isLocal = !!handle;
+    const handle = await getLocalFolderHandle();
+    const isLocal = !!handle;
 
-      storageInfo.textContent = `Current storage: ${isLocal ? "Local Folder" : "IndexedDB (Browser)"}`;
-      container.appendChild(storageInfo);
+    storageInfo.textContent = `Current storage: ${isLocal ? "Local Folder" : "IndexedDB (Browser)"}`;
+    fieldset.appendChild(storageInfo);
 
-      if (isFileSystemAccessSupported()) {
-          const switchBtn = document.createElement("button");
-          switchBtn.textContent = isLocal ? "Switch to IndexedDB..." : "Switch to Local Folder...";
-          switchBtn.style.padding = "2px 10px";
-          switchBtn.onclick = async () => {
-              const { switchToLocalFolder, switchToIndexedDB } = await import("../../../utils/storageSwitch.js");
-              if (isLocal) {
-                  await switchToIndexedDB();
-              } else {
-                  await switchToLocalFolder();
-              }
-          };
-          container.appendChild(switchBtn);
-      } else {
-          const unsupported = document.createElement("div");
-          unsupported.textContent = "Local folder storage is not supported in this browser.";
-          unsupported.style.color = "#800000";
-          unsupported.style.fontSize = "10px";
-          container.appendChild(unsupported);
-      }
+    if (isFileSystemAccessSupported()) {
+      const switchBtn = document.createElement("button");
+      switchBtn.textContent = isLocal
+        ? "Switch to IndexedDB..."
+        : "Switch to Local Folder...";
+      switchBtn.style.padding = "2px 10px";
+      switchBtn.style.fontSize = "11px";
+      switchBtn.onclick = async () => {
+        const { switchToLocalFolder, switchToIndexedDB } = await import(
+          "../../../utils/storageSwitch.js"
+        );
+        if (isLocal) {
+          await switchToIndexedDB();
+        } else {
+          await switchToLocalFolder();
+        }
+      };
+      fieldset.appendChild(switchBtn);
+    } else {
+      const unsupported = document.createElement("div");
+      unsupported.textContent =
+        "Local folder storage is not supported in this browser.";
+      unsupported.style.color = "#800000";
+      unsupported.style.fontSize = "10px";
+      fieldset.appendChild(unsupported);
+    }
+
+    container.appendChild(fieldset);
   }
 }

--- a/src/apps/zenexplorer/fileoperations/PropertiesManager.js
+++ b/src/apps/zenexplorer/fileoperations/PropertiesManager.js
@@ -11,6 +11,7 @@ import {
 import { getIconForFile } from "../interface/FileIconRenderer.js";
 import { RecycleBinManager } from "./RecycleBinManager.js";
 import { ShellManager } from "../extensions/ShellManager.js";
+import { getLocalFolderHandle, isFileSystemAccessSupported } from "../../../utils/localFolderUtils.js";
 
 /**
  * PropertiesManager - Handles showing properties for files and folders in ZenExplorer
@@ -96,6 +97,10 @@ export class PropertiesManager {
       modified,
       accessed,
     });
+
+    if (path === "/C:") {
+        await this._addStorageSection(container);
+    }
 
     const win = ShowDialogWindow({
       title: `${name} Properties`,
@@ -341,5 +346,54 @@ export class PropertiesManager {
     container.appendChild(details);
 
     return { container, sizeEl, containsEl };
+  }
+
+  /**
+   * Add storage switch section for C: drive
+   * @private
+   */
+  static async _addStorageSection(container) {
+      const separator = document.createElement("div");
+      separator.style.borderBottom = "1px solid #808080";
+      separator.style.margin = "15px 0 10px 0";
+      container.appendChild(separator);
+
+      const title = document.createElement("div");
+      title.textContent = "Storage Settings";
+      title.style.fontWeight = "bold";
+      title.style.marginBottom = "10px";
+      title.style.fontSize = "11px";
+      container.appendChild(title);
+
+      const storageInfo = document.createElement("div");
+      storageInfo.style.fontSize = "11px";
+      storageInfo.style.marginBottom = "10px";
+
+      const handle = await getLocalFolderHandle();
+      const isLocal = !!handle;
+
+      storageInfo.textContent = `Current storage: ${isLocal ? "Local Folder" : "IndexedDB (Browser)"}`;
+      container.appendChild(storageInfo);
+
+      if (isFileSystemAccessSupported()) {
+          const switchBtn = document.createElement("button");
+          switchBtn.textContent = isLocal ? "Switch to IndexedDB..." : "Switch to Local Folder...";
+          switchBtn.style.padding = "2px 10px";
+          switchBtn.onclick = async () => {
+              const { switchToLocalFolder, switchToIndexedDB } = await import("../../../utils/storageSwitch.js");
+              if (isLocal) {
+                  await switchToIndexedDB();
+              } else {
+                  await switchToLocalFolder();
+              }
+          };
+          container.appendChild(switchBtn);
+      } else {
+          const unsupported = document.createElement("div");
+          unsupported.textContent = "Local folder storage is not supported in this browser.";
+          unsupported.style.color = "#800000";
+          unsupported.style.fontSize = "10px";
+          container.appendChild(unsupported);
+      }
   }
 }

--- a/src/components/bootScreen.js
+++ b/src/components/bootScreen.js
@@ -64,19 +64,23 @@ function removeLastBlinkingCursor() {
     }
 }
 
-function promptToContinue() {
+function promptToContinue(customMessage) {
     return new Promise((resolve) => {
         removeLastBlinkingCursor();
         const bootLogEl = document.getElementById("boot-log");
         if (bootLogEl) {
             const promptEl = document.createElement("div");
             let countdown = 10;
-            promptEl.textContent = `Press any key to continue... ${countdown}`;
+            const updateText = () => {
+                const baseText = customMessage || "Press any key to continue...";
+                promptEl.textContent = `${baseText} ${countdown}`;
+            };
+            updateText();
             bootLogEl.appendChild(promptEl);
 
             const timer = setInterval(() => {
                 countdown--;
-                promptEl.textContent = `Press any key to continue... ${countdown}`;
+                updateText();
                 if (countdown <= 0) {
                     clearInterval(timer);
                     window.removeEventListener("keydown", continueHandler);

--- a/src/main.js
+++ b/src/main.js
@@ -35,6 +35,7 @@ import { initScreenManager } from "./utils/screenManager.js";
 import { fs, mounts } from "@zenfs/core";
 import { initFileSystem } from "./utils/zenfs-init.js";
 import { RecycleBinManager } from "./apps/zenexplorer/fileoperations/RecycleBinManager.js";
+import { getLocalFolderHandle } from "./utils/localFolderUtils.js";
 
 // Window Management System
 class WindowManagerSystem {
@@ -220,11 +221,32 @@ async function initializeOS() {
     await executeBootStep(async () => {
       const baseMsg = "Initializing file system...";
       let logElement = startBootProcessStep(baseMsg);
+
+      let localHandle = null;
+      try {
+        localHandle = await getLocalFolderHandle();
+        if (localHandle) {
+          if (await localHandle.queryPermission({ mode: 'readwrite' }) !== 'granted') {
+            finalizeBootProcessStep(logElement, "WAITING");
+            await promptToContinue("C: drive is linked to a local folder. Press any key to grant access...");
+            try {
+              await localHandle.requestPermission({ mode: 'readwrite' });
+            } catch (e) {
+              console.warn("Permission denied for local folder, falling back to IndexedDB", e);
+              localHandle = null;
+            }
+            logElement = startBootProcessStep(baseMsg);
+          }
+        }
+      } catch (e) {
+        console.error("Error checking local folder handle:", e);
+      }
+
       await initFileSystem((subStep) => {
         if (logElement && logElement.firstChild) {
           logElement.firstChild.nodeValue = `${baseMsg} ${subStep}`;
         }
-      });
+      }, localHandle);
       if (logElement && logElement.firstChild) {
         logElement.firstChild.nodeValue = baseMsg;
       }

--- a/src/utils/localFolderUtils.js
+++ b/src/utils/localFolderUtils.js
@@ -82,3 +82,58 @@ export async function isLocalFolderEnabled() {
 export function isFileSystemAccessSupported() {
     return 'showDirectoryPicker' in window;
 }
+
+const BLOCKED_EXTENSIONS = new Set([
+    'exe', 'com', 'bat', 'cmd', 'vbs', 'vbe', 'jse', 'ws', 'wsf', 'wsh',
+    'msc', 'cpl', 'inf', 'reg', 'url', 'scf', 'jar', 'msi', 'scr', 'pif'
+]);
+
+const BLOCKED_NAMES = new Set([
+    'CON', 'PRN', 'AUX', 'NUL',
+    'COM1', 'COM2', 'COM3', 'COM4', 'COM5', 'COM6', 'COM7', 'COM8', 'COM9',
+    'LPT1', 'LPT2', 'LPT3', 'LPT4', 'LPT5', 'LPT6', 'LPT7', 'LPT8', 'LPT9'
+]);
+
+/**
+ * Escapes a filename for storage in a local folder to bypass browser restrictions.
+ * @param {string} name
+ * @returns {string}
+ */
+export function escapeName(name) {
+    if (!name || name === '.' || name === '..') return name;
+
+    const lowerName = name.toLowerCase();
+
+    // User specifically requested .lnk -> .lnk.json
+    if (lowerName.endsWith('.lnk')) {
+        return name + '.json';
+    }
+
+    const extMatch = lowerName.match(/\.([^.]+)$/);
+    const ext = extMatch ? extMatch[1] : '';
+
+    if (BLOCKED_EXTENSIONS.has(ext) || BLOCKED_NAMES.has(name.toUpperCase())) {
+        return name + '.z';
+    }
+
+    return name;
+}
+
+/**
+ * Unescapes a filename from local folder storage.
+ * @param {string} name
+ * @returns {string}
+ */
+export function unescapeName(name) {
+    if (!name || name === '.' || name === '..') return name;
+
+    if (name.toLowerCase().endsWith('.lnk.json')) {
+        return name.slice(0, -5);
+    }
+
+    if (name.toLowerCase().endsWith('.z')) {
+        return name.slice(0, -2);
+    }
+
+    return name;
+}

--- a/src/utils/localFolderUtils.js
+++ b/src/utils/localFolderUtils.js
@@ -1,0 +1,84 @@
+const DB_NAME = 'LocalFolderDB';
+const STORE_NAME = 'handles';
+const KEY_NAME = 'c-drive-handle';
+
+/**
+ * Gets the IndexedDB database instance.
+ * @returns {Promise<IDBDatabase>}
+ */
+function getDB() {
+    return new Promise((resolve, reject) => {
+        const request = indexedDB.open(DB_NAME, 1);
+        request.onupgradeneeded = (event) => {
+            const db = event.target.result;
+            if (!db.objectStoreNames.contains(STORE_NAME)) {
+                db.createObjectStore(STORE_NAME);
+            }
+        };
+        request.onsuccess = (event) => resolve(event.target.result);
+        request.onerror = (event) => reject(event.target.error);
+    });
+}
+
+/**
+ * Saves the local folder handle to IndexedDB.
+ * @param {FileSystemDirectoryHandle} handle
+ * @returns {Promise<void>}
+ */
+export async function saveLocalFolderHandle(handle) {
+    const db = await getDB();
+    return new Promise((resolve, reject) => {
+        const transaction = db.transaction(STORE_NAME, 'readwrite');
+        const store = transaction.objectStore(STORE_NAME);
+        const request = store.put(handle, KEY_NAME);
+        request.onsuccess = () => resolve();
+        request.onerror = () => reject(request.error);
+    });
+}
+
+/**
+ * Retrieves the local folder handle from IndexedDB.
+ * @returns {Promise<FileSystemDirectoryHandle|null>}
+ */
+export async function getLocalFolderHandle() {
+    const db = await getDB();
+    return new Promise((resolve, reject) => {
+        const transaction = db.transaction(STORE_NAME, 'readonly');
+        const store = transaction.objectStore(STORE_NAME);
+        const request = store.get(KEY_NAME);
+        request.onsuccess = () => resolve(request.result || null);
+        request.onerror = () => reject(request.error);
+    });
+}
+
+/**
+ * Clears the local folder handle from IndexedDB.
+ * @returns {Promise<void>}
+ */
+export async function clearLocalFolderHandle() {
+    const db = await getDB();
+    return new Promise((resolve, reject) => {
+        const transaction = db.transaction(STORE_NAME, 'readwrite');
+        const store = transaction.objectStore(STORE_NAME);
+        const request = store.delete(KEY_NAME);
+        request.onsuccess = () => resolve();
+        request.onerror = () => reject(request.error);
+    });
+}
+
+/**
+ * Checks if a local folder handle is stored and should be used.
+ * @returns {Promise<boolean>}
+ */
+export async function isLocalFolderEnabled() {
+    const handle = await getLocalFolderHandle();
+    return !!handle;
+}
+
+/**
+ * Checks if the File System Access API is supported.
+ * @returns {boolean}
+ */
+export function isFileSystemAccessSupported() {
+    return 'showDirectoryPicker' in window;
+}

--- a/src/utils/storageSwitch.js
+++ b/src/utils/storageSwitch.js
@@ -1,7 +1,7 @@
 import { fs, resolveMountConfig } from "@zenfs/core";
 import { IndexedDB } from "@zenfs/dom";
 import { ShowDialogWindow } from "../components/DialogWindow.js";
-import { saveLocalFolderHandle, clearLocalFolderHandle, getLocalFolderHandle } from "./localFolderUtils.js";
+import { saveLocalFolderHandle, clearLocalFolderHandle, getLocalFolderHandle, escapeName, unescapeName } from "./localFolderUtils.js";
 import { ProgressBarDialogWindow } from "../apps/zenexplorer/interface/ProgressBarDialogWindow.js";
 import { joinPath, getParentPath } from "../apps/zenexplorer/navigation/PathUtils.js";
 
@@ -60,7 +60,7 @@ async function copyRecursiveToHandle(srcPath, destHandle, dialog) {
         for (const file of files) {
             const childSrcPath = joinPath(srcPath, file);
             const childStats = await fs.promises.stat(childSrcPath);
-            const escapedName = file + '.z';
+            const escapedName = escapeName(file);
 
             if (childStats.isDirectory()) {
                 const subHandle = await destHandle.getDirectoryHandle(escapedName, { create: true });
@@ -86,7 +86,7 @@ async function copyRecursiveFromHandle(srcHandle, destPath, dialog) {
     if (dialog && dialog.cancelled) return;
 
     for await (const entry of srcHandle.values()) {
-        const unescapedName = (entry.name.endsWith('.z')) ? entry.name.slice(0, -2) : entry.name;
+        const unescapedName = unescapeName(entry.name);
         const childDestPath = joinPath(destPath, unescapedName);
 
         if (entry.kind === 'directory') {

--- a/src/utils/storageSwitch.js
+++ b/src/utils/storageSwitch.js
@@ -2,6 +2,7 @@ import { fs, resolveMountConfig } from "@zenfs/core";
 import { IndexedDB, WebAccess } from "@zenfs/dom";
 import { ShowDialogWindow } from "../components/DialogWindow.js";
 import { saveLocalFolderHandle, clearLocalFolderHandle } from "./localFolderUtils.js";
+import { wrapWebAccess } from "./zenfs-init.js";
 import { ProgressBarDialogWindow } from "../apps/zenexplorer/interface/ProgressBarDialogWindow.js";
 import { joinPath, getParentPath } from "../apps/zenexplorer/navigation/PathUtils.js";
 
@@ -120,6 +121,7 @@ export async function switchToLocalFolder() {
             backend: WebAccess,
             handle: win98Handle,
         });
+        wrapWebAccess(targetFs);
         const TEMP_MOUNT = '/temp-migration-target';
         fs.mount(TEMP_MOUNT, targetFs);
 

--- a/src/utils/storageSwitch.js
+++ b/src/utils/storageSwitch.js
@@ -1,8 +1,7 @@
 import { fs, resolveMountConfig } from "@zenfs/core";
-import { IndexedDB, WebAccess } from "@zenfs/dom";
+import { IndexedDB } from "@zenfs/dom";
 import { ShowDialogWindow } from "../components/DialogWindow.js";
-import { saveLocalFolderHandle, clearLocalFolderHandle } from "./localFolderUtils.js";
-import { wrapWebAccess } from "./zenfs-init.js";
+import { saveLocalFolderHandle, clearLocalFolderHandle, getLocalFolderHandle } from "./localFolderUtils.js";
 import { ProgressBarDialogWindow } from "../apps/zenexplorer/interface/ProgressBarDialogWindow.js";
 import { joinPath, getParentPath } from "../apps/zenexplorer/navigation/PathUtils.js";
 
@@ -24,7 +23,7 @@ async function countItems(path) {
     let count = 0;
     const stats = await fs.promises.stat(path);
     if (stats.isDirectory()) {
-        count++; // count the directory itself? or just files?
+        count++;
         const files = await fs.promises.readdir(path);
         for (const file of files) {
             count += await countItems(joinPath(path, file));
@@ -35,24 +34,76 @@ async function countItems(path) {
     return count;
 }
 
-async function copyRecursive(src, dest, dialog) {
-    if (dialog && dialog.cancelled) return;
-    const stats = await fs.promises.stat(src);
-    if (stats.isDirectory()) {
-        try {
-            await fs.promises.mkdir(dest, { recursive: true });
-        } catch (e) {}
-        const files = await fs.promises.readdir(src);
-        for (const file of files) {
-            await copyRecursive(joinPath(src, file), joinPath(dest, file), dialog);
+async function getHandleStats(handle) {
+    let size = 0;
+    let items = 0;
+    for await (const entry of handle.values()) {
+        items++;
+        if (entry.kind === 'directory') {
+            const stats = await getHandleStats(entry);
+            size += stats.size;
+            items += stats.items;
+        } else {
+            const file = await entry.getFile();
+            size += file.size;
         }
-    } else {
-        const data = await fs.promises.readFile(src);
-        await fs.promises.writeFile(dest, data);
-        if (dialog) {
-            dialog.processedSize += stats.size;
-            dialog.processedItems++;
-            dialog.update(src, getParentPath(src), getParentPath(dest), stats.size);
+    }
+    return { size, items };
+}
+
+async function copyRecursiveToHandle(srcPath, destHandle, dialog) {
+    if (dialog && dialog.cancelled) return;
+    const stats = await fs.promises.stat(srcPath);
+
+    if (stats.isDirectory()) {
+        const files = await fs.promises.readdir(srcPath);
+        for (const file of files) {
+            const childSrcPath = joinPath(srcPath, file);
+            const childStats = await fs.promises.stat(childSrcPath);
+            const escapedName = file + '.z';
+
+            if (childStats.isDirectory()) {
+                const subHandle = await destHandle.getDirectoryHandle(escapedName, { create: true });
+                await copyRecursiveToHandle(childSrcPath, subHandle, dialog);
+            } else {
+                const fileHandle = await destHandle.getFileHandle(escapedName, { create: true });
+                const writable = await fileHandle.createWritable();
+                const data = await fs.promises.readFile(childSrcPath);
+                await writable.write(data);
+                await writable.close();
+
+                if (dialog) {
+                    dialog.processedSize += childStats.size;
+                    dialog.processedItems++;
+                    dialog.update(childSrcPath, getParentPath(childSrcPath), "Local Folder", childStats.size);
+                }
+            }
+        }
+    }
+}
+
+async function copyRecursiveFromHandle(srcHandle, destPath, dialog) {
+    if (dialog && dialog.cancelled) return;
+
+    for await (const entry of srcHandle.values()) {
+        const unescapedName = (entry.name.endsWith('.z')) ? entry.name.slice(0, -2) : entry.name;
+        const childDestPath = joinPath(destPath, unescapedName);
+
+        if (entry.kind === 'directory') {
+            try {
+                await fs.promises.mkdir(childDestPath, { recursive: true });
+            } catch (e) {}
+            await copyRecursiveFromHandle(entry, childDestPath, dialog);
+        } else {
+            const file = await entry.getFile();
+            const buffer = await file.arrayBuffer();
+            await fs.promises.writeFile(childDestPath, new Uint8Array(buffer));
+
+            if (dialog) {
+                dialog.processedSize += file.size;
+                dialog.processedItems++;
+                dialog.update(entry.name, "Local Folder", getParentPath(childDestPath), file.size);
+            }
         }
     }
 }
@@ -105,8 +156,6 @@ export async function switchToLocalFolder() {
                 return;
             }
 
-            // Overwrite: we need to clear it first or just let copyRecursive overwrite
-            // To be safe, let's delete it if we can
             try {
                 await handle.removeEntry('win98-c-drive', { recursive: true });
             } catch (e) {
@@ -116,29 +165,19 @@ export async function switchToLocalFolder() {
 
         win98Handle = await handle.getDirectoryHandle('win98-c-drive', { create: true });
 
-        // Mount temporary target
-        const targetFs = await resolveMountConfig({
-            backend: WebAccess,
-            handle: win98Handle,
-        });
-        wrapWebAccess(targetFs);
-        const TEMP_MOUNT = '/temp-migration-target';
-        fs.mount(TEMP_MOUNT, targetFs);
-
         const totalSize = await getTotalSize('/C:');
         const totalItems = await countItems('/C:');
         const dialog = new ProgressBarDialogWindow('copy', totalItems, totalSize);
         dialog.fromToEl.textContent = "Moving C: contents to local folder...";
 
         try {
-            await copyRecursive('/C:', TEMP_MOUNT, dialog);
+            await copyRecursiveToHandle('/C:', win98Handle, dialog);
             if (dialog.cancelled) {
-                fs.umount(TEMP_MOUNT);
+                dialog.close();
                 return;
             }
 
             await saveLocalFolderHandle(handle);
-            fs.umount(TEMP_MOUNT);
             dialog.close();
 
             ShowDialogWindow({
@@ -148,7 +187,6 @@ export async function switchToLocalFolder() {
             });
         } catch (error) {
             console.error("Migration failed:", error);
-            fs.umount(TEMP_MOUNT);
             dialog.close();
             ShowDialogWindow({
                 title: "Migration Failed",
@@ -178,7 +216,22 @@ export async function switchToIndexedDB() {
     if (!confirm) return;
 
     try {
-        // Mount the original IndexedDB temporarily
+        const handle = await getLocalFolderHandle();
+        if (!handle) {
+             throw new Error("Local folder handle not found.");
+        }
+
+        // Check permission
+        const permission = await handle.queryPermission({ mode: 'readwrite' });
+        if (permission !== 'granted') {
+             const newPermission = await handle.requestPermission({ mode: 'readwrite' });
+             if (newPermission !== 'granted') {
+                 throw new Error("Permission denied to access local folder.");
+             }
+        }
+
+        const win98Handle = await handle.getDirectoryHandle('win98-c-drive');
+
         const targetFs = await resolveMountConfig({
             backend: IndexedDB,
             name: "win98-c-drive",
@@ -186,18 +239,15 @@ export async function switchToIndexedDB() {
         const TEMP_MOUNT = '/temp-migration-target-idb';
         fs.mount(TEMP_MOUNT, targetFs);
 
-        // Optional: clear the target IndexedDB before copying
-        // For simplicity, we'll just overwrite.
-
-        const totalSize = await getTotalSize('/C:');
-        const totalItems = await countItems('/C:');
-        const dialog = new ProgressBarDialogWindow('copy', totalItems, totalSize);
+        const stats = await getHandleStats(win98Handle);
+        const dialog = new ProgressBarDialogWindow('copy', stats.items, stats.size);
         dialog.fromToEl.textContent = "Moving C: contents back to IndexedDB...";
 
         try {
-            await copyRecursive('/C:', TEMP_MOUNT, dialog);
+            await copyRecursiveFromHandle(win98Handle, TEMP_MOUNT, dialog);
             if (dialog.cancelled) {
                 fs.umount(TEMP_MOUNT);
+                dialog.close();
                 return;
             }
 
@@ -222,5 +272,10 @@ export async function switchToIndexedDB() {
         }
     } catch (error) {
         console.error("Error during storage switch:", error);
+        ShowDialogWindow({
+            title: "Error",
+            text: "Failed to switch storage: " + error.message,
+            buttons: [{ label: "OK" }]
+        });
     }
 }

--- a/src/utils/storageSwitch.js
+++ b/src/utils/storageSwitch.js
@@ -1,0 +1,224 @@
+import { fs, resolveMountConfig } from "@zenfs/core";
+import { IndexedDB, WebAccess } from "@zenfs/dom";
+import { ShowDialogWindow } from "../components/DialogWindow.js";
+import { saveLocalFolderHandle, clearLocalFolderHandle } from "./localFolderUtils.js";
+import { ProgressBarDialogWindow } from "../apps/zenexplorer/interface/ProgressBarDialogWindow.js";
+import { joinPath, getParentPath } from "../apps/zenexplorer/navigation/PathUtils.js";
+
+async function getTotalSize(path) {
+    let total = 0;
+    const stats = await fs.promises.stat(path);
+    if (stats.isDirectory()) {
+        const files = await fs.promises.readdir(path);
+        for (const file of files) {
+            total += await getTotalSize(joinPath(path, file));
+        }
+    } else {
+        total += stats.size;
+    }
+    return total;
+}
+
+async function countItems(path) {
+    let count = 0;
+    const stats = await fs.promises.stat(path);
+    if (stats.isDirectory()) {
+        count++; // count the directory itself? or just files?
+        const files = await fs.promises.readdir(path);
+        for (const file of files) {
+            count += await countItems(joinPath(path, file));
+        }
+    } else {
+        count++;
+    }
+    return count;
+}
+
+async function copyRecursive(src, dest, dialog) {
+    if (dialog && dialog.cancelled) return;
+    const stats = await fs.promises.stat(src);
+    if (stats.isDirectory()) {
+        try {
+            await fs.promises.mkdir(dest, { recursive: true });
+        } catch (e) {}
+        const files = await fs.promises.readdir(src);
+        for (const file of files) {
+            await copyRecursive(joinPath(src, file), joinPath(dest, file), dialog);
+        }
+    } else {
+        const data = await fs.promises.readFile(src);
+        await fs.promises.writeFile(dest, data);
+        if (dialog) {
+            dialog.processedSize += stats.size;
+            dialog.processedItems++;
+            dialog.update(src, getParentPath(src), getParentPath(dest), stats.size);
+        }
+    }
+}
+
+export async function switchToLocalFolder() {
+    if (!('showDirectoryPicker' in window)) {
+        ShowDialogWindow({
+            title: "Not Supported",
+            text: "Your browser does not support the File System Access API.",
+            buttons: [{ label: "OK" }]
+        });
+        return;
+    }
+
+    try {
+        const handle = await window.showDirectoryPicker({
+            mode: 'readwrite'
+        });
+
+        let win98Handle;
+        let exists = false;
+        try {
+            win98Handle = await handle.getDirectoryHandle('win98-c-drive');
+            exists = true;
+        } catch (e) {
+            // Does not exist
+        }
+
+        if (exists) {
+            const result = await new Promise((resolve) => {
+                ShowDialogWindow({
+                    title: "Folder Already Exists",
+                    text: "The folder already contains 'win98-c-drive'. Would you like to use the existing data or overwrite it with current IndexedDB data?",
+                    buttons: [
+                        { label: "Use Existing", action: () => { resolve('existing'); return true; } },
+                        { label: "Overwrite", action: () => { resolve('overwrite'); return true; } },
+                        { label: "Cancel", action: () => { resolve('cancel'); return true; } }
+                    ]
+                });
+            });
+
+            if (result === 'cancel') return;
+            if (result === 'existing') {
+                await saveLocalFolderHandle(handle);
+                ShowDialogWindow({
+                    title: "Storage Switched",
+                    text: "C: drive has been linked to the local folder. Please restart the system to apply changes.",
+                    buttons: [{ label: "OK", action: () => { location.reload(); } }]
+                });
+                return;
+            }
+
+            // Overwrite: we need to clear it first or just let copyRecursive overwrite
+            // To be safe, let's delete it if we can
+            try {
+                await handle.removeEntry('win98-c-drive', { recursive: true });
+            } catch (e) {
+                console.warn("Failed to delete existing win98-c-drive, will attempt to overwrite files", e);
+            }
+        }
+
+        win98Handle = await handle.getDirectoryHandle('win98-c-drive', { create: true });
+
+        // Mount temporary target
+        const targetFs = await resolveMountConfig({
+            backend: WebAccess,
+            handle: win98Handle,
+        });
+        const TEMP_MOUNT = '/temp-migration-target';
+        fs.mount(TEMP_MOUNT, targetFs);
+
+        const totalSize = await getTotalSize('/C:');
+        const totalItems = await countItems('/C:');
+        const dialog = new ProgressBarDialogWindow('copy', totalItems, totalSize);
+        dialog.fromToEl.textContent = "Moving C: contents to local folder...";
+
+        try {
+            await copyRecursive('/C:', TEMP_MOUNT, dialog);
+            if (dialog.cancelled) {
+                fs.umount(TEMP_MOUNT);
+                return;
+            }
+
+            await saveLocalFolderHandle(handle);
+            fs.umount(TEMP_MOUNT);
+            dialog.close();
+
+            ShowDialogWindow({
+                title: "Migration Complete",
+                text: "Successfully migrated C: drive to local folder. Please restart the system to apply changes.",
+                buttons: [{ label: "Restart Now", action: () => { location.reload(); } }]
+            });
+        } catch (error) {
+            console.error("Migration failed:", error);
+            fs.umount(TEMP_MOUNT);
+            dialog.close();
+            ShowDialogWindow({
+                title: "Migration Failed",
+                text: "An error occurred during migration: " + error.message,
+                buttons: [{ label: "OK" }]
+            });
+        }
+
+    } catch (error) {
+        if (error.name === 'AbortError') return;
+        console.error("Error during storage switch:", error);
+    }
+}
+
+export async function switchToIndexedDB() {
+    const confirm = await new Promise((resolve) => {
+        ShowDialogWindow({
+            title: "Confirm Switch",
+            text: "Are you sure you want to switch back to IndexedDB? Current C: drive contents in the local folder will be copied back to IndexedDB.",
+            buttons: [
+                { label: "Yes", action: () => { resolve(true); return true; } },
+                { label: "No", action: () => { resolve(false); return true; } }
+            ]
+        });
+    });
+
+    if (!confirm) return;
+
+    try {
+        // Mount the original IndexedDB temporarily
+        const targetFs = await resolveMountConfig({
+            backend: IndexedDB,
+            name: "win98-c-drive",
+        });
+        const TEMP_MOUNT = '/temp-migration-target-idb';
+        fs.mount(TEMP_MOUNT, targetFs);
+
+        // Optional: clear the target IndexedDB before copying
+        // For simplicity, we'll just overwrite.
+
+        const totalSize = await getTotalSize('/C:');
+        const totalItems = await countItems('/C:');
+        const dialog = new ProgressBarDialogWindow('copy', totalItems, totalSize);
+        dialog.fromToEl.textContent = "Moving C: contents back to IndexedDB...";
+
+        try {
+            await copyRecursive('/C:', TEMP_MOUNT, dialog);
+            if (dialog.cancelled) {
+                fs.umount(TEMP_MOUNT);
+                return;
+            }
+
+            await clearLocalFolderHandle();
+            fs.umount(TEMP_MOUNT);
+            dialog.close();
+
+            ShowDialogWindow({
+                title: "Switch Complete",
+                text: "C: drive will use IndexedDB on next boot. Please restart the system.",
+                buttons: [{ label: "Restart Now", action: () => { location.reload(); } }]
+            });
+        } catch (error) {
+            console.error("Migration failed:", error);
+            fs.umount(TEMP_MOUNT);
+            dialog.close();
+            ShowDialogWindow({
+                title: "Migration Failed",
+                text: "An error occurred during migration: " + error.message,
+                buttons: [{ label: "OK" }]
+            });
+        }
+    } catch (error) {
+        console.error("Error during storage switch:", error);
+    }
+}

--- a/src/utils/zenfs-init.js
+++ b/src/utils/zenfs-init.js
@@ -8,6 +8,38 @@ import { existsAsync } from "./zenfs-utils.js";
 
 let isInitialized = false;
 
+/**
+ * Wraps a WebAccess FS to escape filenames.
+ * This is necessary because the File System Access API blocks certain extensions (like .lnk).
+ * @param {FileSystem} fs
+ */
+export function wrapWebAccess(fs) {
+    const transformPath = (p) => {
+        if (!p || p === '/') return p;
+        return p.split('/').map(s => s ? s + '.z' : '').join('/');
+    };
+    const untransformSegment = (s) => (s && s.endsWith('.z')) ? s.slice(0, -2) : s;
+
+    // Wrap 'get' on the instance. It's used by almost all other methods.
+    if (typeof fs.get === 'function') {
+        const originalGet = fs.get.bind(fs);
+        fs.get = function(kind, path) {
+            return originalGet(kind, transformPath(path));
+        };
+    }
+
+    // Wrap 'readdir' to untransform the results
+    if (typeof fs.readdir === 'function') {
+        const originalReaddir = fs.readdir.bind(fs);
+        fs.readdir = async function(path, ...args) {
+            const entries = await originalReaddir(transformPath(path), ...args);
+            return entries.map(untransformSegment);
+        };
+    }
+
+    return fs;
+}
+
 export async function initFileSystem(onProgress, localFolderHandle = null) {
     if (isInitialized) return;
 
@@ -34,7 +66,8 @@ export async function initFileSystem(onProgress, localFolderHandle = null) {
                     backend: WebAccess,
                     handle: subfolderHandle,
                 });
-                console.log("C: drive mounted from local folder.");
+                wrapWebAccess(cDriveFs);
+                console.log("C: drive mounted from local folder (wrapped).");
             } catch (e) {
                 console.error("Failed to mount local folder, falling back to IndexedDB:", e);
                 cDriveFs = await resolveMountConfig({

--- a/src/utils/zenfs-init.js
+++ b/src/utils/zenfs-init.js
@@ -5,6 +5,7 @@ import startMenuConfig from "../config/startmenu.js";
 import { getStartupApps } from "./startupManager.js";
 import { apps } from "../config/apps.js";
 import { existsAsync } from "./zenfs-utils.js";
+import { escapeName, unescapeName } from "./localFolderUtils.js";
 
 let isInitialized = false;
 
@@ -18,9 +19,8 @@ const wrappingState = new WeakMap();
 export function wrapWebAccess(fsInstance) {
     const transformPath = (p) => {
         if (typeof p !== 'string' || !p || p === '/' || p === '.') return p;
-        return p.split('/').map(s => (s && s !== '.' && s !== '..') ? s + '.z' : s).join('/');
+        return p.split('/').map(s => escapeName(s)).join('/');
     };
-    const untransformSegment = (s) => (s && s.endsWith('.z')) ? s.slice(0, -2) : s;
 
     const pathArgs = {
         stat: [0], readdir: [0], open: [0], unlink: [0], rmdir: [0], mkdir: [0], _mkdir: [0],
@@ -49,7 +49,7 @@ export function wrapWebAccess(fsInstance) {
 
                     const result = original(...wrappedArgs);
                     if (method === 'readdir' && result instanceof Promise) {
-                        return result.then(entries => entries.map(untransformSegment));
+                        return result.then(entries => entries.map(unescapeName));
                     }
                     return result;
                 } finally {

--- a/src/utils/zenfs-init.js
+++ b/src/utils/zenfs-init.js
@@ -8,46 +8,58 @@ import { existsAsync } from "./zenfs-utils.js";
 
 let isInitialized = false;
 
+const wrappingState = new WeakMap();
+
 /**
  * Wraps a WebAccess FS to escape filenames.
  * This is necessary because the File System Access API blocks certain extensions (like .lnk).
- * @param {FileSystem} fs
+ * @param {FileSystem} fsInstance
  */
-export function wrapWebAccess(fs) {
+export function wrapWebAccess(fsInstance) {
     const transformPath = (p) => {
         if (typeof p !== 'string' || !p || p === '/' || p === '.') return p;
         return p.split('/').map(s => (s && s !== '.' && s !== '..') ? s + '.z' : s).join('/');
     };
     const untransformSegment = (s) => (s && s.endsWith('.z')) ? s.slice(0, -2) : s;
 
-    const methodsToWrap = [
-        'stat', 'readdir', 'open', 'unlink', 'rmdir', 'mkdir', '_mkdir',
-        'rename', 'read', 'write', 'writeFile', 'get', 'remove', 'touch', 'sync',
-        'create', 'createFile', 'link', 'symlink', 'readlink', 'access', 'chown', 'chmod', 'utimes'
-    ];
+    const pathArgs = {
+        stat: [0], readdir: [0], open: [0], unlink: [0], rmdir: [0], mkdir: [0], _mkdir: [0],
+        rename: [0, 1], read: [0], write: [0], writeFile: [0], get: [1], remove: [0],
+        touch: [0], create: [0], createFile: [0], link: [0, 1], symlink: [0, 1],
+        readlink: [0], access: [0], chown: [0], chmod: [0], utimes: [0]
+    };
 
-    for (const method of methodsToWrap) {
-        if (typeof fs[method] === 'function') {
-            const original = fs[method].bind(fs);
-            fs[method] = function(arg1, ...rest) {
-                if (method === 'rename') {
-                    return original(transformPath(arg1), transformPath(rest[0]), ...rest.slice(1));
+    for (const method in pathArgs) {
+        if (typeof fsInstance[method] === 'function') {
+            const original = fsInstance[method].bind(fsInstance);
+            const indices = pathArgs[method];
+            fsInstance[method] = function(...args) {
+                if (wrappingState.get(fsInstance)) {
+                    return original(...args);
                 }
-                if (method === 'readdir') {
-                    return (async () => {
-                        const entries = await original(transformPath(arg1), ...rest);
-                        return entries.map(untransformSegment);
-                    })();
+
+                wrappingState.set(fsInstance, true);
+                try {
+                    const wrappedArgs = args.map((arg, i) => {
+                        if (indices.includes(i) && typeof arg === 'string') {
+                            return transformPath(arg);
+                        }
+                        return arg;
+                    });
+
+                    const result = original(...wrappedArgs);
+                    if (method === 'readdir' && result instanceof Promise) {
+                        return result.then(entries => entries.map(untransformSegment));
+                    }
+                    return result;
+                } finally {
+                    wrappingState.set(fsInstance, false);
                 }
-                if (typeof arg1 === 'string') {
-                    return original(transformPath(arg1), ...rest);
-                }
-                return original(arg1, ...rest);
             };
         }
     }
 
-    return fs;
+    return fsInstance;
 }
 
 export async function initFileSystem(onProgress, localFolderHandle = null) {

--- a/src/utils/zenfs-init.js
+++ b/src/utils/zenfs-init.js
@@ -1,5 +1,5 @@
 import { resolveMountConfig, InMemory, fs } from "@zenfs/core";
-import { IndexedDB } from "@zenfs/dom";
+import { IndexedDB, WebAccess } from "@zenfs/dom";
 import { migrateToZenFS, PINNED_PATH, START_MENU_PATH, FAVORITES_PATH } from "./startMenuUtils.js";
 import startMenuConfig from "../config/startmenu.js";
 import { getStartupApps } from "./startupManager.js";
@@ -8,7 +8,7 @@ import { existsAsync } from "./zenfs-utils.js";
 
 let isInitialized = false;
 
-export async function initFileSystem(onProgress) {
+export async function initFileSystem(onProgress, localFolderHandle = null) {
     if (isInitialized) return;
 
     try {
@@ -25,10 +25,29 @@ export async function initFileSystem(onProgress) {
         fs.mount('/', rootFs);
 
         if (onProgress) onProgress("Mounting C: drive...");
-        const cDriveFs = await resolveMountConfig({
-            backend: IndexedDB,
-            name: "win98-c-drive",
-        });
+        let cDriveFs;
+        if (localFolderHandle) {
+            try {
+                // Try to get win98-c-drive subfolder handle
+                const subfolderHandle = await localFolderHandle.getDirectoryHandle('win98-c-drive', { create: true });
+                cDriveFs = await resolveMountConfig({
+                    backend: WebAccess,
+                    handle: subfolderHandle,
+                });
+                console.log("C: drive mounted from local folder.");
+            } catch (e) {
+                console.error("Failed to mount local folder, falling back to IndexedDB:", e);
+                cDriveFs = await resolveMountConfig({
+                    backend: IndexedDB,
+                    name: "win98-c-drive",
+                });
+            }
+        } else {
+            cDriveFs = await resolveMountConfig({
+                backend: IndexedDB,
+                name: "win98-c-drive",
+            });
+        }
         // Ensure C: mount point exists in root
         if (!(await existsAsync('/C:'))) {
             await fs.promises.mkdir('/C:');

--- a/src/utils/zenfs-init.js
+++ b/src/utils/zenfs-init.js
@@ -15,26 +15,35 @@ let isInitialized = false;
  */
 export function wrapWebAccess(fs) {
     const transformPath = (p) => {
-        if (!p || p === '/') return p;
-        return p.split('/').map(s => s ? s + '.z' : '').join('/');
+        if (typeof p !== 'string' || !p || p === '/' || p === '.') return p;
+        return p.split('/').map(s => (s && s !== '.' && s !== '..') ? s + '.z' : s).join('/');
     };
     const untransformSegment = (s) => (s && s.endsWith('.z')) ? s.slice(0, -2) : s;
 
-    // Wrap 'get' on the instance. It's used by almost all other methods.
-    if (typeof fs.get === 'function') {
-        const originalGet = fs.get.bind(fs);
-        fs.get = function(kind, path) {
-            return originalGet(kind, transformPath(path));
-        };
-    }
+    const methodsToWrap = [
+        'stat', 'readdir', 'open', 'unlink', 'rmdir', 'mkdir', '_mkdir',
+        'rename', 'read', 'write', 'writeFile', 'get', 'remove', 'touch', 'sync'
+    ];
 
-    // Wrap 'readdir' to untransform the results
-    if (typeof fs.readdir === 'function') {
-        const originalReaddir = fs.readdir.bind(fs);
-        fs.readdir = async function(path, ...args) {
-            const entries = await originalReaddir(transformPath(path), ...args);
-            return entries.map(untransformSegment);
-        };
+    for (const method of methodsToWrap) {
+        if (typeof fs[method] === 'function') {
+            const original = fs[method].bind(fs);
+            fs[method] = function(arg1, ...rest) {
+                if (method === 'rename') {
+                    return original(transformPath(arg1), transformPath(rest[0]), ...rest.slice(1));
+                }
+                if (method === 'readdir') {
+                    return (async () => {
+                        const entries = await original(transformPath(arg1), ...rest);
+                        return entries.map(untransformSegment);
+                    })();
+                }
+                if (typeof arg1 === 'string') {
+                    return original(transformPath(arg1), ...rest);
+                }
+                return original(arg1, ...rest);
+            };
+        }
     }
 
     return fs;

--- a/src/utils/zenfs-init.js
+++ b/src/utils/zenfs-init.js
@@ -22,7 +22,8 @@ export function wrapWebAccess(fs) {
 
     const methodsToWrap = [
         'stat', 'readdir', 'open', 'unlink', 'rmdir', 'mkdir', '_mkdir',
-        'rename', 'read', 'write', 'writeFile', 'get', 'remove', 'touch', 'sync'
+        'rename', 'read', 'write', 'writeFile', 'get', 'remove', 'touch', 'sync',
+        'create', 'createFile', 'link', 'symlink', 'readlink', 'access', 'chown', 'chmod', 'utimes'
     ];
 
     for (const method of methodsToWrap) {


### PR DESCRIPTION
This change allows users to switch their C: drive storage from IndexedDB to a local folder on their machine. It includes:
1. A new 'Storage Settings' section in the C: drive Properties dialog.
2. Migration logic to copy files between IndexedDB and the local folder.
3. Persistent mounting of the local folder on boot, with a prompt to grant permission (required by File System Access API).
4. Conflict handling when switching to a folder that already contains C: drive data.
5. Fallback to IndexedDB if local folder access is denied or unsupported.

---
*PR created automatically by Jules for task [4593674820177261066](https://jules.google.com/task/4593674820177261066) started by @azayrahmad*