### PR TITLE
Migrate all apps to ZenFS file picker

### DIFF
--- a/src/apps/appmaker/AppMakerApp.js
+++ b/src/apps/appmaker/AppMakerApp.js
@@ -1,5 +1,7 @@
 import { Application } from '../Application.js';
 import { ShowDialogWindow } from '../../components/DialogWindow.js';
+import { ShowFilePicker } from '../../utils/filePicker.js';
+import { getZenFSFileAsBlob, getZenFSFileAsText } from '../../utils/zenfs-utils.js';
 import './appmaker.css';
 import '../../components/notepad-editor.css';
 import { setupIcons } from '../../components/desktop.js';
@@ -135,7 +137,6 @@ export class AppMakerApp extends Application {
         this.appIconPreview = container.querySelector('#appIconPreview');
         this.appIconUrlInput = container.querySelector('#appIconUrl');
         const uploadButton = container.querySelector('#uploadButton');
-        this.appIconFileInput = container.querySelector('#appIconFile');
 
         this.appIconUrlInput.addEventListener('input', () => {
             const url = this.appIconUrlInput.value.trim();
@@ -155,22 +156,33 @@ export class AppMakerApp extends Application {
             this.appIcon = null;
         };
 
-        uploadButton.addEventListener('click', () => {
-            this.appIconFileInput.click();
-        });
+        uploadButton.addEventListener('click', async () => {
+          const path = await ShowFilePicker({
+            title: "Choose App Icon",
+            mode: "open",
+            fileTypes: [
+              {
+                label: "Image Files",
+                extensions: ["jpg", "jpeg", "png", "gif", "bmp"],
+              },
+            ],
+          });
 
-        this.appIconFileInput.addEventListener('change', (event) => {
-            const file = event.target.files[0];
-            if (file) {
-                const reader = new FileReader();
-                reader.onload = (e) => {
-                    this.appIconPreview.src = e.target.result;
-                    this.appIconPreview.style.display = 'block';
-                    this.appIcon = e.target.result; // This is the data URL
-                    this.appIconUrlInput.value = ''; // Clear URL input
-                };
-                reader.readAsDataURL(file);
+          if (path) {
+            try {
+              const blob = await getZenFSFileAsBlob(path);
+              const reader = new FileReader();
+              reader.onload = (e) => {
+                this.appIconPreview.src = e.target.result;
+                this.appIconPreview.style.display = "block";
+                this.appIcon = e.target.result; // This is the data URL
+                this.appIconUrlInput.value = ""; // Clear URL input
+              };
+              reader.readAsDataURL(blob);
+            } catch (e) {
+              console.error("Error loading icon from ZenFS:", e);
             }
+          }
         });
 
         this._updateTitle();
@@ -182,27 +194,24 @@ export class AppMakerApp extends Application {
         this.win.title(newTitle);
     }
 
-    _openHtmlFile() {
-        const input = document.createElement('input');
-        input.type = 'file';
-        input.accept = '.html';
-        input.onchange = (e) => {
-            const file = e.target.files[0];
-            if (!file) {
-                return;
-            }
+    async _openHtmlFile() {
+      const path = await ShowFilePicker({
+        title: "Open HTML File",
+        mode: "open",
+        fileTypes: [{ label: "HTML Files (*.html)", extensions: ["html"] }],
+      });
 
-            const reader = new FileReader();
-            reader.onload = (event) => {
-                const htmlContent = event.target.result;
-                const fileName = file.name.replace(/\.html$/, '');
-                this.appNameInput.value = fileName;
-                this.editor.setValue(htmlContent);
-                this._updateTitle();
-            };
-            reader.readAsText(file);
-        };
-        input.click();
+      if (path) {
+        try {
+          const htmlContent = await getZenFSFileAsText(path);
+          const fileName = path.split("/").pop().replace(/\.html$/, "");
+          this.appNameInput.value = fileName;
+          this.editor.setValue(htmlContent);
+          this._updateTitle();
+        } catch (e) {
+          console.error("Error loading HTML from ZenFS:", e);
+        }
+      }
     }
 
     _previewApp() {
@@ -288,7 +297,6 @@ export class AppMakerApp extends Application {
                     <input type="text" id="appIconUrl" placeholder="Enter image URL">
                     <span style="margin: 0 5px;">or</span>
                     <button id="uploadButton">Upload File</button>
-                    <input type="file" id="appIconFile" accept="image/*" style="display: none;">
                 </div>
             </div>
 

--- a/src/apps/displayproperties/appearance/appearance.js
+++ b/src/apps/displayproperties/appearance/appearance.js
@@ -10,6 +10,8 @@ import {
   applyPropertiesToPreview,
 } from "../../../utils/themePreview.js";
 import { ShowDialogWindow } from "../../../components/DialogWindow.js";
+import { ShowFilePicker } from "../../../utils/filePicker.js";
+import { getZenFSFileAsText } from "../../../utils/zenfs-utils.js";
 import previewHtml from "./AppearancePreview.html?raw";
 import "./appearance.css";
 
@@ -21,12 +23,6 @@ export const appearanceTab = {
     const $schemeSelect = $tab.find(".scheme-select");
     const $previewContainer = $tab.find(".preview-container");
     $previewContainer.html(previewHtml);
-
-    // Add a hidden file input for theme loading
-    const $fileInput = $(
-      '<input type="file" accept=".theme" style="display: none;">',
-    );
-    $tab.append($fileInput);
 
     // Inject a style block to map preview variables to os-gui variables
     const styleBlock = `
@@ -79,12 +75,62 @@ export const appearanceTab = {
     }
     $schemeSelect.append($loadOption);
 
-    $schemeSelect.on("change", () => {
+    $schemeSelect.on("change", async () => {
       const selectedValue = $schemeSelect.val();
       if (selectedValue === "__load__") {
-        $fileInput.click();
         // Reset the dropdown to the previous value after a brief moment
         setTimeout(() => $schemeSelect.val(currentSchemeId), 100);
+
+        const path = await ShowFilePicker({
+          title: "Load Color Scheme",
+          mode: "open",
+          fileTypes: [
+            { label: "Theme Files (*.theme)", extensions: ["theme"] },
+          ],
+        });
+
+        if (!path) return;
+
+        app._enableApplyButton(win);
+
+        try {
+          const fileContent = await getZenFSFileAsText(path);
+          await loadThemeParser();
+          const colors = window.getColorsFromThemeFile(fileContent);
+
+          if (colors) {
+            const cssProperties =
+              window.generateThemePropertiesFromColors(colors);
+            self.loadedCustomScheme = cssProperties;
+            let variables = {};
+            for (const [key, value] of Object.entries(cssProperties)) {
+              variables[key.replace(/^--/, "")] = value;
+            }
+
+            applyPropertiesToPreview(
+              variables,
+              $previewContainer.find("#appearance-preview-wrapper")[0],
+            );
+            // Update dropdown to show a temporary "Custom" entry
+            $schemeSelect.find('option[value="__load__"]').text("Custom");
+            $schemeSelect.val("__load__");
+          } else {
+            self.loadedCustomScheme = null;
+            ShowDialogWindow({
+              title: "Error",
+              text: "This is not a valid theme file or it does not contain color information.",
+            });
+            $schemeSelect.val(currentSchemeId); // Revert to last selection
+          }
+        } catch (error) {
+          console.error("Error parsing theme file:", error);
+          self.loadedCustomScheme = null;
+          ShowDialogWindow({
+            title: "Error",
+            text: "An error occurred while trying to load the theme file.",
+          });
+          $schemeSelect.val(currentSchemeId); // Revert to last selection
+        }
       } else {
         currentSchemeId = selectedValue;
         self.loadedCustomScheme = null; // Clear custom scheme if a built-in one is selected
@@ -96,55 +142,6 @@ export const appearanceTab = {
           selectedValue,
           $previewContainer.find("#appearance-preview-wrapper")[0],
         );
-      }
-    });
-
-    $fileInput.on("change", async (e) => {
-      const file = e.target.files[0];
-      if (!file) return;
-
-      app._enableApplyButton(win);
-
-      try {
-        const fileContent = await file.text();
-        await loadThemeParser();
-        const colors = window.getColorsFromThemeFile(fileContent);
-
-        if (colors) {
-          const cssProperties =
-            window.generateThemePropertiesFromColors(colors);
-          self.loadedCustomScheme = cssProperties;
-          let variables = {};
-          for (const [key, value] of Object.entries(cssProperties)) {
-            variables[key.replace(/^--/, "")] = value;
-          }
-
-          applyPropertiesToPreview(
-            variables,
-            $previewContainer.find("#appearance-preview-wrapper")[0],
-          );
-          // Update dropdown to show a temporary "Custom" entry
-          $schemeSelect.find('option[value="__load__"]').text("Custom");
-          $schemeSelect.val("__load__");
-        } else {
-          self.loadedCustomScheme = null;
-          ShowDialogWindow({
-            title: "Error",
-            text: "This is not a valid theme file or it does not contain color information.",
-          });
-          $schemeSelect.val(currentSchemeId); // Revert to last selection
-        }
-      } catch (error) {
-        console.error("Error parsing theme file:", error);
-        self.loadedCustomScheme = null;
-        ShowDialogWindow({
-          title: "Error",
-          text: "An error occurred while trying to load the theme file.",
-        });
-        $schemeSelect.val(currentSchemeId); // Revert to last selection
-      } finally {
-        // Reset file input so the same file can be loaded again
-        $fileInput.val("");
       }
     });
 

--- a/src/apps/displayproperties/background/background.js
+++ b/src/apps/displayproperties/background/background.js
@@ -1,5 +1,7 @@
 import { wallpapers } from "../../../config/wallpapers.js";
 import { setItem, LOCAL_STORAGE_KEYS } from "../../../utils/localStorage.js";
+import { ShowFilePicker } from "../../../utils/filePicker.js";
+import { getZenFSFileAsBlob } from "../../../utils/zenfs-utils.js";
 
 function populateWallpaperList(win, app) {
   const $wallpaperList = win.$content.find(".wallpaper-list");
@@ -85,21 +87,34 @@ function updatePreview(win, app) {
   }
 }
 
-function browseForWallpaper(win, app) {
-  const $input = $('<input type="file" accept="image/*" />');
-  $input.on("change", (e) => {
-    const file = e.target.files[0];
-    if (file) {
+async function browseForWallpaper(win, app) {
+  const path = await ShowFilePicker({
+    title: "Browse for Wallpaper",
+    mode: "open",
+    initialPath: "/C:/WINDOWS/Web/Wallpaper",
+    fileTypes: [
+      {
+        label: "Image Files",
+        extensions: ["jpg", "jpeg", "png", "gif", "bmp"],
+      },
+      { label: "All Files", extensions: ["*"] },
+    ],
+  });
+
+  if (path) {
+    try {
+      const blob = await getZenFSFileAsBlob(path);
       const reader = new FileReader();
       reader.onload = (readerEvent) => {
         app.selectedWallpaper = readerEvent.target.result;
         updatePreview(win, app);
         app._enableApplyButton(win);
       };
-      reader.readAsDataURL(file);
+      reader.readAsDataURL(blob);
+    } catch (e) {
+      console.error("Error loading wallpaper from ZenFS:", e);
     }
-  });
-  $input.trigger("click");
+  }
 }
 
 export const backgroundTab = {

--- a/src/apps/image-resizer/ImageResizerApp.js
+++ b/src/apps/image-resizer/ImageResizerApp.js
@@ -1,4 +1,7 @@
 import { Application } from '../Application.js';
+import { fs } from "@zenfs/core";
+import { ShowFilePicker } from '../../utils/filePicker.js';
+import { getZenFSFileAsBlob } from '../../utils/zenfs-utils.js';
 import './image-resizer.css';
 import { ICONS } from '../../config/icons.js';
 
@@ -104,14 +107,12 @@ export class ImageResizerApp extends Application {
                 <div class="status-bar" id="info">
                     <p class="status-bar-field">Drag an image onto the window or use File > Open</p>
                 </div>
-                <input type="file" id="fileInput" accept="image/*" style="display: none;">
             </div>
         `;
     }
 
     _initApp() {
         const content = this.win.$content;
-        const fileInput = content.find('#fileInput')[0];
         const widthInput = content.find('#widthInput')[0];
         const heightInput = content.find('#heightInput')[0];
         const aspectRatio = content.find('#aspectRatio')[0];
@@ -126,7 +127,28 @@ export class ImageResizerApp extends Application {
         let originalImage = null;
         let isUpdatingDimensions = false;
 
-        this.openFile = () => fileInput.click();
+        this.openFile = async () => {
+          const path = await ShowFilePicker({
+            title: "Open Image",
+            mode: "open",
+            fileTypes: [
+              {
+                label: "Image Files",
+                extensions: ["jpg", "jpeg", "png", "gif", "bmp"],
+              },
+              { label: "All Files", extensions: ["*"] },
+            ],
+          });
+
+          if (path) {
+            try {
+              const blob = await getZenFSFileAsBlob(path);
+              loadImage(blob);
+            } catch (e) {
+              console.error("Error loading image from ZenFS:", e);
+            }
+          }
+        };
 
         this.showAboutDialog = () => {
             alert("Image Resizer v1.0\\n\\nResizes images with pixel-perfect precision.");
@@ -151,13 +173,6 @@ export class ImageResizerApp extends Application {
             appContainer.classList.remove('dragover');
             const file = e.dataTransfer.files[0];
             if (file && file.type.startsWith('image/')) {
-                loadImage(file);
-            }
-        });
-
-        fileInput.addEventListener('change', (e) => {
-            const file = e.target.files[0];
-            if (file) {
                 loadImage(file);
             }
         });
@@ -258,11 +273,23 @@ export class ImageResizerApp extends Application {
             `;
         }
 
-        downloadBtn.addEventListener('click', () => {
-            const link = document.createElement('a');
-            link.download = `enlarged_${enlargedCanvas.width}x${enlargedCanvas.height}.png`;
-            link.href = enlargedCanvas.toDataURL('image/png');
-            link.click();
+        downloadBtn.addEventListener('click', async () => {
+          const suggestedName = `enlarged_${enlargedCanvas.width}x${enlargedCanvas.height}.png`;
+          const path = await ShowFilePicker({
+            title: "Save Enlarged Image",
+            mode: "save",
+            suggestedName,
+            fileTypes: [{ label: "PNG Image", extensions: ["png"] }],
+          });
+
+          if (path) {
+            const dataUrl = enlargedCanvas.toDataURL("image/png");
+            const base64Data = dataUrl.split(",")[1];
+            const buffer = Uint8Array.from(atob(base64Data), (c) =>
+              c.charCodeAt(0),
+            );
+            await fs.promises.writeFile(path, buffer);
+          }
         });
     }
 }

--- a/src/apps/imageviewer/ImageViewerApp.js
+++ b/src/apps/imageviewer/ImageViewerApp.js
@@ -1,5 +1,7 @@
 import { Application } from "../Application.js";
+import { fs } from "@zenfs/core";
 import { ShowDialogWindow } from "../../components/DialogWindow.js";
+import { ShowFilePicker } from "../../utils/filePicker.js";
 import "./imageviewer.css";
 import { ICONS } from "../../config/icons.js";
 import { isZenFSPath, getZenFSFileAsBlob } from "../../utils/zenfs-utils.js";
@@ -19,6 +21,7 @@ export class ImageViewerApp extends Application {
   constructor(config) {
     super(config);
     this.file = null;
+    this.zenfsPath = null;
     this.zoomLevel = 1;
     this.zoomStep = 0.1;
 
@@ -136,6 +139,7 @@ export class ImageViewerApp extends Application {
         };
 
         if (isZenFSPath(data)) {
+          this.zenfsPath = data;
           getZenFSFileAsBlob(data)
             .then(handleBlob)
             .catch((e) => {
@@ -244,45 +248,46 @@ export class ImageViewerApp extends Application {
     reader.readAsDataURL(file);
   }
 
-  openFile() {
-    const input = document.createElement("input");
-    input.type = "file";
-    input.accept = "image/*";
-    input.onchange = (e) => {
-      const file = e.target.files[0];
-      if (file) {
+  async openFile() {
+    const path = await ShowFilePicker({
+      title: "Open Image",
+      mode: "open",
+      fileTypes: [
+        {
+          label: "Image Files",
+          extensions: ["jpg", "jpeg", "png", "gif", "bmp", "ico"],
+        },
+        { label: "All Files", extensions: ["*"] },
+      ],
+    });
+
+    if (path) {
+      try {
+        const blob = await getZenFSFileAsBlob(path);
+        const fileName = path.split("/").pop();
+        const file = new File([blob], fileName, { type: blob.type });
+        this.zenfsPath = path;
         this.loadFile(file);
+      } catch (e) {
+        console.error("Error loading image from ZenFS:", e);
       }
-    };
-    input.click();
+    }
   }
 
-  saveFile() {
-    if (!this.img || !this.img.src) {
-      alert("There is no image to save.");
-      return;
+  async saveFile() {
+    if (this.zenfsPath) {
+      try {
+        const response = await fetch(this.img.src);
+        const blob = await response.blob();
+        const arrayBuffer = await blob.arrayBuffer();
+        await fs.promises.writeFile(this.zenfsPath, new Uint8Array(arrayBuffer));
+        console.log("Image saved successfully to ZenFS:", this.zenfsPath);
+        return;
+      } catch (e) {
+        console.error("Error saving image to ZenFS:", e);
+      }
     }
-
-    const link = document.createElement("a");
-    link.href = this.img.src;
-
-    let downloadName;
-    const originalName = this.file ? this.file.name : "image.png";
-
-    if (this.backgroundRemoved) {
-      const nameWithoutExt =
-        originalName.lastIndexOf(".") !== -1
-          ? originalName.substring(0, originalName.lastIndexOf("."))
-          : originalName;
-      downloadName = `${nameWithoutExt}-modified.png`;
-    } else {
-      downloadName = `resized-${originalName}`;
-    }
-
-    link.download = downloadName;
-    document.body.appendChild(link);
-    link.click();
-    document.body.removeChild(link);
+    await this.saveFileAs();
   }
 
   async saveFileAs() {
@@ -291,68 +296,42 @@ export class ImageViewerApp extends Application {
       return;
     }
 
-    try {
-      if ("showSaveFilePicker" in window) {
+    let suggestedName = this.file ? this.file.name : "image.png";
+    if (this.backgroundRemoved) {
+      const nameWithoutExt =
+        suggestedName.lastIndexOf(".") !== -1
+          ? suggestedName.substring(0, suggestedName.lastIndexOf("."))
+          : suggestedName;
+      suggestedName = `${nameWithoutExt}-modified.png`;
+    } else if (suggestedName === "image.png") {
+      suggestedName = "resized-image.png";
+    } else if (!suggestedName.startsWith("resized-")) {
+      suggestedName = `resized-${suggestedName}`;
+    }
+
+    const path = await ShowFilePicker({
+      title: "Save Image As",
+      mode: "save",
+      suggestedName,
+      fileTypes: [
+        { label: "PNG Image", extensions: ["png"] },
+        { label: "JPEG Image", extensions: ["jpg", "jpeg"] },
+        { label: "All Files", extensions: ["*"] },
+      ],
+    });
+
+    if (path) {
+      try {
         const response = await fetch(this.img.src);
         const blob = await response.blob();
-
-        let suggestedName = this.file ? this.file.name : "image.png";
-        let fileType = blob.type;
-        let fileExtension = suggestedName.split(".").pop();
-
-        let types = [
-          {
-            description: "Image Files",
-            accept: { [fileType]: ["." + fileExtension] },
-          },
-        ];
-
-        if (this.backgroundRemoved) {
-          const nameWithoutExt =
-            suggestedName.lastIndexOf(".") !== -1
-              ? suggestedName.substring(0, suggestedName.lastIndexOf("."))
-              : suggestedName;
-          suggestedName = `${nameWithoutExt}-modified.png`;
-          types = [
-            { description: "PNG Image", accept: { "image/png": [".png"] } },
-          ];
-        }
-
-        const options = {
-          suggestedName,
-          types,
-        };
-
-        const fileHandle = await window.showSaveFilePicker(options);
-        const writableStream = await fileHandle.createWritable();
-        await writableStream.write(blob);
-        await writableStream.close();
-        console.log("Image saved successfully with File System Access API.");
-      } else {
-        // Fallback for browsers that don't support showSaveFilePicker
-        const link = document.createElement("a");
-        link.href = this.img.src;
-        let downloadName = this.file ? this.file.name : "image.png";
-
-        if (this.backgroundRemoved) {
-          const nameWithoutExt =
-            downloadName.lastIndexOf(".") !== -1
-              ? downloadName.substring(0, downloadName.lastIndexOf("."))
-              : downloadName;
-          downloadName = `${nameWithoutExt}-modified.png`;
-        }
-
-        link.download = downloadName;
-        document.body.appendChild(link);
-        link.click();
-        document.body.removeChild(link);
-        console.log("Image downloaded (showSaveFilePicker not supported).");
-      }
-    } catch (error) {
-      if (error.name === "AbortError") {
-        console.log("Save operation aborted by user.");
-      } else {
-        console.error("Error saving file:", error);
+        const arrayBuffer = await blob.arrayBuffer();
+        await fs.promises.writeFile(path, new Uint8Array(arrayBuffer));
+        this.zenfsPath = path;
+        this.file = new File([blob], path.split("/").pop(), { type: blob.type });
+        this.win.title(`${this.file.name} - Image Viewer`);
+        console.log("Image saved successfully to ZenFS:", path);
+      } catch (e) {
+        console.error("Error saving image to ZenFS:", e);
         alert("Could not save the image. Please try again.");
       }
     }
@@ -659,7 +638,7 @@ export class ImageViewerApp extends Application {
     reader.readAsArrayBuffer(this.file);
   }
 
-  extractIcon(icon) {
+  async extractIcon(icon) {
     const canvas = document.createElement("canvas");
     canvas.width = icon.width;
     canvas.height = icon.height;
@@ -673,19 +652,32 @@ export class ImageViewerApp extends Application {
     ctx.putImageData(imageData, 0, 0);
 
     const dataUrl = canvas.toDataURL("image/png");
-    const link = document.createElement("a");
-    link.href = dataUrl;
 
     const originalName = this.file.name;
     const nameWithoutExt =
       originalName.lastIndexOf(".") !== -1
         ? originalName.substring(0, originalName.lastIndexOf("."))
         : originalName;
-    link.download = `${nameWithoutExt}-${icon.width}.png`;
+    const suggestedName = `${nameWithoutExt}-${icon.width}.png`;
 
-    document.body.appendChild(link);
-    link.click();
-    document.body.removeChild(link);
+    const path = await ShowFilePicker({
+      title: "Extract Icon",
+      mode: "save",
+      suggestedName,
+      fileTypes: [{ label: "PNG Image", extensions: ["png"] }],
+    });
+
+    if (path) {
+      try {
+        const base64Data = dataUrl.split(",")[1];
+        const buffer = Uint8Array.from(atob(base64Data), (c) => c.charCodeAt(0));
+        await fs.promises.writeFile(path, buffer);
+        console.log("Icon extracted successfully to ZenFS:", path);
+      } catch (e) {
+        console.error("Error extracting icon to ZenFS:", e);
+        alert("Could not extract the icon.");
+      }
+    }
   }
 
   removeBackground() {

--- a/src/apps/themetocss/ThemeToCssApp.js
+++ b/src/apps/themetocss/ThemeToCssApp.js
@@ -1,4 +1,7 @@
 import { Application } from "../Application.js";
+import { fs } from "@zenfs/core";
+import { ShowFilePicker } from "../../utils/filePicker.js";
+import { getZenFSFileAsText } from "../../utils/zenfs-utils.js";
 import { NotepadEditor } from "../../components/NotepadEditor.js";
 import "./themetocss.css";
 import { ICONS } from "../../config/icons.js";
@@ -94,63 +97,53 @@ export class ThemeToCssApp extends Application {
   }
 
   async _openFile() {
-    const input = document.createElement("input");
-    input.type = "file";
-    input.accept = ".theme,.themepack";
-    input.onchange = async (event) => {
-      const file = event.target.files[0];
-      if (!file) return;
+    const path = await ShowFilePicker({
+      title: "Open Theme File",
+      mode: "open",
+      fileTypes: [
+        {
+          label: "Theme Files (*.theme, *.themepack)",
+          extensions: ["theme", "themepack"],
+        },
+      ],
+    });
 
-      const reader = new FileReader();
-      reader.onload = async (e) => {
-        const themeContent = e.target.result;
-        try {
-          await this._loadParserScript();
-          const cssProperties = window.parseThemeFileString(themeContent);
-          if (cssProperties) {
-            const cssFileContent = window.makeThemeCSSFile(cssProperties);
-            this.editor.setValue(cssFileContent);
-            this._renderSwatches(cssProperties);
-          } else {
-            this.editor.setValue(
-              "/* Error: Failed to parse theme file. See console for details. */",
-            );
-          }
-        } catch (error) {
-          console.error(error);
-          this.editor.setValue(`/* Error: ${error.message} */`);
+    if (path) {
+      try {
+        const themeContent = await getZenFSFileAsText(path);
+        await this._loadParserScript();
+        const cssProperties = window.parseThemeFileString(themeContent);
+        if (cssProperties) {
+          const cssFileContent = window.makeThemeCSSFile(cssProperties);
+          this.editor.setValue(cssFileContent);
+          this._renderSwatches(cssProperties);
+        } else {
+          this.editor.setValue(
+            "/* Error: Failed to parse theme file. See console for details. */",
+          );
         }
-      };
-      reader.readAsText(file);
-    };
-    input.click();
+      } catch (error) {
+        console.error(error);
+        this.editor.setValue(`/* Error: ${error.message} */`);
+      }
+    }
   }
 
   async _saveFile() {
     const content = this.editor.getValue();
-    const blob = new Blob([content], { type: "text/css" });
 
-    try {
-      const handle = await window.showSaveFilePicker({
-        suggestedName: "theme.css",
-        types: [
-          {
-            description: "CSS Files",
-            accept: { "text/css": [".css"] },
-          },
-        ],
-      });
-      const writable = await handle.createWritable();
-      await writable.write(blob);
-      await writable.close();
-    } catch (err) {
-      // Fallback for browsers that don't support the API
-      if (err.name !== "AbortError") {
-        const a = document.createElement("a");
-        a.href = URL.createObjectURL(blob);
-        a.download = "theme.css";
-        a.click();
-        URL.revokeObjectURL(a.href);
+    const path = await ShowFilePicker({
+      title: "Save CSS",
+      mode: "save",
+      suggestedName: "theme.css",
+      fileTypes: [{ label: "CSS Files (*.css)", extensions: ["css"] }],
+    });
+
+    if (path) {
+      try {
+        await fs.promises.writeFile(path, content);
+      } catch (err) {
+        console.error("Error saving file:", err);
       }
     }
   }

--- a/src/apps/wordpad/WordPadApp.js
+++ b/src/apps/wordpad/WordPadApp.js
@@ -1,5 +1,8 @@
 import { Application } from "../Application.js";
+import { fs } from "@zenfs/core";
 import { ShowDialogWindow } from "../../components/DialogWindow.js";
+import { ShowFilePicker } from "../../utils/filePicker.js";
+import { getZenFSFileAsText } from "../../utils/zenfs-utils.js";
 import "./wordpad.css";
 import { ICONS } from "../../config/icons.js";
 
@@ -20,7 +23,7 @@ export class WordPadApp extends Application {
     this.win = null;
     this.editor = null;
     this.colorPalette = null;
-    this.fileHandle = null;
+    this.zenfsPath = null;
     this.isDirty = false;
     this.fileName = "Untitled";
     this.findState = {
@@ -811,7 +814,7 @@ export class WordPadApp extends Application {
     if ((await this.checkForUnsavedChanges()) === "cancel") return;
     this.editor.innerHTML = "";
     this.fileName = "Untitled";
-    this.fileHandle = null;
+    this.zenfsPath = null;
     this.isDirty = false;
     this.updateTitle();
     this.findState = {
@@ -823,33 +826,31 @@ export class WordPadApp extends Application {
 
   async openFile() {
     if ((await this.checkForUnsavedChanges()) === "cancel") return;
-    const input = document.createElement("input");
-    input.type = "file";
-    input.accept = ".html";
-    input.onchange = (e) => {
-      const file = e.target.files[0];
-      if (!file) return;
 
-      this.fileName = file.name;
-      this.fileHandle = null;
-      this.isDirty = false;
-      this.updateTitle();
+    const path = await ShowFilePicker({
+      title: "Open Document",
+      mode: "open",
+      fileTypes: [{ label: "HTML Document (*.html)", extensions: ["html"] }],
+    });
 
-      const reader = new FileReader();
-      reader.onload = (event) => {
-        this.editor.innerHTML = event.target.result;
+    if (path) {
+      try {
+        const content = await getZenFSFileAsText(path);
+        this.editor.innerHTML = content;
+        this.zenfsPath = path;
+        this.fileName = path.split("/").pop();
         this.isDirty = false;
         this.updateTitle();
-      };
-      reader.readAsText(file);
-    };
-    input.click();
+      } catch (e) {
+        console.error("Error opening file from ZenFS:", e);
+      }
+    }
   }
 
   async saveFile() {
-    if (this.fileHandle) {
+    if (this.zenfsPath) {
       try {
-        await this.writeFile(this.fileHandle);
+        await fs.promises.writeFile(this.zenfsPath, this.editor.innerHTML);
         this.isDirty = false;
         this.updateTitle();
       } catch (err) {
@@ -861,46 +862,25 @@ export class WordPadApp extends Application {
   }
 
   async saveAs() {
-    const fileTypes = [
-      { description: "HTML Document", accept: { "text/html": [".html"] } },
-    ];
+    const path = await ShowFilePicker({
+      title: "Save Document As",
+      mode: "save",
+      suggestedName:
+        this.fileName === "Untitled" ? "Untitled.html" : this.fileName,
+      fileTypes: [{ label: "HTML Document (*.html)", extensions: ["html"] }],
+    });
 
-    if (window.showSaveFilePicker) {
+    if (path) {
       try {
-        const handle = await window.showSaveFilePicker({
-          types: fileTypes,
-          suggestedName: "Untitled.html",
-        });
-        this.fileHandle = handle;
-        this.fileName = handle.name;
-        await this.writeFile(handle);
+        await fs.promises.writeFile(path, this.editor.innerHTML);
+        this.zenfsPath = path;
+        this.fileName = path.split("/").pop();
         this.isDirty = false;
         this.updateTitle();
       } catch (err) {
-        if (err.name !== "AbortError") console.error("Error saving file:", err);
+        console.error("Error saving file:", err);
       }
-    } else {
-      // Fallback for older browsers
-      const content = this.editor.innerHTML;
-      const blob = new Blob([content], { type: "text/html" });
-      const a = document.createElement("a");
-      a.href = URL.createObjectURL(blob);
-      a.download = this.fileName.endsWith(".html")
-        ? this.fileName
-        : "Untitled.html";
-      a.click();
-      URL.revokeObjectURL(a.href);
-      this.isDirty = false;
-      this.fileName = a.download;
-      this.updateTitle();
     }
-  }
-
-  async writeFile(fileHandle) {
-    const writable = await fileHandle.createWritable();
-    const content = this.editor.innerHTML;
-    await writable.write(content);
-    await writable.close();
   }
 
   showUnsavedChangesDialog(options = {}) {


### PR DESCRIPTION
Identified and migrated all applications using native browser file pickers (except ZenExplorer) to use the custom ZenFS \`ShowFilePicker\`. 

Key changes:
- Updated \`DisplayPropertiesApp\` (Background/Appearance) to use \`ShowFilePicker\` for theme and wallpaper selection.
- Updated \`ImageResizerApp\` to use \`ShowFilePicker\` for opening and saving images.
- Updated \`AppMakerApp\` to use \`ShowFilePicker\` for app icon and HTML selection.
- Updated \`ThemeToCssApp\` to use \`ShowFilePicker\` for theme opening and CSS saving.
- Updated \`ImageViewerApp\` to use \`ShowFilePicker\` for all open, save, and export operations.
- Updated \`WordPadApp\` to use \`ShowFilePicker\` for opening and saving documents.

Removed all browser download fallbacks in favor of ZenFS persistence. Verified integration with Playwright E2E tests.

---
*PR created automatically by Jules for task [13140757079092987468](https://jules.google.com/task/13140757079092987468) started by @azayrahmad*