### PR TITLE
Resolve virtual paths in shortcuts to real ZenFS paths

### DIFF
--- a/src/apps/zenexplorer/ZenExplorerApp.js
+++ b/src/apps/zenexplorer/ZenExplorerApp.js
@@ -484,7 +484,7 @@ export class ZenExplorerApp extends Application {
               const targetName = data.targetPath.split("/").pop();
               const association = getAssociation(targetName);
               if (association.appId) {
-                launchApp(association.appId, data.targetPath);
+                launchApp(association.appId, ShellManager.getRealPath(data.targetPath));
               } else {
                 alert(`Cannot open file: ${targetName} (No association)`);
               }
@@ -499,7 +499,7 @@ export class ZenExplorerApp extends Application {
 
     const association = getAssociation(name);
     if (association.appId) {
-      launchApp(association.appId, fullPath);
+      launchApp(association.appId, ShellManager.getRealPath(fullPath));
     } else {
       alert(`Cannot open file: ${name} (No association)`);
     }

--- a/src/apps/zenexplorer/extensions/ShellManager.js
+++ b/src/apps/zenexplorer/extensions/ShellManager.js
@@ -139,7 +139,7 @@ export class ShellManager {
   static getRealPath(path) {
     const ext = this.getExtensionForPath(path);
     if (ext && ext.getRealPath) {
-      return ext.getRealPath(path);
+      return ext.getRealPath(path) || path;
     }
     return path;
   }

--- a/src/apps/zenexplorer/fileoperations/FileOperations.js
+++ b/src/apps/zenexplorer/fileoperations/FileOperations.js
@@ -54,13 +54,13 @@ export class FileOperations {
                             lnkData.appId = data.appId;
                             lnkData.args = data.args;
                         } else {
-                            lnkData.targetPath = data.targetPath || itemPath;
+                            lnkData.targetPath = ShellManager.getRealPath(data.targetPath || itemPath);
                         }
                     } catch (e) {
-                        lnkData.targetPath = itemPath;
+                        lnkData.targetPath = ShellManager.getRealPath(itemPath);
                     }
                 } else {
-                    lnkData.targetPath = itemPath;
+                    lnkData.targetPath = ShellManager.getRealPath(itemPath);
                 }
 
                 await fs.promises.writeFile(ShellManager.getRealPath(targetLnkPath), JSON.stringify(lnkData, null, 2));

--- a/src/components/desktop.js
+++ b/src/components/desktop.js
@@ -357,7 +357,7 @@ class DesktopController {
               const { getAssociation } = await import("../utils/directory.js");
               const association = getAssociation(targetName);
               if (association.appId) {
-                launchApp(association.appId, data.targetPath);
+                launchApp(association.appId, ShellManager.getRealPath(data.targetPath));
               } else {
                 alert(`Cannot open file: ${targetName} (No association)`);
               }
@@ -377,7 +377,7 @@ class DesktopController {
       const { getAssociation } = await import("../utils/directory.js");
       const association = getAssociation(path.split("/").pop());
       if (association.appId) {
-        launchApp(association.appId, path);
+        launchApp(association.appId, ShellManager.getRealPath(path));
       }
     }
   }

--- a/src/utils/startMenuUtils.js
+++ b/src/utils/startMenuUtils.js
@@ -4,6 +4,7 @@ import { launchApp } from "./appManager.js";
 import { ICONS } from "../config/icons.js";
 import { getAssociation } from "./directory.js";
 import { existsAsync } from "./zenfs-utils.js";
+import { ShellManager } from "../apps/zenexplorer/extensions/ShellManager.js";
 
 export const PINNED_PATH = "/C:/WINDOWS/Start Menu";
 export const START_MENU_PATH = "/C:/WINDOWS/Start Menu/Programs";
@@ -65,7 +66,7 @@ export async function loadLnk(path, iconSize = 16) {
       let action = () => {};
 
       try {
-        const stats = await fs.promises.stat(data.targetPath);
+        const stats = await ShellManager.stat(data.targetPath);
         if (stats.isDirectory()) {
           icon = ICONS.folderClosed[iconSize];
           action = () => launchApp("explorer", data.targetPath);
@@ -73,10 +74,10 @@ export async function loadLnk(path, iconSize = 16) {
           const association = getAssociation(targetName);
           if (association) {
             icon = association.icon[iconSize];
-            action = () => launchApp(association.appId, data.targetPath);
+            action = () => launchApp(association.appId, ShellManager.getRealPath(data.targetPath));
           } else {
             icon = ICONS.file[iconSize];
-            action = () => launchApp("notepad", data.targetPath);
+            action = () => launchApp("notepad", ShellManager.getRealPath(data.targetPath));
           }
         }
       } catch (e) {


### PR DESCRIPTION
This patch fixes a bug where shortcuts created on the Desktop for files already on the Desktop failed to open. The root cause was that these shortcuts stored virtual shell paths (e.g., `/Desktop/Boom.txt`) which applications like Notepad cannot resolve via standard filesystem APIs.

I modified `FileOperations.createShortcuts` to resolve target paths to their real ZenFS locations (e.g., `/C:/WINDOWS/Desktop/Boom.txt`) during creation. I also updated `ZenExplorerApp`, `desktop.js`, and `startMenuUtils` to resolve shortcut targets before launching applications, providing backward compatibility for existing shortcuts. Finally, I improved `ShellManager.getRealPath` to ensure it always returns a valid string path even when an extension partially handles a path.

---
*PR created automatically by Jules for task [5942296185029073727](https://jules.google.com/task/5942296185029073727) started by @azayrahmad*