### PR TITLE
Improve shortcuts and add Paste Shortcut feature

### DIFF
--- a/src/apps/zenexplorer/ZenExplorerApp.js
+++ b/src/apps/zenexplorer/ZenExplorerApp.js
@@ -468,7 +468,7 @@ export class ZenExplorerApp extends Application {
     if (handled) return;
 
     // Handle .lnk files
-    if (name.endsWith(".lnk")) {
+    if (name.endsWith(".lnk.json") || name.endsWith(".lnk")) {
       try {
         const content = await fs.promises.readFile(ShellManager.getRealPath(fullPath), "utf8");
         const data = JSON.parse(content);

--- a/src/apps/zenexplorer/extensions/DesktopExtension.js
+++ b/src/apps/zenexplorer/extensions/DesktopExtension.js
@@ -201,7 +201,7 @@ export class DesktopExtension {
 
       const stats = await fs.promises.stat(realFullPath);
       if (!stats.isDirectory()) {
-        if (name.endsWith(".lnk")) return false; // Let the app handle shortcuts
+        if (name.endsWith(".lnk.json") || name.endsWith(".lnk")) return false; // Let the app handle shortcuts
 
         const { getAssociation } = await import("../../../utils/directory.js");
         const { launchApp } = await import("../../../utils/appManager.js");

--- a/src/apps/zenexplorer/fileoperations/FileOperations.js
+++ b/src/apps/zenexplorer/fileoperations/FileOperations.js
@@ -28,19 +28,25 @@ export class FileOperations {
         ClipboardManager.set(paths, "copy");
     }
 
-    async createShortcuts(paths, destinationPath = null) {
+    async createShortcuts(paths, destinationPath = null, dialog = null) {
         const dest = destinationPath || this.app.currentPath;
         const targetPaths = [];
         try {
             for (const itemPath of paths) {
+                if (dialog && dialog.cancelled) break;
                 const itemName = getPathName(itemPath);
                 const targetLnkPath = await this.getUniquePastePath(dest, itemName, "shortcut");
+
+                if (dialog) {
+                    const sourceDir = getParentPath(itemPath);
+                    dialog.update(itemPath, sourceDir, dest, 0);
+                }
 
                 let lnkData = { type: "shortcut" };
 
                 // Check if it's already a shortcut with an appId
                 const stats = await ShellManager.stat(itemPath).catch(() => ({}));
-                if (stats.isFile && stats.isFile() && itemPath.endsWith(".lnk")) {
+                if (stats.isFile && stats.isFile() && (itemPath.endsWith(".lnk.json") || itemPath.endsWith(".lnk"))) {
                     try {
                         const content = await fs.promises.readFile(ShellManager.getRealPath(itemPath), "utf8");
                         const data = JSON.parse(content);
@@ -59,9 +65,12 @@ export class FileOperations {
 
                 await fs.promises.writeFile(ShellManager.getRealPath(targetLnkPath), JSON.stringify(lnkData, null, 2));
                 targetPaths.push(targetLnkPath);
+                if (dialog) dialog.finishItem(0);
             }
 
-            await this.app.navigateTo(this.app.currentPath, true, true);
+            if (dest === this.app.currentPath) {
+                await this.app.navigateTo(this.app.currentPath, true, true);
+            }
             document.dispatchEvent(new CustomEvent("fs-change", { detail: { sourceAppId: this.app.win.element.id } }));
         } catch (e) {
             handleFileSystemError("create", e, "shortcut");
@@ -102,6 +111,20 @@ export class FileOperations {
             } else if (operation === "copy") {
                 await this.copyItemsDirect(items, destinationPath, {}, dialog);
             }
+        } finally {
+            dialog.close();
+        }
+    }
+
+    async pasteShortcuts(destinationPath) {
+        const { items, operation } = ClipboardManager.get();
+        if (items.length === 0 || operation === "cut") return;
+
+        const { ProgressBarDialogWindow } = await import("../interface/ProgressBarDialogWindow.js");
+        const dialog = new ProgressBarDialogWindow("shortcut", items.length, 0);
+
+        try {
+            await this.createShortcuts(items, destinationPath, dialog);
         } finally {
             dialog.close();
         }
@@ -175,13 +198,14 @@ export class FileOperations {
 
     async getUniquePastePath(destPath, originalName, operation, sourcePath = null) {
         if (operation === "shortcut") {
-            let candidateName = `Shortcut to ${originalName}.lnk`;
+            const cleanName = originalName.replace(".lnk.json", "").replace(".lnk", "");
+            let candidateName = `Shortcut to ${cleanName}.lnk.json`;
             let checkPath = normalizePath(joinPath(destPath, candidateName));
             try {
                 await fs.promises.stat(ShellManager.getRealPath(checkPath));
                 let counter = 2;
                 while (true) {
-                    candidateName = `Shortcut (${counter}) to ${originalName}.lnk`;
+                    candidateName = `Shortcut (${counter}) to ${cleanName}.lnk.json`;
                     checkPath = normalizePath(joinPath(destPath, candidateName));
                     try {
                         await fs.promises.stat(ShellManager.getRealPath(checkPath));

--- a/src/apps/zenexplorer/interface/ContextMenuBuilder.js
+++ b/src/apps/zenexplorer/interface/ContextMenuBuilder.js
@@ -164,6 +164,12 @@ export class ContextMenuBuilder {
             !ClipboardManager.isEmpty() && type === "directory",
         },
         {
+          label: "Paste Shortcut",
+          action: () => this.app.fileOps.pasteShortcuts(path),
+          enabled: () =>
+            !ClipboardManager.isEmpty() && ClipboardManager.operation === "copy" && type === "directory",
+        },
+        {
           label: "Create Shortcut",
           action: () => this.app.fileOps.createShortcuts(selectedPaths),
           enabled: () => !isRootItem && !isRecycleBin && !anyVirtual,
@@ -253,6 +259,11 @@ export class ContextMenuBuilder {
         label: "Paste",
         action: () => this.app.fileOps.pasteItems(this.app.currentPath),
         enabled: () => !ClipboardManager.isEmpty() && ((!isRoot || isVirtualDesktop) && !isGlobalRecycleBin),
+      },
+      {
+        label: "Paste Shortcut",
+        action: () => this.app.fileOps.pasteShortcuts(this.app.currentPath),
+        enabled: () => !ClipboardManager.isEmpty() && ClipboardManager.operation === "copy" && ((!isRoot || isVirtualDesktop) && !isGlobalRecycleBin),
       },
       "MENU_DIVIDER",
       {

--- a/src/apps/zenexplorer/interface/DesktopContextMenuBuilder.js
+++ b/src/apps/zenexplorer/interface/DesktopContextMenuBuilder.js
@@ -92,6 +92,11 @@ export class DesktopContextMenuBuilder extends ContextMenuBuilder {
         action: () => this.app.fileOps.pasteItems(this.app.currentPath),
         enabled: () => !ClipboardManager.isEmpty(),
       },
+      {
+        label: "Paste Shortcut",
+        action: () => this.app.fileOps.pasteShortcuts(this.app.currentPath),
+        enabled: () => !ClipboardManager.isEmpty() && ClipboardManager.operation === "copy",
+      },
       "MENU_DIVIDER",
       {
         label: "New",

--- a/src/apps/zenexplorer/interface/DirectoryView.js
+++ b/src/apps/zenexplorer/interface/DirectoryView.js
@@ -274,9 +274,10 @@ export class DirectoryView {
     const label = icon.querySelector(".icon-label");
     const fullPath = icon.getAttribute("data-path");
     const oldName = fullPath.split("/").pop();
+    const isShortcut = oldName.endsWith(".lnk.json") || oldName.endsWith(".lnk");
     const textarea = document.createElement("textarea");
     textarea.className = "icon-label-input";
-    textarea.value = oldName;
+    textarea.value = isShortcut ? oldName.replace(".lnk.json", "").replace(".lnk", "") : oldName;
     textarea.spellcheck = false;
     label.innerHTML = "";
     label.appendChild(textarea);
@@ -293,7 +294,10 @@ export class DirectoryView {
     const finishRename = async (save) => {
       if (!this._isRenaming) return;
       this._isRenaming = false;
-      const newName = textarea.value.trim();
+      let newName = textarea.value.trim();
+      if (isShortcut && newName && !newName.endsWith(".lnk.json") && !newName.endsWith(".lnk")) {
+        newName += ".lnk.json";
+      }
       const busyId = `rename-${Math.random()}`;
       if (save && newName && newName !== oldName) {
         requestBusyState(busyId, this.app.win.element);

--- a/src/apps/zenexplorer/interface/FileIconRenderer.js
+++ b/src/apps/zenexplorer/interface/FileIconRenderer.js
@@ -128,8 +128,9 @@ export async function renderFileIcon(fileName, fullPath, isDir, options = {}) {
   let isShortcut = false;
 
   // Special handling for shortcuts (.lnk files)
-  if (!isDir && fileName.endsWith(".lnk")) {
+  if (!isDir && (fileName.endsWith(".lnk.json") || fileName.endsWith(".lnk"))) {
     isShortcut = true;
+    displayName = displayName.replace(".lnk.json", "").replace(".lnk", "");
     try {
       const content = await fs.promises.readFile(
         ShellManager.getRealPath(fullPath),

--- a/src/apps/zenexplorer/interface/MenuBarBuilder.js
+++ b/src/apps/zenexplorer/interface/MenuBarBuilder.js
@@ -84,6 +84,11 @@ export class MenuBarBuilder {
         action: () => this.app.fileOps.pasteItems(this.app.currentPath),
         enabled: () => !ClipboardManager.isEmpty() && !isRoot && !isRecycleBin,
       },
+      {
+        label: "Paste &Shortcut",
+        action: () => this.app.fileOps.pasteShortcuts(this.app.currentPath),
+        enabled: () => !ClipboardManager.isEmpty() && ClipboardManager.operation === "copy" && !isRoot && !isRecycleBin,
+      },
     ];
   }
 

--- a/src/apps/zenexplorer/interface/ProgressBarDialogWindow.js
+++ b/src/apps/zenexplorer/interface/ProgressBarDialogWindow.js
@@ -26,7 +26,8 @@ export class ProgressBarDialogWindow {
       recycle: "Recycling...",
       delete: "Deleting...",
       empty: "Emptying Recycle Bin...",
-      restore: "Restoring..."
+      restore: "Restoring...",
+      shortcut: "Creating Shortcuts..."
     }[this.operation] || "Processing...";
 
     const gifUrl = {
@@ -35,7 +36,8 @@ export class ProgressBarDialogWindow {
       recycle: new URL("../assets/moving.gif", import.meta.url).href,
       delete: new URL("../assets/copying.gif", import.meta.url).href,
       empty: new URL("../assets/moving.gif", import.meta.url).href,
-      restore: new URL("../assets/moving.gif", import.meta.url).href
+      restore: new URL("../assets/moving.gif", import.meta.url).href,
+      shortcut: new URL("../assets/moving.gif", import.meta.url).href
     }[this.operation] || new URL("../assets/moving.gif", import.meta.url).href;
 
     const content = document.createElement("div");

--- a/src/apps/zenexplorer/navigation/PathUtils.js
+++ b/src/apps/zenexplorer/navigation/PathUtils.js
@@ -67,7 +67,12 @@ export function formatPathForDisplay(path) {
  */
 export function getDisplayName(path) {
     if (path === "/" || path === "My Computer") return "My Computer";
-    const name = path.split("/").filter(Boolean).pop();
+    let name = path.split("/").filter(Boolean).pop();
+
+    if (name && (name.endsWith(".lnk.json") || name.endsWith(".lnk"))) {
+        name = name.replace(".lnk.json", "").replace(".lnk", "");
+    }
+
     if (name && name.match(/^A:$/i)) {
         const label = FloppyManager.getLabel();
         return label ? `${label} (${name.toUpperCase()})` : `3½ Floppy (${name.toUpperCase()})`;

--- a/src/components/desktop.js
+++ b/src/components/desktop.js
@@ -230,9 +230,10 @@ class DesktopController {
     const label = icon.querySelector(".icon-label");
     const fullPath = path;
     const oldName = fullPath.split("/").pop();
+    const isShortcut = oldName.endsWith(".lnk.json") || oldName.endsWith(".lnk");
     const textarea = document.createElement("textarea");
     textarea.className = "icon-label-input";
-    textarea.value = oldName;
+    textarea.value = isShortcut ? oldName.replace(".lnk.json", "").replace(".lnk", "") : oldName;
     textarea.spellcheck = false;
     label.innerHTML = "";
     label.appendChild(textarea);
@@ -253,7 +254,10 @@ class DesktopController {
     const finishRename = async (save) => {
       if (!this._isRenaming) return;
       this._isRenaming = false;
-      const newName = textarea.value.trim();
+      let newName = textarea.value.trim();
+      if (isShortcut && newName && !newName.endsWith(".lnk.json") && !newName.endsWith(".lnk")) {
+        newName += ".lnk.json";
+      }
       if (save && newName && newName !== oldName) {
         try {
           const parentPath =

--- a/src/components/desktop.js
+++ b/src/components/desktop.js
@@ -294,7 +294,7 @@ class DesktopController {
     if (handled) return;
 
     const name = path.split("/").pop();
-    if (name.endsWith(".lnk")) {
+    if (name.endsWith(".lnk.json") || name.endsWith(".lnk")) {
       try {
         const content = await fs.promises.readFile(ShellManager.getRealPath(path), "utf8");
         const data = JSON.parse(content);

--- a/src/utils/migrateShortcuts.js
+++ b/src/utils/migrateShortcuts.js
@@ -1,0 +1,34 @@
+import { fs } from "@zenfs/core";
+import { joinPath } from "../apps/zenexplorer/navigation/PathUtils.js";
+
+/**
+ * Recursively scans the filesystem and renames .lnk files to .lnk.json
+ * @param {string} dir - Directory to scan
+ */
+export async function migrateShortcuts(dir = "/") {
+    try {
+        const files = await fs.promises.readdir(dir);
+        for (const file of files) {
+            const fullPath = joinPath(dir, file);
+            let stats;
+            try {
+                stats = await fs.promises.stat(fullPath);
+            } catch (e) {
+                continue;
+            }
+
+            if (stats.isDirectory()) {
+                await migrateShortcuts(fullPath);
+            } else if (file.endsWith(".lnk") && !file.endsWith(".lnk.json")) {
+                const newPath = fullPath + ".json";
+                try {
+                    await fs.promises.rename(fullPath, newPath);
+                } catch (e) {
+                    console.error(`Failed to migrate shortcut ${fullPath}:`, e);
+                }
+            }
+        }
+    } catch (e) {
+        console.error(`Error during shortcut migration in ${dir}:`, e);
+    }
+}

--- a/src/utils/startMenuUtils.js
+++ b/src/utils/startMenuUtils.js
@@ -28,7 +28,7 @@ export async function migrateToZenFS(config, targetPath) {
       await migrateToZenFS(item.submenu, dirPath);
     } else if (item.appId) {
       // Create a shortcut
-      const lnkPath = `${targetPath}/${item.label}.lnk`;
+      const lnkPath = `${targetPath}/${item.label}.lnk.json`;
       const lnkData = {
         type: "shortcut",
         appId: item.appId,
@@ -48,7 +48,7 @@ export async function migrateToZenFS(config, targetPath) {
 export async function loadLnk(path, iconSize = 16) {
   try {
     const filename = path.split("/").pop();
-    const label = filename.replace(".lnk", "");
+    const label = filename.replace(".lnk.json", "").replace(".lnk", "");
     const content = await fs.promises.readFile(path, "utf8");
     const data = JSON.parse(content);
 
@@ -117,7 +117,7 @@ export async function getPinnedItemsFromZenFS(path = PINNED_PATH) {
       const fullPath = `${path}/${file}`;
       const stat = await fs.promises.stat(fullPath);
 
-      if (!stat.isDirectory() && file.endsWith(".lnk")) {
+      if (!stat.isDirectory() && file.endsWith(".lnk.json")) {
         const item = await loadLnk(fullPath, 32);
         if (item) {
           menuItems.push(item);
@@ -158,7 +158,7 @@ export async function getMenuFromZenFS(path) {
           icon: ICONS.programs[16],
           submenu: await getMenuFromZenFS(fullPath),
         });
-      } else if (file.endsWith(".lnk")) {
+      } else if (file.endsWith(".lnk.json")) {
         const item = await loadLnk(fullPath);
         if (item) {
           menuItems.push(item);

--- a/src/utils/startupManager.js
+++ b/src/utils/startupManager.js
@@ -19,7 +19,7 @@ export async function getStartupApps() {
     if (await existsAsync(STARTUP_PATH)) {
       const files = await fs.promises.readdir(STARTUP_PATH);
       for (const file of files) {
-        if (file.endsWith(".lnk")) {
+        if (file.endsWith(".lnk.json")) {
           const content = await fs.promises.readFile(`${STARTUP_PATH}/${file}`, "utf8");
           const data = JSON.parse(content);
           if (data.appId) {
@@ -51,7 +51,7 @@ export async function addStartupApp(appId) {
     }
     const app = apps.find(a => a.id === appId);
     const label = app ? app.title : appId;
-    const lnkPath = `${STARTUP_PATH}/${label}.lnk`;
+    const lnkPath = `${STARTUP_PATH}/${label}.lnk.json`;
 
     if (!(await existsAsync(lnkPath))) {
       await fs.promises.writeFile(lnkPath, JSON.stringify({
@@ -81,7 +81,7 @@ export async function removeStartupApp(appId) {
     if (await existsAsync(STARTUP_PATH)) {
       const files = await fs.promises.readdir(STARTUP_PATH);
       for (const file of files) {
-        if (file.endsWith(".lnk")) {
+        if (file.endsWith(".lnk.json")) {
           const content = await fs.promises.readFile(`${STARTUP_PATH}/${file}`, "utf8");
           const data = JSON.parse(content);
           if (data.appId === appId) {

--- a/src/utils/zenfs-init.js
+++ b/src/utils/zenfs-init.js
@@ -1,6 +1,7 @@
 import { resolveMountConfig, InMemory, fs } from "@zenfs/core";
 import { IndexedDB } from "@zenfs/dom";
 import { migrateToZenFS, PINNED_PATH, START_MENU_PATH, FAVORITES_PATH } from "./startMenuUtils.js";
+import { migrateShortcuts } from "./migrateShortcuts.js";
 import startMenuConfig from "../config/startmenu.js";
 import { getStartupApps } from "./startupManager.js";
 import { apps } from "../config/apps.js";
@@ -73,7 +74,7 @@ export async function initFileSystem(onProgress) {
         }
 
         // Ensure About shortcut exists in PINNED_PATH
-        const aboutLnkPath = `${PINNED_PATH}/About.lnk`;
+        const aboutLnkPath = `${PINNED_PATH}/About.lnk.json`;
         if (!(await existsAsync(aboutLnkPath))) {
             await fs.promises.writeFile(aboutLnkPath, JSON.stringify({
                 type: "shortcut",
@@ -97,7 +98,7 @@ export async function initFileSystem(onProgress) {
                 for (const appId of startupApps) {
                     const app = apps.find(a => a.id === appId);
                     const label = app ? app.title : appId;
-                    const lnkPath = `${startupPath}/${label}.lnk`;
+                    const lnkPath = `${startupPath}/${label}.lnk.json`;
                     if (!(await existsAsync(lnkPath))) {
                         await fs.promises.writeFile(lnkPath, JSON.stringify({
                             type: "shortcut",
@@ -106,6 +107,12 @@ export async function initFileSystem(onProgress) {
                     }
                 }
             }
+        }
+
+        if (!(await existsAsync("/C:/.shortcuts_migrated"))) {
+            if (onProgress) onProgress("Migrating shortcuts...");
+            await migrateShortcuts("/C:");
+            await fs.promises.writeFile("/C:/.shortcuts_migrated", "done");
         }
 
         if (onProgress) onProgress("Initializing Favorites...");

--- a/src/utils/zenfs-utils.js
+++ b/src/utils/zenfs-utils.js
@@ -119,7 +119,7 @@ export async function addDesktopShortcut(appId, appTitle) {
     if (!(await existsAsync(desktopPath))) {
       await fs.promises.mkdir(desktopPath, { recursive: true });
     }
-    const lnkPath = `${desktopPath}/${appTitle}.lnk`;
+    const lnkPath = `${desktopPath}/${appTitle}.lnk.json`;
 
     if (!(await existsAsync(lnkPath))) {
       await fs.promises.writeFile(lnkPath, JSON.stringify({
@@ -143,7 +143,7 @@ export async function removeDesktopShortcut(appId) {
     if (await existsAsync(desktopPath)) {
       const files = await fs.promises.readdir(desktopPath);
       for (const file of files) {
-        if (file.endsWith(".lnk")) {
+        if (file.endsWith(".lnk.json")) {
           const content = await fs.promises.readFile(`${desktopPath}/${file}`, "utf8");
           try {
             const data = JSON.parse(content);


### PR DESCRIPTION
Improved shortcut handling by switching the file extension to `.lnk.json` for better compatibility with local disk backends. Included a migration script that runs once during boot to rename existing shortcuts. Added a new "Paste Shortcut" feature to context menus and the Explorer menu bar, which allows creating shortcuts for copied items. The "Paste Shortcut" option is correctly disabled when the clipboard contains items from a "cut" operation.

---
*PR created automatically by Jules for task [4631912369200594551](https://jules.google.com/task/4631912369200594551) started by @azayrahmad*