### PR TITLE
Fix dialog window Enter key interception

### DIFF
--- a/src/apps/zenexplorer/interface/KeyboardHandler.js
+++ b/src/apps/zenexplorer/interface/KeyboardHandler.js
@@ -9,7 +9,13 @@ export class KeyboardHandler {
   }
 
   handleKeyDown(e) {
-    if (e.target.tagName === "INPUT" || e.target.tagName === "TEXTAREA") {
+    const tag = e.target.tagName;
+    if (
+      tag === "INPUT" ||
+      tag === "TEXTAREA" ||
+      tag === "SELECT" ||
+      tag === "BUTTON"
+    ) {
       return;
     }
 

--- a/src/components/desktop.js
+++ b/src/components/desktop.js
@@ -598,7 +598,16 @@ export async function initDesktop(profile = null) {
   });
 
   window.addEventListener("keydown", (e) => {
-    if (e.target.tagName === "INPUT" || e.target.tagName === "TEXTAREA") return;
+    const tag = e.target.tagName;
+    if (
+      tag === "INPUT" ||
+      tag === "TEXTAREA" ||
+      tag === "SELECT" ||
+      tag === "BUTTON" ||
+      e.target.closest(".os-window")
+    ) {
+      return;
+    }
 
     const selectedIcons = [...desktopController.iconManager.selectedIcons];
 


### PR DESCRIPTION
This change fixes a bug where global keyboard shortcuts (like Enter, Delete, and F2) handled by the Desktop and Zen Explorer would intercept key events even when a dialog window was active and focused. 

The fix involves adding checks to the keydown listeners in `src/components/desktop.js` and `src/apps/zenexplorer/interface/KeyboardHandler.js` to ensure they don't call `preventDefault()` or perform actions if the target of the event is an interactive element (like a button) or is within an application window (`.os-window`).

Verified with an E2E test that pressing Enter on a 'Confirm File Delete' dialog correctly closes the dialog and does not open the selected file.

---
*PR created automatically by Jules for task [7233770332293057038](https://jules.google.com/task/7233770332293057038) started by @azayrahmad*