### PR TITLE
Support for switching C: drive to local folder storage

### DIFF
--- a/src/apps/zenexplorer/fileoperations/PropertiesManager.js
+++ b/src/apps/zenexplorer/fileoperations/PropertiesManager.js
@@ -405,7 +405,10 @@ export class PropertiesManager {
     try {
         let success = false;
         const { ProgressBarDialogWindow } = await import("../interface/ProgressBarDialogWindow.js");
-        const dialog = new ProgressBarDialogWindow("move", 0, 0); // We'll update it as we go
+
+        // Calculate total size for progress bar
+        const totalSize = await this._getRecursiveSize("/C:");
+        const dialog = new ProgressBarDialogWindow("move", 0, totalSize);
 
         let totalMigrated = 0;
         if (isToLocal) {

--- a/src/apps/zenexplorer/fileoperations/PropertiesManager.js
+++ b/src/apps/zenexplorer/fileoperations/PropertiesManager.js
@@ -11,6 +11,7 @@ import {
 import { getIconForFile } from "../interface/FileIconRenderer.js";
 import { RecycleBinManager } from "./RecycleBinManager.js";
 import { ShellManager } from "../extensions/ShellManager.js";
+import { getStoredHandle, migrateToLocalFolder, migrateToIndexedDB } from "../../../utils/storageSwitch.js";
 
 /**
  * PropertiesManager - Handles showing properties for files and folders in ZenExplorer
@@ -84,6 +85,9 @@ export class PropertiesManager {
     const modified = formatDate(stats.mtime);
     const accessed = formatDate(stats.atime);
 
+    const storageHandle = isUserDrive && path === "/C:" ? await getStoredHandle() : null;
+    const storageType = storageHandle ? "Local Folder" : "IndexedDB";
+
     const { container, sizeEl, containsEl } = this._createPropertiesUI({
       iconUrl,
       name,
@@ -95,6 +99,8 @@ export class PropertiesManager {
       created,
       modified,
       accessed,
+      isCDrive: path === "/C:",
+      storageType
     });
 
     const win = ShowDialogWindow({
@@ -338,8 +344,104 @@ export class PropertiesManager {
       addRow("Accessed", data.accessed);
     }
 
+    if (data.isCDrive) {
+      const separator = document.createElement("div");
+      separator.style.gridColumn = "span 2";
+      separator.style.borderBottom = "1px solid #808080";
+      separator.style.margin = "10px 0";
+      details.appendChild(separator);
+
+      const storageLabel = document.createElement("div");
+      storageLabel.textContent = "Storage:";
+      details.appendChild(storageLabel);
+
+      const storageContainer = document.createElement("div");
+      storageContainer.style.display = "flex";
+      storageContainer.style.justifyContent = "space-between";
+      storageContainer.style.alignItems = "center";
+
+      const storageText = document.createElement("span");
+      storageText.textContent = data.storageType;
+      storageContainer.appendChild(storageText);
+
+      const changeBtn = document.createElement("button");
+      changeBtn.textContent = "Change...";
+      changeBtn.style.padding = "2px 10px";
+      changeBtn.onclick = () => PropertiesManager._handleChangeStorage(data.storageType);
+      storageContainer.appendChild(changeBtn);
+
+      details.appendChild(storageContainer);
+    }
+
     container.appendChild(details);
 
     return { container, sizeEl, containsEl };
+  }
+
+  /**
+   * Handle storage backend change
+   * @private
+   */
+  static async _handleChangeStorage(currentType) {
+    const isToLocal = currentType === "IndexedDB";
+    const title = isToLocal ? "Switch to Local Folder" : "Switch to IndexedDB";
+    const text = isToLocal
+      ? "Switching to a local folder will move all your data from IndexedDB to a folder on your computer. Your browser will ask for permission each time you boot. Proceed?"
+      : "Switching to IndexedDB will move all your data from the local folder back to the browser's internal storage. Proceed?";
+
+    const confirmed = await new Promise(resolve => {
+        ShowDialogWindow({
+            title,
+            text,
+            buttons: [
+                { label: "Yes", action: (win) => { win.close(); resolve(true); } },
+                { label: "No", action: (win) => { win.close(); resolve(false); } }
+            ]
+        });
+    });
+
+    if (!confirmed) return;
+
+    try {
+        let success = false;
+        const { ProgressBarDialogWindow } = await import("../interface/ProgressBarDialogWindow.js");
+        const dialog = new ProgressBarDialogWindow("move", 0, 0); // We'll update it as we go
+
+        let totalMigrated = 0;
+        if (isToLocal) {
+            const handle = await window.showDirectoryPicker();
+            success = await migrateToLocalFolder(handle, (bytes) => {
+                totalMigrated += bytes;
+                dialog.update("Migrating...", "IndexedDB", handle.name, totalMigrated);
+            });
+        } else {
+            success = await migrateToIndexedDB((bytes) => {
+                totalMigrated += bytes;
+                dialog.update("Migrating...", "Local Folder", "IndexedDB", totalMigrated);
+            });
+        }
+
+        dialog.close();
+
+        if (success) {
+            ShowDialogWindow({
+                title: "Restart Required",
+                text: "The storage backend has been changed. Please restart the system to apply changes.",
+                buttons: [
+                    { label: "Restart Now", action: () => window.location.reload() },
+                    { label: "Later", action: (win) => win.close() }
+                ]
+            });
+        }
+    } catch (e) {
+        if (e.name !== 'AbortError') {
+            console.error("Storage migration failed:", e);
+            ShowDialogWindow({
+                title: "Migration Failed",
+                text: "An error occurred during migration: " + e.message,
+                buttons: [{ label: "OK" }]
+            });
+        }
+    }
   }
 }

--- a/src/main.js
+++ b/src/main.js
@@ -213,10 +213,17 @@ async function initializeOS() {
       finalizeBootProcessStep(logElement, "OK");
     });
 
+    let localFolderHandle = null;
     await executeBootStep(async () => {
       let logElement = startBootProcessStep("Connecting to network...");
       await new Promise((resolve) => setTimeout(resolve, 1000));
       finalizeBootProcessStep(logElement, navigator.onLine ? "OK" : "FAILED");
+    });
+
+    await executeBootStep(async () => {
+      const { getStoredHandle } = await import("./utils/storageSwitch.js");
+      localFolderHandle = await getStoredHandle();
+      await promptToContinue();
     });
 
     await executeBootStep(async () => {
@@ -226,7 +233,7 @@ async function initializeOS() {
         if (logElement && logElement.firstChild) {
           logElement.firstChild.nodeValue = `${baseMsg} ${subStep}`;
         }
-      });
+      }, localFolderHandle);
       if (logElement && logElement.firstChild) {
         logElement.firstChild.nodeValue = baseMsg;
       }
@@ -305,10 +312,6 @@ async function initializeOS() {
       await new Promise((resolve) => setTimeout(resolve, 50));
       loadCustomApps();
       finalizeBootProcessStep(logElement, "OK");
-    });
-
-    await executeBootStep(async () => {
-      await promptToContinue();
     });
 
     await executeBootStep(async () => {

--- a/src/utils/storageSwitch.js
+++ b/src/utils/storageSwitch.js
@@ -1,0 +1,192 @@
+import { fs, resolveMountConfig, mount, umount } from "@zenfs/core";
+import { IndexedDB } from "@zenfs/dom";
+import { ShowDialogWindow } from "../components/DialogWindow.js";
+import { joinPath } from "../apps/zenexplorer/navigation/PathUtils.js";
+
+const DB_NAME = "LocalFolderDB";
+const STORE_NAME = "handles";
+const HANDLE_KEY = "c-drive-handle";
+
+/**
+ * Open the IndexedDB for storage handles
+ */
+function openDB() {
+  return new Promise((resolve, reject) => {
+    const request = indexedDB.open(DB_NAME, 1);
+    request.onupgradeneeded = (event) => {
+      const db = event.target.result;
+      if (!db.objectStoreNames.contains(STORE_NAME)) {
+        db.createObjectStore(STORE_NAME);
+      }
+    };
+    request.onsuccess = (event) => resolve(event.target.result);
+    request.onerror = (event) => reject(event.error);
+  });
+}
+
+/**
+ * Get the stored FileSystemDirectoryHandle
+ */
+export async function getStoredHandle() {
+  try {
+    const db = await openDB();
+    return new Promise((resolve, reject) => {
+      const transaction = db.transaction(STORE_NAME, "readonly");
+      const store = transaction.objectStore(STORE_NAME);
+      const request = store.get(HANDLE_KEY);
+      request.onsuccess = () => resolve(request.result);
+      request.onerror = () => reject(request.error);
+    });
+  } catch (e) {
+    console.error("Failed to get stored handle:", e);
+    return null;
+  }
+}
+
+/**
+ * Store a FileSystemDirectoryHandle
+ */
+export async function storeHandle(handle) {
+  const db = await openDB();
+  return new Promise((resolve, reject) => {
+    const transaction = db.transaction(STORE_NAME, "readwrite");
+    const store = transaction.objectStore(STORE_NAME);
+    const request = store.put(handle, HANDLE_KEY);
+    request.onsuccess = () => resolve();
+    request.onerror = () => reject(request.error);
+  });
+}
+
+/**
+ * Remove the stored handle
+ */
+export async function removeStoredHandle() {
+  const db = await openDB();
+  return new Promise((resolve, reject) => {
+    const transaction = db.transaction(STORE_NAME, "readwrite");
+    const store = transaction.objectStore(STORE_NAME);
+    const request = store.delete(HANDLE_KEY);
+    request.onsuccess = () => resolve();
+    request.onerror = () => reject(request.error);
+  });
+}
+
+/**
+ * Check if the target directory handle is empty
+ */
+async function isDirectoryEmpty(handle) {
+    for await (const entry of handle.values()) {
+        return false;
+    }
+    return true;
+}
+
+/**
+ * Copy a file from ZenFS to a native FileSystemDirectoryHandle
+ */
+async function copyToNative(zenfsPath, targetHandle, fileName, onProgress) {
+    const data = await fs.promises.readFile(zenfsPath);
+    // Escape filename with .z
+    const escapedName = fileName + ".z";
+    const fileHandle = await targetHandle.getFileHandle(escapedName, { create: true });
+    const writable = await fileHandle.createWritable();
+    await writable.write(data);
+    await writable.close();
+    if (onProgress) onProgress(data.length);
+}
+
+/**
+ * Recursively copy a directory from ZenFS to a native FileSystemDirectoryHandle
+ */
+async function copyDirectoryToNative(zenfsPath, targetHandle, onProgress) {
+    const entries = await fs.promises.readdir(zenfsPath);
+    for (const entry of entries) {
+        const fullPath = joinPath(zenfsPath, entry);
+        const stats = await fs.promises.stat(fullPath);
+        if (stats.isDirectory()) {
+            const escapedName = entry + ".z";
+            const subHandle = await targetHandle.getDirectoryHandle(escapedName, { create: true });
+            await copyDirectoryToNative(fullPath, subHandle, onProgress);
+        } else {
+            await copyToNative(fullPath, targetHandle, entry, onProgress);
+        }
+    }
+}
+
+/**
+ * Migrate from ZenFS (IndexedDB) to a native local folder
+ */
+export async function migrateToLocalFolder(targetHandle, onProgress) {
+    if (!(await isDirectoryEmpty(targetHandle))) {
+        const confirmed = await new Promise(resolve => {
+            ShowDialogWindow({
+                title: "Folder Not Empty",
+                text: "The selected folder is not empty. Do you want to overwrite existing files?",
+                buttons: [
+                    { label: "Yes", action: (win) => { win.close(); resolve(true); } },
+                    { label: "No", action: (win) => { win.close(); resolve(false); } }
+                ]
+            });
+        });
+        if (!confirmed) return false;
+    }
+
+    await copyDirectoryToNative("/C:", targetHandle, onProgress);
+    await storeHandle(targetHandle);
+    return true;
+}
+
+/**
+ * Recursively copy a directory in ZenFS
+ */
+async function copyDirectoryRecursive(src, dest, onProgress) {
+    if (!fs.existsSync(dest)) {
+        await fs.promises.mkdir(dest, { recursive: true });
+    }
+    const entries = await fs.promises.readdir(src);
+    for (const entry of entries) {
+        const srcPath = joinPath(src, entry);
+        const destPath = joinPath(dest, entry);
+        const stats = await fs.promises.stat(srcPath);
+        if (stats.isDirectory()) {
+            await copyDirectoryRecursive(srcPath, destPath, onProgress);
+        } else {
+            const data = await fs.promises.readFile(srcPath);
+            await fs.promises.writeFile(destPath, data);
+            if (onProgress) onProgress(data.length);
+        }
+    }
+}
+
+/**
+ * Migration from Local Folder back to IndexedDB
+ */
+export async function migrateToIndexedDB(onProgress) {
+    // 1. Create/resolve the IndexedDB mount config
+    const idbFs = await resolveMountConfig({
+        backend: IndexedDB,
+        name: "win98-c-drive",
+    });
+
+    // 2. Mount it temporarily
+    const tempMount = "/temp-c";
+    if (!fs.existsSync(tempMount)) {
+        await fs.promises.mkdir(tempMount);
+    }
+    mount(tempMount, idbFs);
+
+    try {
+        // 3. Copy everything from /C: to /temp-c
+        // (Assuming /C: is currently the local folder)
+        await copyDirectoryRecursive("/C:", tempMount, onProgress);
+
+        // 4. Remove the stored handle
+        await removeStoredHandle();
+        return true;
+    } catch (e) {
+        console.error("Failed to migrate to IndexedDB:", e);
+        throw e;
+    } finally {
+        umount(tempMount);
+    }
+}

--- a/src/utils/zenfs-init.js
+++ b/src/utils/zenfs-init.js
@@ -1,15 +1,88 @@
 import { resolveMountConfig, InMemory, fs } from "@zenfs/core";
-import { IndexedDB } from "@zenfs/dom";
+import { IndexedDB, WebAccess } from "@zenfs/dom";
 import { migrateToZenFS, PINNED_PATH, START_MENU_PATH, FAVORITES_PATH } from "./startMenuUtils.js";
 import { migrateShortcuts } from "./migrateShortcuts.js";
 import startMenuConfig from "../config/startmenu.js";
 import { getStartupApps } from "./startupManager.js";
 import { apps } from "../config/apps.js";
 import { existsAsync } from "./zenfs-utils.js";
+import { getStoredHandle } from "./storageSwitch.js";
 
 let isInitialized = false;
 
-export async function initFileSystem(onProgress) {
+const wrappedBackends = new WeakMap();
+
+/**
+ * Wraps a WebAccess backend to append .z to all filenames on the host filesystem.
+ * This bypasses browser/OS restrictions on reserved filenames like CON, PRN, or .lnk.
+ */
+function wrapWebAccess(backend) {
+    if (wrappedBackends.has(backend)) {
+        return wrappedBackends.get(backend);
+    }
+
+    const wrapPath = (path) => {
+        if (!path || path === '/') return path;
+        return path.split('/')
+            .map(segment => segment && segment !== '.' && segment !== '..' ? segment + '.z' : segment)
+            .join('/');
+    };
+
+    const unwrapPath = (path) => {
+        if (!path) return path;
+        return path.split('/')
+            .map(segment => segment.endsWith('.z') ? segment.slice(0, -2) : segment)
+            .join('/');
+    };
+
+    const proxy = new Proxy(backend, {
+        get(target, prop) {
+            const original = target[prop];
+            if (typeof original !== 'function') {
+                return original;
+            }
+
+            return function (...args) {
+                // Intercept path-based methods
+                const pathMethods = ['stat', 'statSync', 'open', 'openSync', 'replacems', 'replacemsSync',
+                                   'mkdir', 'mkdirSync', 'rmdir', 'rmdirSync', 'unlink', 'unlinkSync',
+                                   'link', 'linkSync', 'symlink', 'symlinkSync', 'readlink', 'readlinkSync',
+                                   'chown', 'chownSync', 'chmod', 'chmodSync', 'utimes', 'utimesSync'];
+
+                if (pathMethods.includes(prop)) {
+                    args[0] = wrapPath(args[0]);
+                }
+
+                if (prop === 'rename' || prop === 'renameSync') {
+                    args[0] = wrapPath(args[0]);
+                    args[1] = wrapPath(args[1]);
+                }
+
+                const result = original.apply(target, args);
+
+                if (result instanceof Promise) {
+                    return result.then(res => {
+                        if (prop === 'readdir') {
+                            return res.map(unwrapPath);
+                        }
+                        return res;
+                    });
+                }
+
+                if (prop === 'readdirSync') {
+                    return result.map(unwrapPath);
+                }
+
+                return result;
+            };
+        }
+    });
+
+    wrappedBackends.set(backend, proxy);
+    return proxy;
+}
+
+export async function initFileSystem(onProgress, localFolderHandle = null) {
     if (isInitialized) return;
 
     try {
@@ -26,10 +99,29 @@ export async function initFileSystem(onProgress) {
         fs.mount('/', rootFs);
 
         if (onProgress) onProgress("Mounting C: drive...");
-        const cDriveFs = await resolveMountConfig({
-            backend: IndexedDB,
-            name: "win98-c-drive",
-        });
+        let cDriveFs;
+
+        if (localFolderHandle) {
+            try {
+                // Re-request permission. This needs a user gesture if not already granted.
+                const permission = await localFolderHandle.requestPermission({ mode: 'readwrite' });
+                if (permission === 'granted') {
+                    const webAccessFs = await WebAccess.create({ handle: localFolderHandle });
+                    cDriveFs = wrapWebAccess(webAccessFs);
+                    console.log("C: drive mounted using Local Folder.");
+                }
+            } catch (err) {
+                console.warn("Failed to mount Local Folder, falling back to IndexedDB:", err);
+            }
+        }
+
+        if (!cDriveFs) {
+            cDriveFs = await resolveMountConfig({
+                backend: IndexedDB,
+                name: "win98-c-drive",
+            });
+            console.log("C: drive mounted using IndexedDB.");
+        }
         // Ensure C: mount point exists in root
         if (!(await existsAsync('/C:'))) {
             await fs.promises.mkdir('/C:');

--- a/src/utils/zenfs-init.js
+++ b/src/utils/zenfs-init.js
@@ -22,33 +22,33 @@ function wrapWebAccess(backend) {
     }
 
     const wrapPath = (path) => {
-        if (!path || path === '/') return path;
+        if (typeof path !== 'string' || !path || path === '/') return path;
         return path.split('/')
             .map(segment => segment && segment !== '.' && segment !== '..' ? segment + '.z' : segment)
             .join('/');
     };
 
     const unwrapPath = (path) => {
-        if (!path) return path;
+        if (typeof path !== 'string' || !path) return path;
         return path.split('/')
             .map(segment => segment.endsWith('.z') ? segment.slice(0, -2) : segment)
             .join('/');
     };
 
+    const pathMethods = ['stat', 'statSync', 'open', 'openSync', 'replacems', 'replacemsSync',
+                       'mkdir', 'mkdirSync', 'rmdir', 'rmdirSync', 'unlink', 'unlinkSync',
+                       'link', 'linkSync', 'symlink', 'symlinkSync', 'readlink', 'readlinkSync',
+                       'chown', 'chownSync', 'chmod', 'chmodSync', 'utimes', 'utimesSync',
+                       'access', 'accessSync', 'readdir', 'readdirSync'];
+
     const proxy = new Proxy(backend, {
-        get(target, prop) {
-            const original = target[prop];
-            if (typeof original !== 'function') {
-                return original;
+        get(target, prop, receiver) {
+            const value = Reflect.get(target, prop, receiver);
+            if (typeof value !== 'function') {
+                return value;
             }
 
             return function (...args) {
-                // Intercept path-based methods
-                const pathMethods = ['stat', 'statSync', 'open', 'openSync', 'replacems', 'replacemsSync',
-                                   'mkdir', 'mkdirSync', 'rmdir', 'rmdirSync', 'unlink', 'unlinkSync',
-                                   'link', 'linkSync', 'symlink', 'symlinkSync', 'readlink', 'readlinkSync',
-                                   'chown', 'chownSync', 'chmod', 'chmodSync', 'utimes', 'utimesSync'];
-
                 if (pathMethods.includes(prop)) {
                     args[0] = wrapPath(args[0]);
                 }
@@ -58,7 +58,7 @@ function wrapWebAccess(backend) {
                     args[1] = wrapPath(args[1]);
                 }
 
-                const result = original.apply(target, args);
+                const result = Reflect.apply(value, receiver, args);
 
                 if (result instanceof Promise) {
                     return result.then(res => {


### PR DESCRIPTION
This change allows users to switch the C: drive storage from IndexedDB to a local folder on their host machine using the File System Access API. It includes a migration utility that copies all files between backends, a robust filename wrapping system to bypass OS-specific restrictions, and UI integration in the C: drive Properties dialog. The boot sequence was updated to ensure that the necessary user gesture is captured before requesting permission to access the local folder.

---
*PR created automatically by Jules for task [5295635186513048558](https://jules.google.com/task/5295635186513048558) started by @azayrahmad*