### PR TITLE
Prevent file renaming on cut-and-paste to same directory

### DIFF
--- a/e2e/zenexplorer_cut_paste.spec.js
+++ b/e2e/zenexplorer_cut_paste.spec.js
@@ -1,0 +1,157 @@
+import { test, expect } from '@playwright/test';
+
+test.describe('ZenExplorer File Operations', () => {
+    test.beforeEach(async ({ page }) => {
+        test.setTimeout(120000);
+        await page.goto('http://localhost:5173/win98-web/');
+
+        // Wait for the "Press any key to continue" boot prompt (if any)
+        await page.waitForTimeout(5000);
+        await page.keyboard.press('Enter');
+
+        // Wait for the desktop to be ready
+        const desktop = page.locator('.desktop');
+        await expect(desktop).toBeVisible({ timeout: 60000 });
+
+        // Ensure launchApp is available
+        await page.waitForFunction(() => typeof window.System?.launchApp === 'function');
+    });
+
+    test('Cut and Paste to same directory should NOT rename', async ({ page }) => {
+        // Launch ZenExplorer directly to C:
+        await page.evaluate(() => {
+            window.System.launchApp('explorer', '/C:');
+        });
+
+        const zenWin = page.locator('.window[data-app-id="explorer"]').first();
+        await expect(zenWin).toBeVisible();
+
+        // Create a new file
+        await zenWin.locator('.explorer-icon-view').click({ button: 'right' });
+        await page.getByRole('menuitem', { name: 'New' }).click();
+        await page.getByRole('menuitem', { name: 'Text Document' }).click();
+
+        // Name it "CutTest.txt"
+        const renameInput = zenWin.locator('.icon-label-input');
+        await expect(renameInput).toBeVisible();
+        await renameInput.fill('CutTest.txt');
+        await renameInput.press('Enter');
+
+        const fileIcon = zenWin.locator('.explorer-icon[data-name="CutTest.txt"]');
+        await expect(fileIcon).toBeVisible();
+
+        // Cut the file
+        await fileIcon.click({ button: 'right' });
+        await page.getByRole('menuitem', { name: 'Cut', exact: true }).click();
+
+        // Paste in the same directory (C:)
+        await zenWin.locator('.explorer-icon-view').click({ button: 'right' });
+        await page.getByRole('menuitem', { name: 'Paste', exact: true }).click();
+
+        // Wait for potential refresh/animation
+        await page.waitForTimeout(2000);
+
+        // Assert the file name is still "CutTest.txt" and NOT "CutTest (1).txt"
+        const fileNames = await zenWin.locator('.explorer-icon').evaluateAll(icons => icons.map(i => i.getAttribute('data-name')));
+        console.log('File names after same-dir cut-paste:', fileNames);
+
+        expect(fileNames).toContain('CutTest.txt');
+        expect(fileNames).not.toContain('CutTest (1).txt');
+    });
+
+    test('Copy and Paste to same directory should create "Copy of ..."', async ({ page }) => {
+        // Launch ZenExplorer directly to C:
+        await page.evaluate(() => {
+            window.System.launchApp('explorer', '/C:');
+        });
+
+        const zenWin = page.locator('.window[data-app-id="explorer"]').first();
+        await expect(zenWin).toBeVisible();
+
+        // Create a new file
+        await zenWin.locator('.explorer-icon-view').click({ button: 'right' });
+        await page.getByRole('menuitem', { name: 'New' }).click();
+        await page.getByRole('menuitem', { name: 'Text Document' }).click();
+
+        // Name it "CopyTest.txt"
+        const renameInput = zenWin.locator('.icon-label-input');
+        await expect(renameInput).toBeVisible();
+        await renameInput.fill('CopyTest.txt');
+        await renameInput.press('Enter');
+
+        const fileIcon = zenWin.locator('.explorer-icon[data-name="CopyTest.txt"]');
+        await expect(fileIcon).toBeVisible();
+
+        // Copy the file
+        await fileIcon.click({ button: 'right' });
+        await page.getByRole('menuitem', { name: 'Copy', exact: true }).click();
+
+        // Paste in the same directory (C:)
+        await zenWin.locator('.explorer-icon-view').click({ button: 'right' });
+        await page.getByRole('menuitem', { name: 'Paste', exact: true }).click();
+
+        // Wait for potential refresh/animation
+        await page.waitForTimeout(2000);
+
+        // Assert that "Copy of CopyTest.txt" exists
+        const fileNames = await zenWin.locator('.explorer-icon').evaluateAll(icons => icons.map(i => i.getAttribute('data-name')));
+        console.log('File names after same-dir copy-paste:', fileNames);
+
+        expect(fileNames).toContain('CopyTest.txt');
+        expect(fileNames).toContain('Copy of CopyTest.txt');
+    });
+
+    test('Cut and Paste to DIFFERENT directory with conflict should rename', async ({ page }) => {
+        // Launch ZenExplorer directly to C:
+        await page.evaluate(() => {
+            window.System.launchApp('explorer', '/C:');
+        });
+
+        const zenWin = page.locator('.window[data-app-id="explorer"]').first();
+        await expect(zenWin).toBeVisible();
+
+        // Create "Conflict.txt" in C:
+        await zenWin.locator('.explorer-icon-view').click({ button: 'right' });
+        await page.getByRole('menuitem', { name: 'New' }).click();
+        await page.getByRole('menuitem', { name: 'Text Document' }).click();
+        let renameInput = zenWin.locator('.icon-label-input');
+        await expect(renameInput).toBeVisible();
+        await renameInput.fill('Conflict.txt');
+        await renameInput.press('Enter');
+
+        // Create "Conflict.txt" in C:/WINDOWS
+        await zenWin.locator('.explorer-icon').filter({ hasText: /^WINDOWS$/ }).dblclick();
+        await page.waitForTimeout(1000);
+        await zenWin.locator('.explorer-icon-view').click({ button: 'right' });
+        await page.getByRole('menuitem', { name: 'New' }).click();
+        await page.getByRole('menuitem', { name: 'Text Document' }).click();
+        renameInput = zenWin.locator('.icon-label-input');
+        await expect(renameInput).toBeVisible();
+        await renameInput.fill('Conflict.txt');
+        await renameInput.press('Enter');
+
+        // Go back to C:
+        await zenWin.getByRole('button', { name: 'Up' }).click();
+        await page.waitForTimeout(1000);
+
+        // Cut Conflict.txt from C:
+        const fileIcon = zenWin.locator('.explorer-icon[data-name="Conflict.txt"]');
+        await fileIcon.click({ button: 'right' });
+        await page.getByRole('menuitem', { name: 'Cut', exact: true }).click();
+
+        // Paste into C:/WINDOWS
+        await zenWin.locator('.explorer-icon').filter({ hasText: /^WINDOWS$/ }).click({ button: 'right' });
+        await page.getByRole('menuitem', { name: 'Paste', exact: true }).click();
+
+        // Navigate into C:/WINDOWS to verify
+        await zenWin.locator('.explorer-icon').filter({ hasText: /^WINDOWS$/ }).dblclick();
+        await page.waitForTimeout(2000);
+
+        // Assert that "Conflict (1).txt" exists
+        const fileNames = await zenWin.locator('.explorer-icon').evaluateAll(icons => icons.map(i => i.getAttribute('data-name')));
+        console.log('File names in WINDOWS after cross-dir conflict cut-paste:', fileNames);
+
+        expect(fileNames).toContain('Conflict.txt');
+        expect(fileNames).toContain('Conflict (1).txt');
+    });
+});

