### PR TITLE
Move icon assets to C:\ drive

### DIFF
--- a/src/config/fileAssociations.js
+++ b/src/config/fileAssociations.js
@@ -10,7 +10,7 @@ export const fileAssociations = {
   js: {
     name: "JScript Script File",
     appId: "notepad",
-    icon: ICONS.textFile,
+    icon: ICONS.rnaui,
   },
   json: {
     name: "JSON File",

--- a/src/config/icons.js
+++ b/src/config/icons.js
@@ -1,421 +1,601 @@
 export const ICONS = {
   appmaker: {
     16: new URL("../assets/icons/appwizard-0.png", import.meta.url).href,
+    path16: "/C:/WINDOWS/Icons/appwizard-0.png",
     32: new URL("../assets/icons/appwizard-2.png", import.meta.url).href,
+    path32: "/C:/WINDOWS/Icons/appwizard-2.png",
   },
   appmakerApp: {
     16: new URL("../assets/icons/SHELL32_3-16.png", import.meta.url).href,
+    path16: "/C:/WINDOWS/Icons/SHELL32_3-16.png",
     32: new URL("../assets/icons/SHELL32_3-32.png", import.meta.url).href,
+    path32: "/C:/WINDOWS/Icons/SHELL32_3-32.png",
   },
   "internet-explorer": {
     16: new URL("../assets/icons/msie1-4.png", import.meta.url).href,
+    path16: "/C:/WINDOWS/Icons/msie1-4.png",
     32: new URL("../assets/icons/msie1-1.png", import.meta.url).href,
+    path32: "/C:/WINDOWS/Icons/msie1-1.png",
   },
   about: {
     16: new URL("../assets/icons/COMCTL32_20481-16.png", import.meta.url).href,
+    path16: "/C:/WINDOWS/Icons/COMCTL32_20481-16.png",
     32: new URL("../assets/icons/COMCTL32_20481-32.png", import.meta.url).href,
+    path32: "/C:/WINDOWS/Icons/COMCTL32_20481-32.png",
   },
   pdf: {
     16: new URL("../assets/icons/word_001-16.png", import.meta.url).href,
+    path16: "/C:/WINDOWS/Icons/word_001-16.png",
     32: new URL("../assets/icons/word_001-32.png", import.meta.url).href,
+    path32: "/C:/WINDOWS/Icons/word_001-32.png",
   },
   tip: {
     16: new URL("../assets/icons/help_book_cool-0.png", import.meta.url).href,
+    path16: "/C:/WINDOWS/Icons/help_book_cool-0.png",
     32: new URL("../assets/icons/help_book_cool-0.png", import.meta.url).href,
+    path32: "/C:/WINDOWS/Icons/help_book_cool-0.png",
   },
   notepad: {
     16: new URL("../assets/icons/notepad-0.png", import.meta.url).href,
+    path16: "/C:/WINDOWS/Icons/notepad-0.png",
     32: new URL("../assets/icons/NOTEPAD_1-32.png", import.meta.url).href,
+    path32: "/C:/WINDOWS/Icons/NOTEPAD_1-32.png",
   },
   clippy: {
     16: new URL("../assets/icons/msagent_file-1.png", import.meta.url).href,
+    path16: "/C:/WINDOWS/Icons/msagent_file-1.png",
     32: new URL("../assets/icons/msagent_file-1.png", import.meta.url).href,
+    path32: "/C:/WINDOWS/Icons/msagent_file-1.png",
   },
   webamp: {
     16: new URL("../assets/icons/winamp.png", import.meta.url).href,
+    path16: "/C:/WINDOWS/Icons/winamp.png",
     32: new URL("../assets/icons/winamp.png", import.meta.url).href,
+    path32: "/C:/WINDOWS/Icons/winamp.png",
   },
   image: {
     16: new URL("../assets/icons/kodak_imaging-0.png", import.meta.url).href,
+    path16: "/C:/WINDOWS/Icons/kodak_imaging-0.png",
     32: new URL("../assets/icons/kodak_imaging-0.png", import.meta.url).href,
+    path32: "/C:/WINDOWS/Icons/kodak_imaging-0.png",
   },
   imageViewer: {
     16: new URL("../assets/icons/image_viewer-0.png", import.meta.url).href,
+    path16: "/C:/WINDOWS/Icons/image_viewer-0.png",
     32: new URL("../assets/icons/image_viewer-0.png", import.meta.url).href,
+    path32: "/C:/WINDOWS/Icons/image_viewer-0.png",
   },
   computer: {
     16: new URL("../assets/icons/computer_explorer-0.png", import.meta.url)
       .href,
+    path16: "/C:/WINDOWS/Icons/computer_explorer-0.png",
     32: new URL("../assets/icons/computer_explorer-32.png", import.meta.url)
       .href,
+    path32: "/C:/WINDOWS/Icons/computer_explorer-32.png",
   },
   disketteDrive: {
     16: new URL("../assets/icons/SHELL32_7-16.png", import.meta.url).href,
+    path16: "/C:/WINDOWS/Icons/SHELL32_7-16.png",
     32: new URL("../assets/icons/SHELL32_7-32.png", import.meta.url).href,
+    path32: "/C:/WINDOWS/Icons/SHELL32_7-32.png",
   },
   cdDrive: {
     16: new URL("../assets/icons/cd_drive-1.png", import.meta.url).href,
+    path16: "/C:/WINDOWS/Icons/cd_drive-1.png",
     32: new URL("../assets/icons/cd_drive-2.png", import.meta.url).href,
+    path32: "/C:/WINDOWS/Icons/cd_drive-2.png",
   },
   defrag: {
     16: new URL("../assets/icons/defragment-1.png", import.meta.url).href,
+    path16: "/C:/WINDOWS/Icons/defragment-1.png",
     32: new URL("../assets/icons/defragment-0.png", import.meta.url).href,
+    path32: "/C:/WINDOWS/Icons/defragment-0.png",
   },
   drive: {
     16: new URL("../assets/icons/SHELL32_9-16.png", import.meta.url).href,
+    path16: "/C:/WINDOWS/Icons/SHELL32_9-16.png",
     32: new URL("../assets/icons/SHELL32_9-32.png", import.meta.url).href,
+    path32: "/C:/WINDOWS/Icons/SHELL32_9-32.png",
   },
   removableDrive: {
     16: new URL("../assets/icons/removable_disk_drive-1.png", import.meta.url)
       .href,
+    path16: "/C:/WINDOWS/Icons/removable_disk_drive-1.png",
     32: new URL("../assets/icons/removable_disk_drive-0.png", import.meta.url)
       .href,
+    path32: "/C:/WINDOWS/Icons/removable_disk_drive-0.png",
   },
   folder: {
     16: new URL(
       "../assets/icons/directory_open_file_mydocs_small-5.png",
       import.meta.url,
     ).href,
+    path16: "/C:/WINDOWS/Icons/directory_open_file_mydocs_small-5.png",
     32: new URL(
       "../assets/icons/directory_open_file_mydocs-1.png",
       import.meta.url,
     ).href,
+    path32: "/C:/WINDOWS/Icons/directory_open_file_mydocs-1.png",
   },
   folderClosed: {
     16: new URL("../assets/icons/SHELL32_4-16.png", import.meta.url).href,
+    path16: "/C:/WINDOWS/Icons/SHELL32_4-16.png",
     32: new URL("../assets/icons/SHELL32_4-32.png", import.meta.url).href,
+    path32: "/C:/WINDOWS/Icons/SHELL32_4-32.png",
   },
   folderOpen: {
     16: new URL("../assets/icons/SHELL32_5-16.png", import.meta.url).href,
+    path16: "/C:/WINDOWS/Icons/SHELL32_5-16.png",
     32: new URL("../assets/icons/SHELL32_5-32.png", import.meta.url).href,
+    path32: "/C:/WINDOWS/Icons/SHELL32_5-32.png",
   },
   warning: {
     16: new URL("../assets/icons/msg_warning-0.png", import.meta.url).href,
+    path16: "/C:/WINDOWS/Icons/msg_warning-0.png",
     32: new URL("../assets/icons/msg_warning-0.png", import.meta.url).href,
+    path32: "/C:/WINDOWS/Icons/msg_warning-0.png",
   },
   shutdown: {
     16: new URL("../assets/icons/SHELL32_28-16.png", import.meta.url).href,
+    path16: "/C:/WINDOWS/Icons/SHELL32_28-16.png",
     32: new URL("../assets/icons/SHELL32_28-32.png", import.meta.url).href,
+    path32: "/C:/WINDOWS/Icons/SHELL32_28-32.png",
   },
   windows: {
     16: new URL("../assets/icons/windows-4.png", import.meta.url).href,
+    path16: "/C:/WINDOWS/Icons/windows-4.png",
     32: new URL("../assets/icons/windows-4.png", import.meta.url).href,
+    path32: "/C:/WINDOWS/Icons/windows-4.png",
   },
   key: {
     16: new URL("../assets/icons/key_win_alt-16.png", import.meta.url).href,
+    path16: "/C:/WINDOWS/Icons/key_win_alt-16.png",
     32: new URL("../assets/icons/key_win-4.png", import.meta.url).href,
+    path32: "/C:/WINDOWS/Icons/key_win-4.png",
   },
   shell: {
     16: new URL("../assets/icons/SHELL32_3-16.png", import.meta.url).href,
+    path16: "/C:/WINDOWS/Icons/SHELL32_3-16.png",
     32: new URL("../assets/icons/SHELL32_3-32.png", import.meta.url).href,
+    path32: "/C:/WINDOWS/Icons/SHELL32_3-32.png",
   },
   systray: {
     16: new URL("../assets/icons/SYSTRAY_220-16.png", import.meta.url).href,
+    path16: "/C:/WINDOWS/Icons/SYSTRAY_220-16.png",
     32: new URL("../assets/icons/SYSTRAY_220.ico", import.meta.url).href,
+    path32: "/C:/WINDOWS/Icons/SYSTRAY_220.ico",
   },
   rnaui: {
     16: new URL("../assets/icons/RNAUI_106.ico", import.meta.url).href,
+    path16: "/C:/WINDOWS/Icons/RNAUI_106.ico",
     32: new URL("../assets/icons/RNAUI_106-32.png", import.meta.url).href,
+    path32: "/C:/WINDOWS/Icons/RNAUI_106-32.png",
   },
   setdebug: {
     16: new URL("../assets/icons/SETDEBUG_100.ico", import.meta.url).href,
+    path16: "/C:/WINDOWS/Icons/SETDEBUG_100.ico",
     32: new URL("../assets/icons/SETDEBUG_100-32.png", import.meta.url).href,
+    path32: "/C:/WINDOWS/Icons/SETDEBUG_100-32.png",
   },
   mmsys: {
     16: new URL("../assets/icons/MMSYS_110-16.png", import.meta.url).href,
+    path16: "/C:/WINDOWS/Icons/MMSYS_110-16.png",
     32: new URL("../assets/icons/MMSYS_110-32.png", import.meta.url).href,
+    path32: "/C:/WINDOWS/Icons/MMSYS_110-32.png",
   },
   comctl32: {
     16: new URL("../assets/icons/COMCTL32_20481-16.png", import.meta.url).href,
+    path16: "/C:/WINDOWS/Icons/COMCTL32_20481-16.png",
     32: new URL("../assets/icons/COMCTL32_20481-32.png", import.meta.url).href,
+    path32: "/C:/WINDOWS/Icons/COMCTL32_20481-32.png",
   },
   desktop_old: {
     16: new URL("../assets/icons/desktop-4.png", import.meta.url).href,
+    path16: "/C:/WINDOWS/Icons/desktop-4.png",
     32: new URL("../assets/icons/desktop-1.png", import.meta.url).href,
+    path32: "/C:/WINDOWS/Icons/desktop-1.png",
   },
   themetocss: {
     16: new URL("../assets/icons/word_001-16.png", import.meta.url).href,
+    path16: "/C:/WINDOWS/Icons/word_001-16.png",
     32: new URL("../assets/icons/word_001-32.png", import.meta.url).href,
+    path32: "/C:/WINDOWS/Icons/word_001-32.png",
   },
   programs: {
     16: new URL("../assets/icons/SHELL32_20-16.png", import.meta.url).href,
+    path16: "/C:/WINDOWS/Icons/SHELL32_20-16.png",
     32: new URL("../assets/icons/SHELL32_20-32.png", import.meta.url).href,
+    path32: "/C:/WINDOWS/Icons/SHELL32_20-32.png",
   },
   favorites: {
     16: new URL("../assets/icons/SHELL32_44-16.png", import.meta.url).href,
+    path16: "/C:/WINDOWS/Icons/SHELL32_44-16.png",
     32: new URL("../assets/icons/SHELL32_44-32.png", import.meta.url).href,
+    path32: "/C:/WINDOWS/Icons/SHELL32_44-32.png",
   },
   documents: {
     16: new URL("../assets/icons/SHELL32_21-16.png", import.meta.url).href,
+    path16: "/C:/WINDOWS/Icons/SHELL32_21-16.png",
     32: new URL("../assets/icons/SHELL32_21-32.png", import.meta.url).href,
+    path32: "/C:/WINDOWS/Icons/SHELL32_21-32.png",
   },
   settings: {
     16: new URL("../assets/icons/SHELL32_22-16.png", import.meta.url).href,
+    path16: "/C:/WINDOWS/Icons/SHELL32_22-16.png",
     32: new URL("../assets/icons/SHELL32_22-32.png", import.meta.url).href,
+    path32: "/C:/WINDOWS/Icons/SHELL32_22-32.png",
   },
   find: {
     16: new URL("../assets/icons/SHELL32_23-16.png", import.meta.url).href,
+    path16: "/C:/WINDOWS/Icons/SHELL32_23-16.png",
     32: new URL("../assets/icons/SHELL32_23-32.png", import.meta.url).href,
+    path32: "/C:/WINDOWS/Icons/SHELL32_23-32.png",
   },
   help: {
     16: new URL("../assets/icons/SHELL32_24-16.png", import.meta.url).href,
+    path16: "/C:/WINDOWS/Icons/SHELL32_24-16.png",
     32: new URL("../assets/icons/SHELL32_24-32.png", import.meta.url).href,
+    path32: "/C:/WINDOWS/Icons/SHELL32_24-32.png",
   },
   run: {
     16: new URL("../assets/icons/SHELL32_25-16.png", import.meta.url).href,
+    path16: "/C:/WINDOWS/Icons/SHELL32_25-16.png",
     32: new URL("../assets/icons/SHELL32_25-32.png", import.meta.url).href,
+    path32: "/C:/WINDOWS/Icons/SHELL32_25-32.png",
   },
   logoff: {
     16: new URL("../assets/icons/SHELL32_45-16.png", import.meta.url).href,
+    path16: "/C:/WINDOWS/Icons/SHELL32_45-16.png",
     32: new URL("../assets/icons/SHELL32_45-32.png", import.meta.url).href,
+    path32: "/C:/WINDOWS/Icons/SHELL32_45-32.png",
   },
   windowsUpdate: {
     16: new URL("../assets/icons/SHELL32_47-16.png", import.meta.url).href,
+    path16: "/C:/WINDOWS/Icons/SHELL32_47-16.png",
     32: new URL("../assets/icons/SHELL32_47-32.png", import.meta.url).href,
+    path32: "/C:/WINDOWS/Icons/SHELL32_47-32.png",
   },
   startMenuFolder: {
     16: new URL("../assets/icons/SHELL32_37-16.png", import.meta.url).href,
+    path16: "/C:/WINDOWS/Icons/SHELL32_37-16.png",
     32: new URL("../assets/icons/SHELL32_37-32.png", import.meta.url).href,
+    path32: "/C:/WINDOWS/Icons/SHELL32_37-32.png",
   },
   soundschemeexplorer: {
     16: new URL("../assets/icons/MMSYS_110-16.png", import.meta.url).href,
+    path16: "/C:/WINDOWS/Icons/MMSYS_110-16.png",
     32: new URL("../assets/icons/MMSYS_110-32.png", import.meta.url).href,
+    path32: "/C:/WINDOWS/Icons/MMSYS_110-32.png",
   },
   desktopthemes: {
     16: new URL("../assets/icons/themes-2.png", import.meta.url).href,
+    path16: "/C:/WINDOWS/Icons/themes-2.png",
     32: new URL("../assets/icons/themes-2.png", import.meta.url).href,
+    path32: "/C:/WINDOWS/Icons/themes-2.png",
   },
   recycleBinEmpty: {
     16: new URL(
       "../assets/icons/theme-icons/recycle_bin_empty-4.png",
       import.meta.url,
     ).href,
+    path16: "/C:/WINDOWS/Icons/recycle_bin_empty-4.png",
     32: new URL(
       "../assets/icons/theme-icons/recycle_bin_empty-4.png",
       import.meta.url,
     ).href,
+    path32: "/C:/WINDOWS/Icons/recycle_bin_empty-4.png",
   },
   recycleBinFull: {
     16: new URL(
       "../assets/icons/theme-icons/recycle_bin_full-4.png",
       import.meta.url,
     ).href,
+    path16: "/C:/WINDOWS/Icons/recycle_bin_full-4.png",
     32: new URL(
       "../assets/icons/theme-icons/recycle_bin_full-4.png",
       import.meta.url,
     ).href,
+    path32: "/C:/WINDOWS/Icons/recycle_bin_full-4.png",
   },
   pinball: {
     16: new URL("../assets/icons/PINBALL-16.png", import.meta.url).href,
+    path16: "/C:/WINDOWS/Icons/PINBALL-16.png",
     32: new URL("../assets/icons/PINBALL-32.png", import.meta.url).href,
+    path32: "/C:/WINDOWS/Icons/PINBALL-32.png",
   },
   solitaire: {
     16: new URL("../assets/icons/SolitaireWin31Icon.png", import.meta.url).href,
+    path16: "/C:/WINDOWS/Icons/SolitaireWin31Icon.png",
     32: new URL("../assets/icons/SolitaireWin31Icon.png", import.meta.url).href,
+    path32: "/C:/WINDOWS/Icons/SolitaireWin31Icon.png",
   },
   princeofpersia: {
     16: new URL("../assets/icons/pop-16.png", import.meta.url).href,
+    path16: "/C:/WINDOWS/Icons/pop-16.png",
     32: new URL("../assets/icons/pop-32.png", import.meta.url).href,
+    path32: "/C:/WINDOWS/Icons/pop-32.png",
   },
   paint: {
     16: new URL("../assets/icons/Paint-16.png", import.meta.url).href,
+    path16: "/C:/WINDOWS/Icons/Paint-16.png",
     32: new URL("../assets/icons/Paint-32.png", import.meta.url).href,
+    path32: "/C:/WINDOWS/Icons/Paint-32.png",
   },
   simcity2000: {
     16: new URL("../assets/icons/games/SIMCITY_2.ico", import.meta.url).href,
+    path16: "/C:/WINDOWS/Icons/SIMCITY_2.ico",
     32: new URL("../assets/icons/games/SIMCITY_2.ico", import.meta.url).href,
+    path32: "/C:/WINDOWS/Icons/SIMCITY_2.ico",
   },
   displayProperties: {
     16: new URL("../assets/icons/Display-16.png", import.meta.url).href,
+    path16: "/C:/WINDOWS/Icons/Display-16.png",
     32: new URL("../assets/icons/Display-32.png", import.meta.url).href,
+    path32: "/C:/WINDOWS/Icons/Display-32.png",
   },
   networkNeighborhood: {
     16: new URL("../assets/icons/SHELL32_18-16.png", import.meta.url).href,
+    path16: "/C:/WINDOWS/Icons/SHELL32_18-16.png",
     32: new URL("../assets/icons/SHELL32_18-32.png", import.meta.url).href,
+    path32: "/C:/WINDOWS/Icons/SHELL32_18-32.png",
   },
   htmlFile: {
     16: new URL("../assets/icons/html2-4.png", import.meta.url).href,
+    path16: "/C:/WINDOWS/Icons/html2-4.png",
     32: new URL("../assets/icons/html2-3.png", import.meta.url).href,
+    path32: "/C:/WINDOWS/Icons/html2-3.png",
   },
   "buy-me-a-coffee": {
     16: new URL("../assets/icons/Ko-fi_COIN-16.gif", import.meta.url).href,
+    path16: "/C:/WINDOWS/Icons/Ko-fi_COIN-16.gif",
     32: new URL("../assets/icons/Ko-fi_COIN-32.gif", import.meta.url).href,
+    path32: "/C:/WINDOWS/Icons/Ko-fi_COIN-32.gif",
   },
   textFile: {
     16: new URL("../assets/icons/notepad_file-1.png", import.meta.url).href,
+    path16: "/C:/WINDOWS/Icons/notepad_file-1.png",
     32: new URL("../assets/icons/notepad_file-0.png", import.meta.url).href,
+    path32: "/C:/WINDOWS/Icons/notepad_file-0.png",
   },
   imageJpgFile: {
     16: new URL("../assets/icons/imagjpeg-0.png", import.meta.url).href,
+    path16: "/C:/WINDOWS/Icons/imagjpeg-0.png",
     32: new URL("../assets/icons/imagjpeg-1.png", import.meta.url).href,
+    path32: "/C:/WINDOWS/Icons/imagjpeg-1.png",
   },
   imageGifFile: {
     16: new URL("../assets/icons/imaggif-0.png", import.meta.url).href,
+    path16: "/C:/WINDOWS/Icons/imaggif-0.png",
     32: new URL("../assets/icons/imaggif-1.png", import.meta.url).href,
+    path32: "/C:/WINDOWS/Icons/imaggif-1.png",
   },
   imageBmpFile: {
     16: new URL("../assets/icons/paint_file-1.png", import.meta.url).href,
+    path16: "/C:/WINDOWS/Icons/paint_file-1.png",
     32: new URL("../assets/icons/paint_file-3.png", import.meta.url).href,
+    path32: "/C:/WINDOWS/Icons/paint_file-3.png",
   },
   file: {
     16: new URL("../assets/icons/file_lines-1.png", import.meta.url).href,
+    path16: "/C:/WINDOWS/Icons/file_lines-1.png",
     32: new URL("../assets/icons/file_lines-0.png", import.meta.url).href,
+    path32: "/C:/WINDOWS/Icons/file_lines-0.png",
   },
   fileSet: {
     16: new URL("../assets/icons/file_set-1.png", import.meta.url).href,
+    path16: "/C:/WINDOWS/Icons/file_set-1.png",
     32: new URL("../assets/icons/file_set-0.png", import.meta.url).href,
+    path32: "/C:/WINDOWS/Icons/file_set-0.png",
   },
   "cursor-explorer": {
     16: new URL("../assets/icons/COMCTL32_20481-16.png", import.meta.url).href,
+    path16: "/C:/WINDOWS/Icons/COMCTL32_20481-16.png",
     32: new URL("../assets/icons/COMCTL32_20481-32.png", import.meta.url).href,
+    path32: "/C:/WINDOWS/Icons/COMCTL32_20481-32.png",
   },
   networkComputer: {
     16: new URL("../assets/icons/computer_2-1.png", import.meta.url).href,
+    path16: "/C:/WINDOWS/Icons/computer_2-1.png",
     32: new URL("../assets/icons/computer_2-3.png", import.meta.url).href,
+    path32: "/C:/WINDOWS/Icons/computer_2-3.png",
   },
   doom: {
     16: new URL("../assets/icons/games/doom.png", import.meta.url).href,
+    path16: "/C:/WINDOWS/Icons/doom.png",
     32: new URL("../assets/icons/games/doom.png", import.meta.url).href,
+    path32: "/C:/WINDOWS/Icons/doom.png",
   },
   mediaPlayer: {
     16: new URL("../assets/icons/MPLAYER2_110-16.png", import.meta.url).href,
+    path16: "/C:/WINDOWS/Icons/MPLAYER2_110-16.png",
     32: new URL("../assets/icons/MPLAYER2_110-32.png", import.meta.url).href,
+    path32: "/C:/WINDOWS/Icons/MPLAYER2_110-32.png",
   },
   mediaPlayerFile: {
     16: new URL("../assets/icons/media_player_file-1.png", import.meta.url)
       .href,
+    path16: "/C:/WINDOWS/Icons/media_player_file-1.png",
     32: new URL("../assets/icons/media_player_file-0.png", import.meta.url)
       .href,
+    path32: "/C:/WINDOWS/Icons/media_player_file-0.png",
   },
   flashPlayer: {
     16: new URL("../assets/icons/Fl-player6.webp", import.meta.url).href,
+    path16: "/C:/WINDOWS/Icons/Fl-player6.webp",
     32: new URL("../assets/icons/Fl-player6.webp", import.meta.url).href,
+    path32: "/C:/WINDOWS/Icons/Fl-player6.webp",
   },
   swfFile: {
     16: new URL(
       "../assets/icons/Flash_Player_6_file_icon.webp",
       import.meta.url,
     ).href,
+    path16: "/C:/WINDOWS/Icons/Flash_Player_6_file_icon.webp",
     32: new URL(
       "../assets/icons/Flash_Player_6_file_icon.webp",
       import.meta.url,
     ).href,
+    path32: "/C:/WINDOWS/Icons/Flash_Player_6_file_icon.webp",
   },
   briefcase: {
     16: new URL("../assets/icons/briefcase-5.png", import.meta.url).href,
+    path16: "/C:/WINDOWS/Icons/briefcase-5.png",
     32: new URL("../assets/icons/briefcase-3.png", import.meta.url).href,
+    path32: "/C:/WINDOWS/Icons/briefcase-3.png",
   },
   windowsExplorer: {
     16: new URL("../assets/icons/directory_explorer-3.png", import.meta.url)
       .href,
+    path16: "/C:/WINDOWS/Icons/directory_explorer-3.png",
     32: new URL("../assets/icons/directory_explorer-4.png", import.meta.url)
       .href,
+    path32: "/C:/WINDOWS/Icons/directory_explorer-4.png",
   },
   windowsUpdate: {
     16: new URL("../assets/icons/windows_update_large-3.png", import.meta.url)
       .href,
+    path16: "/C:/WINDOWS/Icons/windows_update_large-3.png",
     32: new URL("../assets/icons/windows_update_large-4.png", import.meta.url)
       .href,
+    path32: "/C:/WINDOWS/Icons/windows_update_large-4.png",
   },
   controlPanel: {
     16: new URL(
       "../assets/icons/directory_control_panel-1.png",
       import.meta.url,
     ).href,
+    path16: "/C:/WINDOWS/Icons/directory_control_panel-1.png",
     32: new URL(
       "../assets/icons/directory_control_panel-2.png",
       import.meta.url,
     ).href,
+    path32: "/C:/WINDOWS/Icons/directory_control_panel-2.png",
   },
   favoritesFolder: {
     16: new URL("../assets/icons/directory_favorites-5.png", import.meta.url)
       .href,
+    path16: "/C:/WINDOWS/Icons/directory_favorites-5.png",
     32: new URL("../assets/icons/directory_favorites-4.png", import.meta.url)
       .href,
+    path32: "/C:/WINDOWS/Icons/directory_favorites-4.png",
   },
   mouse: {
     16: new URL("../assets/icons/mouse-3.png", import.meta.url).href,
+    path16: "/C:/WINDOWS/Icons/mouse-3.png",
     32: new URL("../assets/icons/mouse-1.png", import.meta.url).href,
+    path32: "/C:/WINDOWS/Icons/mouse-1.png",
   },
   keen: {
     16: new URL(
       "../assets/icons/games/commander-keen-logo.png",
       import.meta.url,
     ).href,
+    path16: "/C:/WINDOWS/Icons/commander-keen-logo.png",
     32: new URL(
       "../assets/icons/games/commander-keen-logo.png",
       import.meta.url,
     ).href,
+    path32: "/C:/WINDOWS/Icons/commander-keen-logo.png",
   },
   diablo: {
     16: new URL("../assets/icons/diablo-16.png", import.meta.url).href,
+    path16: "/C:/WINDOWS/Icons/diablo-16.png",
     32: new URL("../assets/icons/diablo-32.png", import.meta.url).href,
+    path32: "/C:/WINDOWS/Icons/diablo-32.png",
   },
   msdos: {
     16: new URL("../assets/icons/ms_dos-1.png", import.meta.url).href,
+    path16: "/C:/WINDOWS/Icons/ms_dos-1.png",
     32: new URL("../assets/icons/ms_dos-1.png", import.meta.url).href,
+    path32: "/C:/WINDOWS/Icons/ms_dos-1.png",
   },
   esheep: {
     16: new URL("../apps/esheep/esheep.webp", import.meta.url).href,
+    path16: "/C:/WINDOWS/Icons/esheep.webp",
     32: new URL("../apps/esheep/esheep.webp", import.meta.url).href,
+    path32: "/C:/WINDOWS/Icons/esheep.webp",
   },
   minesweeper: {
     16: new URL(
       "../assets/minesweeper/minesweeper-icon-small.png",
       import.meta.url,
     ).href,
+    path16: "/C:/WINDOWS/Icons/minesweeper-icon-small.png",
     32: new URL(
       "../assets/minesweeper/minesweeper-icon-large.png",
       import.meta.url,
     ).href,
+    path32: "/C:/WINDOWS/Icons/minesweeper-icon-large.png",
   },
   wordpad: {
     16: new URL("../assets/icons/write_wordpad-0.png", import.meta.url).href,
+    path16: "/C:/WINDOWS/Icons/write_wordpad-0.png",
     32: new URL("../assets/icons/write_wordpad-1.png", import.meta.url).href,
+    path32: "/C:/WINDOWS/Icons/write_wordpad-1.png",
   },
   calculator: {
     16: new URL("../assets/icons/calc-16.png", import.meta.url).href,
+    path16: "/C:/WINDOWS/Icons/calc-16.png",
     32: new URL("../assets/icons/calc-32.png", import.meta.url).href,
+    path32: "/C:/WINDOWS/Icons/calc-32.png",
   },
   helpBook: {
     16: new URL("../assets/icons/directory_explorer-3.png", import.meta.url)
       .href,
+    path16: "/C:/WINDOWS/Icons/directory_explorer-3.png",
     32: new URL("../assets/icons/directory_explorer-3.png", import.meta.url)
       .href,
+    path32: "/C:/WINDOWS/Icons/directory_explorer-3.png",
   },
   helpBookOpen: {
     16: new URL("../assets/icons/directory_explorer-4.png", import.meta.url)
       .href,
+    path16: "/C:/WINDOWS/Icons/directory_explorer-4.png",
     32: new URL("../assets/icons/directory_explorer-4.png", import.meta.url)
       .href,
+    path32: "/C:/WINDOWS/Icons/directory_explorer-4.png",
   },
   helpPage: {
     16: new URL("../assets/icons/file_lines-1.png", import.meta.url).href,
+    path16: "/C:/WINDOWS/Icons/file_lines-1.png",
     32: new URL("../assets/icons/file_lines-0.png", import.meta.url).href,
+    path32: "/C:/WINDOWS/Icons/file_lines-0.png",
   },
   quake: {
     16: new URL("../assets/icons/quake-16.png", import.meta.url).href,
+    path16: "/C:/WINDOWS/Icons/quake-16.png",
     32: new URL("../assets/icons/quake-32.png", import.meta.url).href,
+    path32: "/C:/WINDOWS/Icons/quake-32.png",
   },
   spidersolitaire: {
     16: new URL("../assets/icons/spider-16.png", import.meta.url).href,
+    path16: "/C:/WINDOWS/Icons/spider-16.png",
     32: new URL("../assets/icons/spider-32.png", import.meta.url).href,
+    path32: "/C:/WINDOWS/Icons/spider-32.png",
   },
   freecell: {
     16: new URL("../assets/icons/game_freecell-2.png", import.meta.url).href,
+    path16: "/C:/WINDOWS/Icons/game_freecell-2.png",
     32: new URL("../assets/icons/game_freecell-2.png", import.meta.url).href,
+    path32: "/C:/WINDOWS/Icons/game_freecell-2.png",
   },
   buggyprogram: {
     16: new URL("../assets/icons/msg_warning-0.png", import.meta.url).href,
+    path16: "/C:/WINDOWS/Icons/msg_warning-0.png",
     32: new URL("../assets/icons/msg_warning-0.png", import.meta.url).href,
+    path32: "/C:/WINDOWS/Icons/msg_warning-0.png",
   },
   error: {
     16: new URL("../assets/icons/msg_error-2.png", import.meta.url).href,
+    path16: "/C:/WINDOWS/Icons/msg_error-2.png",
     32: new URL("../assets/icons/msg_error-0.png", import.meta.url).href,
+    path32: "/C:/WINDOWS/Icons/msg_error-0.png",
   },
 };
 
 export const SHORTCUT_OVERLAY = {
   16: new URL("../assets/icons/overlay_shortcut_16.png", import.meta.url).href,
+  path16: "/C:/WINDOWS/Icons/overlay_shortcut_16.png",
   32: new URL("../assets/icons/overlay_shortcut_32.png", import.meta.url).href,
+  path32: "/C:/WINDOWS/Icons/overlay_shortcut_32.png",
 };

--- a/src/config/icons.js
+++ b/src/config/icons.js
@@ -1,601 +1,421 @@
 export const ICONS = {
   appmaker: {
     16: new URL("../assets/icons/appwizard-0.png", import.meta.url).href,
-    path16: "/C:/WINDOWS/Icons/appwizard-0.png",
     32: new URL("../assets/icons/appwizard-2.png", import.meta.url).href,
-    path32: "/C:/WINDOWS/Icons/appwizard-2.png",
   },
   appmakerApp: {
     16: new URL("../assets/icons/SHELL32_3-16.png", import.meta.url).href,
-    path16: "/C:/WINDOWS/Icons/SHELL32_3-16.png",
     32: new URL("../assets/icons/SHELL32_3-32.png", import.meta.url).href,
-    path32: "/C:/WINDOWS/Icons/SHELL32_3-32.png",
   },
   "internet-explorer": {
     16: new URL("../assets/icons/msie1-4.png", import.meta.url).href,
-    path16: "/C:/WINDOWS/Icons/msie1-4.png",
     32: new URL("../assets/icons/msie1-1.png", import.meta.url).href,
-    path32: "/C:/WINDOWS/Icons/msie1-1.png",
   },
   about: {
     16: new URL("../assets/icons/COMCTL32_20481-16.png", import.meta.url).href,
-    path16: "/C:/WINDOWS/Icons/COMCTL32_20481-16.png",
     32: new URL("../assets/icons/COMCTL32_20481-32.png", import.meta.url).href,
-    path32: "/C:/WINDOWS/Icons/COMCTL32_20481-32.png",
   },
   pdf: {
     16: new URL("../assets/icons/word_001-16.png", import.meta.url).href,
-    path16: "/C:/WINDOWS/Icons/word_001-16.png",
     32: new URL("../assets/icons/word_001-32.png", import.meta.url).href,
-    path32: "/C:/WINDOWS/Icons/word_001-32.png",
   },
   tip: {
     16: new URL("../assets/icons/help_book_cool-0.png", import.meta.url).href,
-    path16: "/C:/WINDOWS/Icons/help_book_cool-0.png",
     32: new URL("../assets/icons/help_book_cool-0.png", import.meta.url).href,
-    path32: "/C:/WINDOWS/Icons/help_book_cool-0.png",
   },
   notepad: {
     16: new URL("../assets/icons/notepad-0.png", import.meta.url).href,
-    path16: "/C:/WINDOWS/Icons/notepad-0.png",
     32: new URL("../assets/icons/NOTEPAD_1-32.png", import.meta.url).href,
-    path32: "/C:/WINDOWS/Icons/NOTEPAD_1-32.png",
   },
   clippy: {
     16: new URL("../assets/icons/msagent_file-1.png", import.meta.url).href,
-    path16: "/C:/WINDOWS/Icons/msagent_file-1.png",
     32: new URL("../assets/icons/msagent_file-1.png", import.meta.url).href,
-    path32: "/C:/WINDOWS/Icons/msagent_file-1.png",
   },
   webamp: {
     16: new URL("../assets/icons/winamp.png", import.meta.url).href,
-    path16: "/C:/WINDOWS/Icons/winamp.png",
     32: new URL("../assets/icons/winamp.png", import.meta.url).href,
-    path32: "/C:/WINDOWS/Icons/winamp.png",
   },
   image: {
     16: new URL("../assets/icons/kodak_imaging-0.png", import.meta.url).href,
-    path16: "/C:/WINDOWS/Icons/kodak_imaging-0.png",
     32: new URL("../assets/icons/kodak_imaging-0.png", import.meta.url).href,
-    path32: "/C:/WINDOWS/Icons/kodak_imaging-0.png",
   },
   imageViewer: {
     16: new URL("../assets/icons/image_viewer-0.png", import.meta.url).href,
-    path16: "/C:/WINDOWS/Icons/image_viewer-0.png",
     32: new URL("../assets/icons/image_viewer-0.png", import.meta.url).href,
-    path32: "/C:/WINDOWS/Icons/image_viewer-0.png",
   },
   computer: {
     16: new URL("../assets/icons/computer_explorer-0.png", import.meta.url)
       .href,
-    path16: "/C:/WINDOWS/Icons/computer_explorer-0.png",
     32: new URL("../assets/icons/computer_explorer-32.png", import.meta.url)
       .href,
-    path32: "/C:/WINDOWS/Icons/computer_explorer-32.png",
   },
   disketteDrive: {
     16: new URL("../assets/icons/SHELL32_7-16.png", import.meta.url).href,
-    path16: "/C:/WINDOWS/Icons/SHELL32_7-16.png",
     32: new URL("../assets/icons/SHELL32_7-32.png", import.meta.url).href,
-    path32: "/C:/WINDOWS/Icons/SHELL32_7-32.png",
   },
   cdDrive: {
     16: new URL("../assets/icons/cd_drive-1.png", import.meta.url).href,
-    path16: "/C:/WINDOWS/Icons/cd_drive-1.png",
     32: new URL("../assets/icons/cd_drive-2.png", import.meta.url).href,
-    path32: "/C:/WINDOWS/Icons/cd_drive-2.png",
   },
   defrag: {
     16: new URL("../assets/icons/defragment-1.png", import.meta.url).href,
-    path16: "/C:/WINDOWS/Icons/defragment-1.png",
     32: new URL("../assets/icons/defragment-0.png", import.meta.url).href,
-    path32: "/C:/WINDOWS/Icons/defragment-0.png",
   },
   drive: {
     16: new URL("../assets/icons/SHELL32_9-16.png", import.meta.url).href,
-    path16: "/C:/WINDOWS/Icons/SHELL32_9-16.png",
     32: new URL("../assets/icons/SHELL32_9-32.png", import.meta.url).href,
-    path32: "/C:/WINDOWS/Icons/SHELL32_9-32.png",
   },
   removableDrive: {
     16: new URL("../assets/icons/removable_disk_drive-1.png", import.meta.url)
       .href,
-    path16: "/C:/WINDOWS/Icons/removable_disk_drive-1.png",
     32: new URL("../assets/icons/removable_disk_drive-0.png", import.meta.url)
       .href,
-    path32: "/C:/WINDOWS/Icons/removable_disk_drive-0.png",
   },
   folder: {
     16: new URL(
       "../assets/icons/directory_open_file_mydocs_small-5.png",
       import.meta.url,
     ).href,
-    path16: "/C:/WINDOWS/Icons/directory_open_file_mydocs_small-5.png",
     32: new URL(
       "../assets/icons/directory_open_file_mydocs-1.png",
       import.meta.url,
     ).href,
-    path32: "/C:/WINDOWS/Icons/directory_open_file_mydocs-1.png",
   },
   folderClosed: {
     16: new URL("../assets/icons/SHELL32_4-16.png", import.meta.url).href,
-    path16: "/C:/WINDOWS/Icons/SHELL32_4-16.png",
     32: new URL("../assets/icons/SHELL32_4-32.png", import.meta.url).href,
-    path32: "/C:/WINDOWS/Icons/SHELL32_4-32.png",
   },
   folderOpen: {
     16: new URL("../assets/icons/SHELL32_5-16.png", import.meta.url).href,
-    path16: "/C:/WINDOWS/Icons/SHELL32_5-16.png",
     32: new URL("../assets/icons/SHELL32_5-32.png", import.meta.url).href,
-    path32: "/C:/WINDOWS/Icons/SHELL32_5-32.png",
   },
   warning: {
     16: new URL("../assets/icons/msg_warning-0.png", import.meta.url).href,
-    path16: "/C:/WINDOWS/Icons/msg_warning-0.png",
     32: new URL("../assets/icons/msg_warning-0.png", import.meta.url).href,
-    path32: "/C:/WINDOWS/Icons/msg_warning-0.png",
   },
   shutdown: {
     16: new URL("../assets/icons/SHELL32_28-16.png", import.meta.url).href,
-    path16: "/C:/WINDOWS/Icons/SHELL32_28-16.png",
     32: new URL("../assets/icons/SHELL32_28-32.png", import.meta.url).href,
-    path32: "/C:/WINDOWS/Icons/SHELL32_28-32.png",
   },
   windows: {
     16: new URL("../assets/icons/windows-4.png", import.meta.url).href,
-    path16: "/C:/WINDOWS/Icons/windows-4.png",
     32: new URL("../assets/icons/windows-4.png", import.meta.url).href,
-    path32: "/C:/WINDOWS/Icons/windows-4.png",
   },
   key: {
     16: new URL("../assets/icons/key_win_alt-16.png", import.meta.url).href,
-    path16: "/C:/WINDOWS/Icons/key_win_alt-16.png",
     32: new URL("../assets/icons/key_win-4.png", import.meta.url).href,
-    path32: "/C:/WINDOWS/Icons/key_win-4.png",
   },
   shell: {
     16: new URL("../assets/icons/SHELL32_3-16.png", import.meta.url).href,
-    path16: "/C:/WINDOWS/Icons/SHELL32_3-16.png",
     32: new URL("../assets/icons/SHELL32_3-32.png", import.meta.url).href,
-    path32: "/C:/WINDOWS/Icons/SHELL32_3-32.png",
   },
   systray: {
     16: new URL("../assets/icons/SYSTRAY_220-16.png", import.meta.url).href,
-    path16: "/C:/WINDOWS/Icons/SYSTRAY_220-16.png",
     32: new URL("../assets/icons/SYSTRAY_220.ico", import.meta.url).href,
-    path32: "/C:/WINDOWS/Icons/SYSTRAY_220.ico",
   },
   rnaui: {
     16: new URL("../assets/icons/RNAUI_106.ico", import.meta.url).href,
-    path16: "/C:/WINDOWS/Icons/RNAUI_106.ico",
     32: new URL("../assets/icons/RNAUI_106-32.png", import.meta.url).href,
-    path32: "/C:/WINDOWS/Icons/RNAUI_106-32.png",
   },
   setdebug: {
     16: new URL("../assets/icons/SETDEBUG_100.ico", import.meta.url).href,
-    path16: "/C:/WINDOWS/Icons/SETDEBUG_100.ico",
     32: new URL("../assets/icons/SETDEBUG_100-32.png", import.meta.url).href,
-    path32: "/C:/WINDOWS/Icons/SETDEBUG_100-32.png",
   },
   mmsys: {
     16: new URL("../assets/icons/MMSYS_110-16.png", import.meta.url).href,
-    path16: "/C:/WINDOWS/Icons/MMSYS_110-16.png",
     32: new URL("../assets/icons/MMSYS_110-32.png", import.meta.url).href,
-    path32: "/C:/WINDOWS/Icons/MMSYS_110-32.png",
   },
   comctl32: {
     16: new URL("../assets/icons/COMCTL32_20481-16.png", import.meta.url).href,
-    path16: "/C:/WINDOWS/Icons/COMCTL32_20481-16.png",
     32: new URL("../assets/icons/COMCTL32_20481-32.png", import.meta.url).href,
-    path32: "/C:/WINDOWS/Icons/COMCTL32_20481-32.png",
   },
   desktop_old: {
     16: new URL("../assets/icons/desktop-4.png", import.meta.url).href,
-    path16: "/C:/WINDOWS/Icons/desktop-4.png",
     32: new URL("../assets/icons/desktop-1.png", import.meta.url).href,
-    path32: "/C:/WINDOWS/Icons/desktop-1.png",
   },
   themetocss: {
     16: new URL("../assets/icons/word_001-16.png", import.meta.url).href,
-    path16: "/C:/WINDOWS/Icons/word_001-16.png",
     32: new URL("../assets/icons/word_001-32.png", import.meta.url).href,
-    path32: "/C:/WINDOWS/Icons/word_001-32.png",
   },
   programs: {
     16: new URL("../assets/icons/SHELL32_20-16.png", import.meta.url).href,
-    path16: "/C:/WINDOWS/Icons/SHELL32_20-16.png",
     32: new URL("../assets/icons/SHELL32_20-32.png", import.meta.url).href,
-    path32: "/C:/WINDOWS/Icons/SHELL32_20-32.png",
   },
   favorites: {
     16: new URL("../assets/icons/SHELL32_44-16.png", import.meta.url).href,
-    path16: "/C:/WINDOWS/Icons/SHELL32_44-16.png",
     32: new URL("../assets/icons/SHELL32_44-32.png", import.meta.url).href,
-    path32: "/C:/WINDOWS/Icons/SHELL32_44-32.png",
   },
   documents: {
     16: new URL("../assets/icons/SHELL32_21-16.png", import.meta.url).href,
-    path16: "/C:/WINDOWS/Icons/SHELL32_21-16.png",
     32: new URL("../assets/icons/SHELL32_21-32.png", import.meta.url).href,
-    path32: "/C:/WINDOWS/Icons/SHELL32_21-32.png",
   },
   settings: {
     16: new URL("../assets/icons/SHELL32_22-16.png", import.meta.url).href,
-    path16: "/C:/WINDOWS/Icons/SHELL32_22-16.png",
     32: new URL("../assets/icons/SHELL32_22-32.png", import.meta.url).href,
-    path32: "/C:/WINDOWS/Icons/SHELL32_22-32.png",
   },
   find: {
     16: new URL("../assets/icons/SHELL32_23-16.png", import.meta.url).href,
-    path16: "/C:/WINDOWS/Icons/SHELL32_23-16.png",
     32: new URL("../assets/icons/SHELL32_23-32.png", import.meta.url).href,
-    path32: "/C:/WINDOWS/Icons/SHELL32_23-32.png",
   },
   help: {
     16: new URL("../assets/icons/SHELL32_24-16.png", import.meta.url).href,
-    path16: "/C:/WINDOWS/Icons/SHELL32_24-16.png",
     32: new URL("../assets/icons/SHELL32_24-32.png", import.meta.url).href,
-    path32: "/C:/WINDOWS/Icons/SHELL32_24-32.png",
   },
   run: {
     16: new URL("../assets/icons/SHELL32_25-16.png", import.meta.url).href,
-    path16: "/C:/WINDOWS/Icons/SHELL32_25-16.png",
     32: new URL("../assets/icons/SHELL32_25-32.png", import.meta.url).href,
-    path32: "/C:/WINDOWS/Icons/SHELL32_25-32.png",
   },
   logoff: {
     16: new URL("../assets/icons/SHELL32_45-16.png", import.meta.url).href,
-    path16: "/C:/WINDOWS/Icons/SHELL32_45-16.png",
     32: new URL("../assets/icons/SHELL32_45-32.png", import.meta.url).href,
-    path32: "/C:/WINDOWS/Icons/SHELL32_45-32.png",
   },
   windowsUpdate: {
     16: new URL("../assets/icons/SHELL32_47-16.png", import.meta.url).href,
-    path16: "/C:/WINDOWS/Icons/SHELL32_47-16.png",
     32: new URL("../assets/icons/SHELL32_47-32.png", import.meta.url).href,
-    path32: "/C:/WINDOWS/Icons/SHELL32_47-32.png",
   },
   startMenuFolder: {
     16: new URL("../assets/icons/SHELL32_37-16.png", import.meta.url).href,
-    path16: "/C:/WINDOWS/Icons/SHELL32_37-16.png",
     32: new URL("../assets/icons/SHELL32_37-32.png", import.meta.url).href,
-    path32: "/C:/WINDOWS/Icons/SHELL32_37-32.png",
   },
   soundschemeexplorer: {
     16: new URL("../assets/icons/MMSYS_110-16.png", import.meta.url).href,
-    path16: "/C:/WINDOWS/Icons/MMSYS_110-16.png",
     32: new URL("../assets/icons/MMSYS_110-32.png", import.meta.url).href,
-    path32: "/C:/WINDOWS/Icons/MMSYS_110-32.png",
   },
   desktopthemes: {
     16: new URL("../assets/icons/themes-2.png", import.meta.url).href,
-    path16: "/C:/WINDOWS/Icons/themes-2.png",
     32: new URL("../assets/icons/themes-2.png", import.meta.url).href,
-    path32: "/C:/WINDOWS/Icons/themes-2.png",
   },
   recycleBinEmpty: {
     16: new URL(
       "../assets/icons/theme-icons/recycle_bin_empty-4.png",
       import.meta.url,
     ).href,
-    path16: "/C:/WINDOWS/Icons/recycle_bin_empty-4.png",
     32: new URL(
       "../assets/icons/theme-icons/recycle_bin_empty-4.png",
       import.meta.url,
     ).href,
-    path32: "/C:/WINDOWS/Icons/recycle_bin_empty-4.png",
   },
   recycleBinFull: {
     16: new URL(
       "../assets/icons/theme-icons/recycle_bin_full-4.png",
       import.meta.url,
     ).href,
-    path16: "/C:/WINDOWS/Icons/recycle_bin_full-4.png",
     32: new URL(
       "../assets/icons/theme-icons/recycle_bin_full-4.png",
       import.meta.url,
     ).href,
-    path32: "/C:/WINDOWS/Icons/recycle_bin_full-4.png",
   },
   pinball: {
     16: new URL("../assets/icons/PINBALL-16.png", import.meta.url).href,
-    path16: "/C:/WINDOWS/Icons/PINBALL-16.png",
     32: new URL("../assets/icons/PINBALL-32.png", import.meta.url).href,
-    path32: "/C:/WINDOWS/Icons/PINBALL-32.png",
   },
   solitaire: {
     16: new URL("../assets/icons/SolitaireWin31Icon.png", import.meta.url).href,
-    path16: "/C:/WINDOWS/Icons/SolitaireWin31Icon.png",
     32: new URL("../assets/icons/SolitaireWin31Icon.png", import.meta.url).href,
-    path32: "/C:/WINDOWS/Icons/SolitaireWin31Icon.png",
   },
   princeofpersia: {
     16: new URL("../assets/icons/pop-16.png", import.meta.url).href,
-    path16: "/C:/WINDOWS/Icons/pop-16.png",
     32: new URL("../assets/icons/pop-32.png", import.meta.url).href,
-    path32: "/C:/WINDOWS/Icons/pop-32.png",
   },
   paint: {
     16: new URL("../assets/icons/Paint-16.png", import.meta.url).href,
-    path16: "/C:/WINDOWS/Icons/Paint-16.png",
     32: new URL("../assets/icons/Paint-32.png", import.meta.url).href,
-    path32: "/C:/WINDOWS/Icons/Paint-32.png",
   },
   simcity2000: {
     16: new URL("../assets/icons/games/SIMCITY_2.ico", import.meta.url).href,
-    path16: "/C:/WINDOWS/Icons/SIMCITY_2.ico",
     32: new URL("../assets/icons/games/SIMCITY_2.ico", import.meta.url).href,
-    path32: "/C:/WINDOWS/Icons/SIMCITY_2.ico",
   },
   displayProperties: {
     16: new URL("../assets/icons/Display-16.png", import.meta.url).href,
-    path16: "/C:/WINDOWS/Icons/Display-16.png",
     32: new URL("../assets/icons/Display-32.png", import.meta.url).href,
-    path32: "/C:/WINDOWS/Icons/Display-32.png",
   },
   networkNeighborhood: {
     16: new URL("../assets/icons/SHELL32_18-16.png", import.meta.url).href,
-    path16: "/C:/WINDOWS/Icons/SHELL32_18-16.png",
     32: new URL("../assets/icons/SHELL32_18-32.png", import.meta.url).href,
-    path32: "/C:/WINDOWS/Icons/SHELL32_18-32.png",
   },
   htmlFile: {
     16: new URL("../assets/icons/html2-4.png", import.meta.url).href,
-    path16: "/C:/WINDOWS/Icons/html2-4.png",
     32: new URL("../assets/icons/html2-3.png", import.meta.url).href,
-    path32: "/C:/WINDOWS/Icons/html2-3.png",
   },
   "buy-me-a-coffee": {
     16: new URL("../assets/icons/Ko-fi_COIN-16.gif", import.meta.url).href,
-    path16: "/C:/WINDOWS/Icons/Ko-fi_COIN-16.gif",
     32: new URL("../assets/icons/Ko-fi_COIN-32.gif", import.meta.url).href,
-    path32: "/C:/WINDOWS/Icons/Ko-fi_COIN-32.gif",
   },
   textFile: {
     16: new URL("../assets/icons/notepad_file-1.png", import.meta.url).href,
-    path16: "/C:/WINDOWS/Icons/notepad_file-1.png",
     32: new URL("../assets/icons/notepad_file-0.png", import.meta.url).href,
-    path32: "/C:/WINDOWS/Icons/notepad_file-0.png",
   },
   imageJpgFile: {
     16: new URL("../assets/icons/imagjpeg-0.png", import.meta.url).href,
-    path16: "/C:/WINDOWS/Icons/imagjpeg-0.png",
     32: new URL("../assets/icons/imagjpeg-1.png", import.meta.url).href,
-    path32: "/C:/WINDOWS/Icons/imagjpeg-1.png",
   },
   imageGifFile: {
     16: new URL("../assets/icons/imaggif-0.png", import.meta.url).href,
-    path16: "/C:/WINDOWS/Icons/imaggif-0.png",
     32: new URL("../assets/icons/imaggif-1.png", import.meta.url).href,
-    path32: "/C:/WINDOWS/Icons/imaggif-1.png",
   },
   imageBmpFile: {
     16: new URL("../assets/icons/paint_file-1.png", import.meta.url).href,
-    path16: "/C:/WINDOWS/Icons/paint_file-1.png",
     32: new URL("../assets/icons/paint_file-3.png", import.meta.url).href,
-    path32: "/C:/WINDOWS/Icons/paint_file-3.png",
   },
   file: {
     16: new URL("../assets/icons/file_lines-1.png", import.meta.url).href,
-    path16: "/C:/WINDOWS/Icons/file_lines-1.png",
     32: new URL("../assets/icons/file_lines-0.png", import.meta.url).href,
-    path32: "/C:/WINDOWS/Icons/file_lines-0.png",
   },
   fileSet: {
     16: new URL("../assets/icons/file_set-1.png", import.meta.url).href,
-    path16: "/C:/WINDOWS/Icons/file_set-1.png",
     32: new URL("../assets/icons/file_set-0.png", import.meta.url).href,
-    path32: "/C:/WINDOWS/Icons/file_set-0.png",
   },
   "cursor-explorer": {
     16: new URL("../assets/icons/COMCTL32_20481-16.png", import.meta.url).href,
-    path16: "/C:/WINDOWS/Icons/COMCTL32_20481-16.png",
     32: new URL("../assets/icons/COMCTL32_20481-32.png", import.meta.url).href,
-    path32: "/C:/WINDOWS/Icons/COMCTL32_20481-32.png",
   },
   networkComputer: {
     16: new URL("../assets/icons/computer_2-1.png", import.meta.url).href,
-    path16: "/C:/WINDOWS/Icons/computer_2-1.png",
     32: new URL("../assets/icons/computer_2-3.png", import.meta.url).href,
-    path32: "/C:/WINDOWS/Icons/computer_2-3.png",
   },
   doom: {
     16: new URL("../assets/icons/games/doom.png", import.meta.url).href,
-    path16: "/C:/WINDOWS/Icons/doom.png",
     32: new URL("../assets/icons/games/doom.png", import.meta.url).href,
-    path32: "/C:/WINDOWS/Icons/doom.png",
   },
   mediaPlayer: {
     16: new URL("../assets/icons/MPLAYER2_110-16.png", import.meta.url).href,
-    path16: "/C:/WINDOWS/Icons/MPLAYER2_110-16.png",
     32: new URL("../assets/icons/MPLAYER2_110-32.png", import.meta.url).href,
-    path32: "/C:/WINDOWS/Icons/MPLAYER2_110-32.png",
   },
   mediaPlayerFile: {
     16: new URL("../assets/icons/media_player_file-1.png", import.meta.url)
       .href,
-    path16: "/C:/WINDOWS/Icons/media_player_file-1.png",
     32: new URL("../assets/icons/media_player_file-0.png", import.meta.url)
       .href,
-    path32: "/C:/WINDOWS/Icons/media_player_file-0.png",
   },
   flashPlayer: {
     16: new URL("../assets/icons/Fl-player6.webp", import.meta.url).href,
-    path16: "/C:/WINDOWS/Icons/Fl-player6.webp",
     32: new URL("../assets/icons/Fl-player6.webp", import.meta.url).href,
-    path32: "/C:/WINDOWS/Icons/Fl-player6.webp",
   },
   swfFile: {
     16: new URL(
       "../assets/icons/Flash_Player_6_file_icon.webp",
       import.meta.url,
     ).href,
-    path16: "/C:/WINDOWS/Icons/Flash_Player_6_file_icon.webp",
     32: new URL(
       "../assets/icons/Flash_Player_6_file_icon.webp",
       import.meta.url,
     ).href,
-    path32: "/C:/WINDOWS/Icons/Flash_Player_6_file_icon.webp",
   },
   briefcase: {
     16: new URL("../assets/icons/briefcase-5.png", import.meta.url).href,
-    path16: "/C:/WINDOWS/Icons/briefcase-5.png",
     32: new URL("../assets/icons/briefcase-3.png", import.meta.url).href,
-    path32: "/C:/WINDOWS/Icons/briefcase-3.png",
   },
   windowsExplorer: {
     16: new URL("../assets/icons/directory_explorer-3.png", import.meta.url)
       .href,
-    path16: "/C:/WINDOWS/Icons/directory_explorer-3.png",
     32: new URL("../assets/icons/directory_explorer-4.png", import.meta.url)
       .href,
-    path32: "/C:/WINDOWS/Icons/directory_explorer-4.png",
   },
   windowsUpdate: {
     16: new URL("../assets/icons/windows_update_large-3.png", import.meta.url)
       .href,
-    path16: "/C:/WINDOWS/Icons/windows_update_large-3.png",
     32: new URL("../assets/icons/windows_update_large-4.png", import.meta.url)
       .href,
-    path32: "/C:/WINDOWS/Icons/windows_update_large-4.png",
   },
   controlPanel: {
     16: new URL(
       "../assets/icons/directory_control_panel-1.png",
       import.meta.url,
     ).href,
-    path16: "/C:/WINDOWS/Icons/directory_control_panel-1.png",
     32: new URL(
       "../assets/icons/directory_control_panel-2.png",
       import.meta.url,
     ).href,
-    path32: "/C:/WINDOWS/Icons/directory_control_panel-2.png",
   },
   favoritesFolder: {
     16: new URL("../assets/icons/directory_favorites-5.png", import.meta.url)
       .href,
-    path16: "/C:/WINDOWS/Icons/directory_favorites-5.png",
     32: new URL("../assets/icons/directory_favorites-4.png", import.meta.url)
       .href,
-    path32: "/C:/WINDOWS/Icons/directory_favorites-4.png",
   },
   mouse: {
     16: new URL("../assets/icons/mouse-3.png", import.meta.url).href,
-    path16: "/C:/WINDOWS/Icons/mouse-3.png",
     32: new URL("../assets/icons/mouse-1.png", import.meta.url).href,
-    path32: "/C:/WINDOWS/Icons/mouse-1.png",
   },
   keen: {
     16: new URL(
       "../assets/icons/games/commander-keen-logo.png",
       import.meta.url,
     ).href,
-    path16: "/C:/WINDOWS/Icons/commander-keen-logo.png",
     32: new URL(
       "../assets/icons/games/commander-keen-logo.png",
       import.meta.url,
     ).href,
-    path32: "/C:/WINDOWS/Icons/commander-keen-logo.png",
   },
   diablo: {
     16: new URL("../assets/icons/diablo-16.png", import.meta.url).href,
-    path16: "/C:/WINDOWS/Icons/diablo-16.png",
     32: new URL("../assets/icons/diablo-32.png", import.meta.url).href,
-    path32: "/C:/WINDOWS/Icons/diablo-32.png",
   },
   msdos: {
     16: new URL("../assets/icons/ms_dos-1.png", import.meta.url).href,
-    path16: "/C:/WINDOWS/Icons/ms_dos-1.png",
     32: new URL("../assets/icons/ms_dos-1.png", import.meta.url).href,
-    path32: "/C:/WINDOWS/Icons/ms_dos-1.png",
   },
   esheep: {
     16: new URL("../apps/esheep/esheep.webp", import.meta.url).href,
-    path16: "/C:/WINDOWS/Icons/esheep.webp",
     32: new URL("../apps/esheep/esheep.webp", import.meta.url).href,
-    path32: "/C:/WINDOWS/Icons/esheep.webp",
   },
   minesweeper: {
     16: new URL(
       "../assets/minesweeper/minesweeper-icon-small.png",
       import.meta.url,
     ).href,
-    path16: "/C:/WINDOWS/Icons/minesweeper-icon-small.png",
     32: new URL(
       "../assets/minesweeper/minesweeper-icon-large.png",
       import.meta.url,
     ).href,
-    path32: "/C:/WINDOWS/Icons/minesweeper-icon-large.png",
   },
   wordpad: {
     16: new URL("../assets/icons/write_wordpad-0.png", import.meta.url).href,
-    path16: "/C:/WINDOWS/Icons/write_wordpad-0.png",
     32: new URL("../assets/icons/write_wordpad-1.png", import.meta.url).href,
-    path32: "/C:/WINDOWS/Icons/write_wordpad-1.png",
   },
   calculator: {
     16: new URL("../assets/icons/calc-16.png", import.meta.url).href,
-    path16: "/C:/WINDOWS/Icons/calc-16.png",
     32: new URL("../assets/icons/calc-32.png", import.meta.url).href,
-    path32: "/C:/WINDOWS/Icons/calc-32.png",
   },
   helpBook: {
     16: new URL("../assets/icons/directory_explorer-3.png", import.meta.url)
       .href,
-    path16: "/C:/WINDOWS/Icons/directory_explorer-3.png",
     32: new URL("../assets/icons/directory_explorer-3.png", import.meta.url)
       .href,
-    path32: "/C:/WINDOWS/Icons/directory_explorer-3.png",
   },
   helpBookOpen: {
     16: new URL("../assets/icons/directory_explorer-4.png", import.meta.url)
       .href,
-    path16: "/C:/WINDOWS/Icons/directory_explorer-4.png",
     32: new URL("../assets/icons/directory_explorer-4.png", import.meta.url)
       .href,
-    path32: "/C:/WINDOWS/Icons/directory_explorer-4.png",
   },
   helpPage: {
     16: new URL("../assets/icons/file_lines-1.png", import.meta.url).href,
-    path16: "/C:/WINDOWS/Icons/file_lines-1.png",
     32: new URL("../assets/icons/file_lines-0.png", import.meta.url).href,
-    path32: "/C:/WINDOWS/Icons/file_lines-0.png",
   },
   quake: {
     16: new URL("../assets/icons/quake-16.png", import.meta.url).href,
-    path16: "/C:/WINDOWS/Icons/quake-16.png",
     32: new URL("../assets/icons/quake-32.png", import.meta.url).href,
-    path32: "/C:/WINDOWS/Icons/quake-32.png",
   },
   spidersolitaire: {
     16: new URL("../assets/icons/spider-16.png", import.meta.url).href,
-    path16: "/C:/WINDOWS/Icons/spider-16.png",
     32: new URL("../assets/icons/spider-32.png", import.meta.url).href,
-    path32: "/C:/WINDOWS/Icons/spider-32.png",
   },
   freecell: {
     16: new URL("../assets/icons/game_freecell-2.png", import.meta.url).href,
-    path16: "/C:/WINDOWS/Icons/game_freecell-2.png",
     32: new URL("../assets/icons/game_freecell-2.png", import.meta.url).href,
-    path32: "/C:/WINDOWS/Icons/game_freecell-2.png",
   },
   buggyprogram: {
     16: new URL("../assets/icons/msg_warning-0.png", import.meta.url).href,
-    path16: "/C:/WINDOWS/Icons/msg_warning-0.png",
     32: new URL("../assets/icons/msg_warning-0.png", import.meta.url).href,
-    path32: "/C:/WINDOWS/Icons/msg_warning-0.png",
   },
   error: {
     16: new URL("../assets/icons/msg_error-2.png", import.meta.url).href,
-    path16: "/C:/WINDOWS/Icons/msg_error-2.png",
     32: new URL("../assets/icons/msg_error-0.png", import.meta.url).href,
-    path32: "/C:/WINDOWS/Icons/msg_error-0.png",
   },
 };
 
 export const SHORTCUT_OVERLAY = {
   16: new URL("../assets/icons/overlay_shortcut_16.png", import.meta.url).href,
-  path16: "/C:/WINDOWS/Icons/overlay_shortcut_16.png",
   32: new URL("../assets/icons/overlay_shortcut_32.png", import.meta.url).href,
-  path32: "/C:/WINDOWS/Icons/overlay_shortcut_32.png",
 };

--- a/src/config/system-files.js
+++ b/src/config/system-files.js
@@ -1,0 +1,29 @@
+// src/config/system-files.js
+
+/**
+ * This file captures the source code of essential boot components at build time
+ * using Vite's glob import feature. These are then stored in ZenFS for
+ * offline persistence and user peeking.
+ */
+
+// Core source files
+const coreFiles = import.meta.glob([
+  '../main.js',
+  '../utils/*.js',
+  '../config/*.js',
+  '../components/bootScreen.js',
+  '../components/ui.js',
+  '../components/taskbar.js',
+  '../components/desktop.js',
+  '../components/StartMenu.js',
+  '../apps/Application.js',
+], { query: '?raw', import: 'default', eager: true });
+
+export const SYSTEM_SOURCE_FILES = {};
+
+for (const path in coreFiles) {
+  // Normalize path to be relative to src root for ZenFS storage
+  // e.g. ../utils/zenfs-init.js -> utils/zenfs-init.js
+  const normalizedPath = path.replace('../', '');
+  SYSTEM_SOURCE_FILES[normalizedPath] = coreFiles[path];
+}

--- a/src/utils/iconSync.js
+++ b/src/utils/iconSync.js
@@ -1,80 +1,49 @@
 import { fs } from "@zenfs/core";
 import { ICONS, SHORTCUT_OVERLAY } from "../config/icons.js";
-import { existsAsync, getZenFSFileUrl } from "./zenfs-utils.js";
+import { getZenFSFileUrl, existsAsync } from "./zenfs-utils.js";
 
-const ICON_DIR = "/C:/WINDOWS/Icons";
+async function syncIcon(key, icon, prefix = "") {
+    // Generate paths if they don't exist
+    const name = prefix ? `${prefix}_${key}` : key;
+    const path16 = `/C:/WINDOWS/Icons/${name}_16.png`;
+    const path32 = `/C:/WINDOWS/Icons/${name}_32.png`;
 
-/**
- * Synchronizes icons from their bundled URLs to ZenFS and updates the icon objects
- * to use Blob URLs from the ZenFS files.
- * @param {Function} onProgress Optional callback for progress logging
- */
-export async function syncIconsToZenFS(onProgress) {
-  try {
-    // Ensure icon directory exists
-    if (!(await existsAsync(ICON_DIR))) {
-      await fs.promises.mkdir(ICON_DIR, { recursive: true });
-    }
+    // Inject paths into the icon object (optional, but good for reference)
+    icon.path16 = path16;
+    icon.path32 = path32;
 
-    const iconItems = [...Object.values(ICONS), SHORTCUT_OVERLAY];
-    let totalIcons = 0;
-    let processedEntries = 0;
-    const blobUrlCache = new Map();
-
-    // Count icons for progress reporting
-    for (const item of iconItems) {
-      if (item.path16) totalIcons++;
-      if (item.path32) totalIcons++;
-    }
-
-    for (const item of iconItems) {
-      // Handle 16px version
-      if (item.path16) {
-        if (onProgress) onProgress(`Syncing icons (${processedEntries}/${totalIcons})...`);
-
-        if (!blobUrlCache.has(item.path16)) {
-          await syncIcon(item[16], item.path16);
-          blobUrlCache.set(item.path16, await getZenFSFileUrl(item.path16));
+    try {
+        if (!(await existsAsync(path16))) {
+            const blob16 = await (await fetch(icon[16])).blob();
+            const arrayBuffer16 = await blob16.arrayBuffer();
+            await fs.promises.writeFile(path16, new Uint8Array(arrayBuffer16));
         }
-        item[16] = blobUrlCache.get(item.path16);
-        processedEntries++;
-      }
-
-      // Handle 32px version
-      if (item.path32) {
-        if (onProgress) onProgress(`Syncing icons (${processedEntries}/${totalIcons})...`);
-
-        if (!blobUrlCache.has(item.path32)) {
-          await syncIcon(item[32], item.path32);
-          blobUrlCache.set(item.path32, await getZenFSFileUrl(item.path32));
+        if (!(await existsAsync(path32))) {
+            const blob32 = await (await fetch(icon[32])).blob();
+            const arrayBuffer32 = await blob32.arrayBuffer();
+            await fs.promises.writeFile(path32, new Uint8Array(arrayBuffer32));
         }
-        item[32] = blobUrlCache.get(item.path32);
-        processedEntries++;
-      }
-    }
 
-    if (onProgress) onProgress(`Syncing icons completed.`);
-  } catch (error) {
-    console.error("Failed to sync icons to ZenFS:", error);
-  }
+        // Update the URL to use the ZenFS path (via Blob URL)
+        // This mutates the global ICONS/SHORTCUT_OVERLAY objects
+        icon[16] = await getZenFSFileUrl(path16);
+        icon[32] = await getZenFSFileUrl(path32);
+    } catch (e) {
+        console.warn(`Failed to sync icon ${name}:`, e);
+    }
 }
 
-/**
- * Syncs a single icon file from URL to ZenFS if it doesn't exist.
- * @param {string} url Bundled asset URL
- * @param {string} path ZenFS destination path
- */
-async function syncIcon(url, path) {
-  if (await existsAsync(path)) {
-    return;
-  }
+export async function syncIcons() {
+    const iconsDir = "/C:/WINDOWS/Icons";
+    if (!(await existsAsync(iconsDir))) {
+        await fs.promises.mkdir(iconsDir, { recursive: true });
+    }
 
-  try {
-    const response = await fetch(url);
-    if (!response.ok) throw new Error(`HTTP error! status: ${response.status}`);
-    const buffer = await response.arrayBuffer();
-    await fs.promises.writeFile(path, new Uint8Array(buffer));
-  } catch (error) {
-    console.error(`Failed to sync icon ${url} to ${path}:`, error);
-  }
+    // Sync all main icons
+    const iconPromises = Object.entries(ICONS).map(([key, icon]) => syncIcon(key, icon));
+
+    // Sync shortcut overlay
+    iconPromises.push(syncIcon("shortcut", SHORTCUT_OVERLAY, "overlay"));
+
+    await Promise.all(iconPromises);
 }

--- a/src/utils/iconSync.js
+++ b/src/utils/iconSync.js
@@ -1,0 +1,80 @@
+import { fs } from "@zenfs/core";
+import { ICONS, SHORTCUT_OVERLAY } from "../config/icons.js";
+import { existsAsync, getZenFSFileUrl } from "./zenfs-utils.js";
+
+const ICON_DIR = "/C:/WINDOWS/Icons";
+
+/**
+ * Synchronizes icons from their bundled URLs to ZenFS and updates the icon objects
+ * to use Blob URLs from the ZenFS files.
+ * @param {Function} onProgress Optional callback for progress logging
+ */
+export async function syncIconsToZenFS(onProgress) {
+  try {
+    // Ensure icon directory exists
+    if (!(await existsAsync(ICON_DIR))) {
+      await fs.promises.mkdir(ICON_DIR, { recursive: true });
+    }
+
+    const iconItems = [...Object.values(ICONS), SHORTCUT_OVERLAY];
+    let totalIcons = 0;
+    let processedEntries = 0;
+    const blobUrlCache = new Map();
+
+    // Count icons for progress reporting
+    for (const item of iconItems) {
+      if (item.path16) totalIcons++;
+      if (item.path32) totalIcons++;
+    }
+
+    for (const item of iconItems) {
+      // Handle 16px version
+      if (item.path16) {
+        if (onProgress) onProgress(`Syncing icons (${processedEntries}/${totalIcons})...`);
+
+        if (!blobUrlCache.has(item.path16)) {
+          await syncIcon(item[16], item.path16);
+          blobUrlCache.set(item.path16, await getZenFSFileUrl(item.path16));
+        }
+        item[16] = blobUrlCache.get(item.path16);
+        processedEntries++;
+      }
+
+      // Handle 32px version
+      if (item.path32) {
+        if (onProgress) onProgress(`Syncing icons (${processedEntries}/${totalIcons})...`);
+
+        if (!blobUrlCache.has(item.path32)) {
+          await syncIcon(item[32], item.path32);
+          blobUrlCache.set(item.path32, await getZenFSFileUrl(item.path32));
+        }
+        item[32] = blobUrlCache.get(item.path32);
+        processedEntries++;
+      }
+    }
+
+    if (onProgress) onProgress(`Syncing icons completed.`);
+  } catch (error) {
+    console.error("Failed to sync icons to ZenFS:", error);
+  }
+}
+
+/**
+ * Syncs a single icon file from URL to ZenFS if it doesn't exist.
+ * @param {string} url Bundled asset URL
+ * @param {string} path ZenFS destination path
+ */
+async function syncIcon(url, path) {
+  if (await existsAsync(path)) {
+    return;
+  }
+
+  try {
+    const response = await fetch(url);
+    if (!response.ok) throw new Error(`HTTP error! status: ${response.status}`);
+    const buffer = await response.arrayBuffer();
+    await fs.promises.writeFile(path, new Uint8Array(buffer));
+  } catch (error) {
+    console.error(`Failed to sync icon ${url} to ${path}:`, error);
+  }
+}

--- a/src/utils/systemSync.js
+++ b/src/utils/systemSync.js
@@ -1,0 +1,39 @@
+import { fs } from "@zenfs/core";
+import { SYSTEM_SOURCE_FILES } from "../config/system-files.js";
+import { existsAsync } from "./zenfs-utils.js";
+
+export async function syncSystemFiles() {
+    const systemDir = "/C:/WINDOWS/System/src";
+    if (!(await existsAsync(systemDir))) {
+        await fs.promises.mkdir(systemDir, { recursive: true });
+    }
+
+    for (const [path, content] of Object.entries(SYSTEM_SOURCE_FILES)) {
+        // path is like './main.js' or './utils/zenfs-init.js'
+        // We want to save it to /C:/WINDOWS/System/src/...
+        const targetPath = `${systemDir}/${path.replace('./', '')}`;
+
+        // Ensure subdirectories exist
+        const parts = targetPath.split('/');
+        parts.pop(); // Remove filename
+        const dir = parts.join('/');
+        if (!(await existsAsync(dir))) {
+            await fs.promises.mkdir(dir, { recursive: true });
+        }
+
+        try {
+            await fs.promises.writeFile(targetPath, content);
+        } catch (e) {
+            console.warn(`Failed to sync system file ${path}:`, e);
+        }
+    }
+
+    // Try to capture the kernel (the entry point script)
+    try {
+        const response = await fetch(import.meta.url);
+        const code = await response.text();
+        await fs.promises.writeFile("/C:/WINDOWS/System/kernel.js", code);
+    } catch (e) {
+        // This might fail in some environments, that's okay
+    }
+}

--- a/src/utils/zenfs-init.js
+++ b/src/utils/zenfs-init.js
@@ -6,7 +6,8 @@ import startMenuConfig from "../config/startmenu.js";
 import { getStartupApps } from "./startupManager.js";
 import { apps } from "../config/apps.js";
 import { existsAsync } from "./zenfs-utils.js";
-import { syncIconsToZenFS } from "./iconSync.js";
+import { syncIcons } from "./iconSync.js";
+import { syncSystemFiles } from "./systemSync.js";
 
 let isInitialized = false;
 
@@ -130,7 +131,10 @@ export async function initFileSystem(onProgress) {
         }
 
         if (onProgress) onProgress("Synchronizing icons...");
-        await syncIconsToZenFS(onProgress);
+        await syncIcons(onProgress);
+
+        if (onProgress) onProgress("Synchronizing system files...");
+        await syncSystemFiles();
 
         isInitialized = true;
         console.log("ZenFS initialized successfully.");

--- a/src/utils/zenfs-init.js
+++ b/src/utils/zenfs-init.js
@@ -6,6 +6,7 @@ import startMenuConfig from "../config/startmenu.js";
 import { getStartupApps } from "./startupManager.js";
 import { apps } from "../config/apps.js";
 import { existsAsync } from "./zenfs-utils.js";
+import { syncIconsToZenFS } from "./iconSync.js";
 
 let isInitialized = false;
 
@@ -48,6 +49,11 @@ export async function initFileSystem(onProgress) {
         // Ensure WINDOWS directory exists on C: for persistence
         if (!(await existsAsync('/C:/WINDOWS'))) {
             await fs.promises.mkdir('/C:/WINDOWS');
+        }
+
+        // Ensure WINDOWS/Icons directory exists
+        if (!(await existsAsync('/C:/WINDOWS/Icons'))) {
+            await fs.promises.mkdir('/C:/WINDOWS/Icons');
         }
 
         // Ensure Program Files/Doom exists
@@ -122,6 +128,9 @@ export async function initFileSystem(onProgress) {
                 await migrateToZenFS(favoritesConfig.submenu, FAVORITES_PATH);
             }
         }
+
+        if (onProgress) onProgress("Synchronizing icons...");
+        await syncIconsToZenFS(onProgress);
 
         isInitialized = true;
         console.log("ZenFS initialized successfully.");


### PR DESCRIPTION
Moved icon assets to the virtual `C:\WINDOWS\Icons` directory. Implemented a synchronization mechanism during boot that copies bundled icons to ZenFS and replaces in-memory references with local Blob URLs. This enables offline access to icons and makes them browsable in the filesystem.

---
*PR created automatically by Jules for task [4801534132095460987](https://jules.google.com/task/4801534132095460987) started by @azayrahmad*