### PR TITLE
Fix desktop icon dragging coordinates

### DIFF
--- a/src/apps/zenexplorer/fileoperations/DragDropManager.js
+++ b/src/apps/zenexplorer/fileoperations/DragDropManager.js
@@ -130,10 +130,16 @@ export class DragDropManager {
         const sourcePaths = draggedItems.map(item => item.path);
         const offsets = draggedItems.map(item => ({ x: offsetX - item.offsetX, y: offsetY - item.offsetY }));
         let dropX = null, dropY = null;
-        if (targetApp && targetApp.iconContainer) {
-            const rect = targetApp.iconContainer.getBoundingClientRect();
-            dropX = e.clientX - rect.left + targetApp.iconContainer.scrollLeft - offsetX;
-            dropY = e.clientY - rect.top + targetApp.iconContainer.scrollTop - offsetY;
+
+        let container = (targetApp && targetApp.iconContainer);
+        if (!container && dropTarget) {
+            container = dropTarget.closest('.explorer-icon-view') || dropTarget.closest('.desktop');
+        }
+
+        if (container) {
+            const rect = container.getBoundingClientRect();
+            dropX = e.clientX - rect.left + (container.scrollLeft || 0) - offsetX;
+            dropY = e.clientY - rect.top + (container.scrollTop || 0) - offsetY;
         }
         const sourceDir = sourcePaths[0].substring(0, sourcePaths[0].lastIndexOf('/')) || '/';
         if (!isCopy && destinationPath === sourceDir) {


### PR DESCRIPTION
Fixed a bug where dragging icons on the desktop would place them at coordinates (0,0) when Auto Arrange was disabled. The issue was caused by DragDropManager failing to identify the desktop as a valid icon container for coordinate calculation. The fix adds a fallback to locate the container via DOM traversal if the target application is not recognized. Verified with Playwright scripts for single and multiple icon dragging on both desktop and explorer windows.

---
*PR created automatically by Jules for task [4725428805144215527](https://jules.google.com/task/4725428805144215527) started by @azayrahmad*