--- a/src/apps/zenexplorer/fileoperations/FileOperations.js
+++ b/src/apps/zenexplorer/fileoperations/FileOperations.js
@@ -113,15 +113,17 @@ export class FileOperations {
             for (const itemPath of sourcePaths) {
                 if (dialog && dialog.cancelled) break;
                 const itemName = getPathName(itemPath);
-                const targetPath = await this.getUniquePastePath(destinationPath, itemName, "cut");
-                if (dialog) {
-                    const stats = await fs.promises.stat(ShellManager.getRealPath(itemPath));
-                    const sourceDir = getParentPath(itemPath);
-                    dialog.update(itemPath, sourceDir, destinationPath, 0);
-                    await fs.promises.rename(ShellManager.getRealPath(itemPath), ShellManager.getRealPath(targetPath));
-                    dialog.finishItem(stats.isDirectory() ? 0 : stats.size);
-                } else {
-                    await fs.promises.rename(ShellManager.getRealPath(itemPath), ShellManager.getRealPath(targetPath));
+                const targetPath = await this.getUniquePastePath(destinationPath, itemName, "cut", itemPath);
+                if (itemPath !== targetPath) {
+                    if (dialog) {
+                        const stats = await fs.promises.stat(ShellManager.getRealPath(itemPath));
+                        const sourceDir = getParentPath(itemPath);
+                        dialog.update(itemPath, sourceDir, destinationPath, 0);
+                        await fs.promises.rename(ShellManager.getRealPath(itemPath), ShellManager.getRealPath(targetPath));
+                        dialog.finishItem(stats.isDirectory() ? 0 : stats.size);
+                    } else {
+                        await fs.promises.rename(ShellManager.getRealPath(itemPath), ShellManager.getRealPath(targetPath));
+                    }
                 }
                 targetPaths.push(targetPath);
             }
@@ -149,7 +151,7 @@ export class FileOperations {
             for (const itemPath of sourcePaths) {
                 if (dialog && dialog.cancelled) break;
                 const itemName = getPathName(itemPath);
-                const targetPath = await this.getUniquePastePath(destinationPath, itemName, "copy");
+                const targetPath = await this.getUniquePastePath(destinationPath, itemName, "copy", itemPath);
                 await this.copyRecursive(itemPath, targetPath, dialog);
                 targetPaths.push(targetPath);
             }
@@ -171,7 +173,7 @@ export class FileOperations {
         }
     }
 
-    async getUniquePastePath(destPath, originalName, operation) {
+    async getUniquePastePath(destPath, originalName, operation, sourcePath = null) {
         if (operation === "shortcut") {
             let candidateName = `Shortcut to ${originalName}.lnk`;
             let checkPath = normalizePath(joinPath(destPath, candidateName));
@@ -190,6 +192,11 @@ export class FileOperations {
         }
 
         let checkPath = normalizePath(joinPath(destPath, originalName));
+
+        if (operation === "cut" && sourcePath && normalizePath(sourcePath) === normalizePath(checkPath)) {
+            return checkPath;
+        }
+
         try {
             await fs.promises.stat(ShellManager.getRealPath(checkPath));
         } catch (e) {


### PR DESCRIPTION
Prevent ZenExplorer from renaming files with a counter when they are cut and pasted into the same directory. Added comprehensive E2E tests and verified visually.

---
*PR created automatically by Jules for task [12468664842133808346](https://jules.google.com/task/12468664842133808346) started by @azayrahmad*