### PR TITLE
Fix Internet Explorer shell extension for local HTML files

### DIFF
--- a/src/apps/zenexplorer/ZenExplorerApp.js
+++ b/src/apps/zenexplorer/ZenExplorerApp.js
@@ -46,20 +46,29 @@ ShellManager.registerExtension(new InternetExplorerExtension());
 export class ZenExplorerApp extends Application {
   isWebPath(path) {
     if (!path) return false;
+    const p = path.toLowerCase();
     if (
-      path.startsWith("http://") ||
-      path.startsWith("https://") ||
-      path.includes("azay.rahmad")
+      p.startsWith("http://") ||
+      p.startsWith("https://") ||
+      p.includes("azay.rahmad")
     ) {
       return true;
     }
     // Domain-like: contains a dot, doesn't start with a slash or drive letter, and no spaces
-    return (
+    if (
       !path.startsWith("/") &&
       !/^[A-Z]:/i.test(path) &&
       path.includes(".") &&
       !path.includes(" ")
-    );
+    ) {
+      return true;
+    }
+    // Local HTML: must start with a slash to be considered a "web path" within the shell
+    // This allows unnormalized local paths (like C:\index.html) to be normalized first
+    if (path.startsWith("/") && (p.endsWith(".html") || p.endsWith(".htm"))) {
+      return true;
+    }
+    return false;
   }
 
   static config = {
@@ -86,6 +95,7 @@ export class ZenExplorerApp extends Application {
     this.keyboardHandler = new KeyboardHandler(this);
     this.retroMode = true;
     this.blobUrl = null;
+    this.isInWebMode = false;
   }
 
   async launch(data = null) {
@@ -196,7 +206,7 @@ export class ZenExplorerApp extends Application {
           items.push({ name, path, icon: iconObj[16], indent });
         };
 
-        if (this.isWebPath(currentPath)) {
+        if (this.isInWebMode) {
           // Show history in IE mode
           return this.navHistory.history.map((url) => ({
             name: url,
@@ -580,7 +590,7 @@ export class ZenExplorerApp extends Application {
   }
 
   _updateMode() {
-    const isWeb = this.isWebPath(this.currentPath);
+    const isWeb = this.isInWebMode;
     const wasWeb = this.iframe.style.display === "block";
 
     if (isWeb) {

--- a/src/apps/zenexplorer/interface/DirectoryView.js
+++ b/src/apps/zenexplorer/interface/DirectoryView.js
@@ -57,7 +57,7 @@ export class DirectoryView {
       icon = getThemedIconObj("recycle", isEmpty);
     }
 
-    const isWeb = this.app.isWebPath(path);
+    const isWeb = this.app.isInWebMode;
     const displayPath = isWeb ? path : formatPathForDisplay(path);
     const displayTitle = isWeb ? `${name} - Internet Explorer` : name;
 

--- a/src/apps/zenexplorer/navigation/NavigationController.js
+++ b/src/apps/zenexplorer/navigation/NavigationController.js
@@ -48,11 +48,13 @@ export class NavigationController {
       }
 
       const stats = await ShellManager.stat(normalizedPath);
-      const isWeb = this.app.isWebPath(normalizedPath);
+      const isWeb = this.app.isWebPath(normalizedPath) && !stats.isDirectory();
 
       if (!stats.isDirectory() && !isWeb) {
         throw new Error("Not a directory");
       }
+
+      this.app.isInWebMode = isWeb;
 
       // Update navigation history
       if (!isHistoryNav) {


### PR DESCRIPTION
This PR fixes a bug in ZenExplorer where attempting to open a local HTML file (e.g., from an icon or address bar) would fail with a "Not a directory" error from the NavigationController.

Key changes:
1. **State-based IE Mode**: Introduced `isInWebMode` in `ZenExplorerApp` to provide a consistent source of truth for the UI mode, replacing inconsistent heuristics.
2. **Local HTML Support**: Updated `isWebPath` to include absolute ZenFS paths ending in `.html` or `.htm`.
3. **Refined Navigation Logic**: `NavigationController` now checks if a path is both a "web path" and not a directory before deciding to enter IE mode. This correctly handles folders that happen to have web-like extensions.
4. **Icon and Association Preservation**: By only updating the app-level `isWebPath` and not the `InternetExplorerExtension.handlesPath`, we ensure that local HTML files still use their standard "HTML document" icon and maintain their default file associations (opening in a new window on double-click) while allowing in-window navigation via the address bar.

---
*PR created automatically by Jules for task [15717850048069381642](https://jules.google.com/task/15717850048069381642) started by @azayrahmad*