### PR TITLE
Add public/songs to My Documents and create Desktop shortcut

### DIFF
--- a/src/apps/webamp/WebampApp.js
+++ b/src/apps/webamp/WebampApp.js
@@ -75,7 +75,8 @@ export class WebampApp extends Application {
 
             const trackFilenames = playlistText
               .split("\n")
-              .filter((line) => line.trim() !== "" && !line.startsWith("#"));
+              .map((line) => line.trim())
+              .filter((line) => line !== "" && !line.startsWith("#"));
             if (trackFilenames.length === 0) return;
 
             const baseUrl = path.substring(0, path.lastIndexOf("/") + 1);

--- a/src/config/songs.js
+++ b/src/config/songs.js
@@ -1,0 +1,20 @@
+export const songs = [
+  "songs/anosci - Blank VHS Tape Jingle Collection/anosci - Blank VHS Tape Jingle Collection - 01 spun telecom tape.ogg",
+  "songs/anosci - Blank VHS Tape Jingle Collection/anosci - Blank VHS Tape Jingle Collection - 02 golden springs tape.ogg",
+  "songs/anosci - Blank VHS Tape Jingle Collection/anosci - Blank VHS Tape Jingle Collection - 03 gentle envelopment.ogg",
+  "songs/anosci - Blank VHS Tape Jingle Collection/anosci - Blank VHS Tape Jingle Collection - 04 waiting room disco tape (loop).ogg",
+  "songs/anosci - Blank VHS Tape Jingle Collection/anosci - Blank VHS Tape Jingle Collection - 05 checker field tape (stinger).ogg",
+  "songs/anosci - Blank VHS Tape Jingle Collection/anosci - Blank VHS Tape Jingle Collection - 06 gridsquare tape (fade).ogg",
+  "songs/anosci - Blank VHS Tape Jingle Collection/anosci - Blank VHS Tape Jingle Collection - 07 augs and 6ths study (15).ogg",
+  "songs/anosci - Blank VHS Tape Jingle Collection/anosci - Blank VHS Tape Jingle Collection - 08 augs and 6th study (30).ogg",
+  "songs/anosci - Blank VHS Tape Jingle Collection/anosci - Blank VHS Tape Jingle Collection - 09 beach tape (cut).ogg",
+  "songs/anosci - Blank VHS Tape Jingle Collection/anosci - Blank VHS Tape Jingle Collection - 10 synth tape (loop).ogg",
+  "songs/anosci - Blank VHS Tape Jingle Collection/anosci - Blank VHS Tape Jingle Collection - 11 kinda western tape (15).ogg",
+  "songs/anosci - Blank VHS Tape Jingle Collection/anosci - Blank VHS Tape Jingle Collection - 12 kinda western tape (15 + intro).ogg",
+  "songs/anosci - Blank VHS Tape Jingle Collection/anosci - Blank VHS Tape Jingle Collection - 13 three hit tape (loop).ogg",
+  "songs/anosci - Blank VHS Tape Jingle Collection/anosci - Blank VHS Tape Jingle Collection - 14 2 bright tape (15).ogg",
+  "songs/anosci - Blank VHS Tape Jingle Collection/anosci - Blank VHS Tape Jingle Collection - 15 2 bright tape (30).ogg",
+  "songs/anosci - Blank VHS Tape Jingle Collection/anosci - Blank VHS Tape Jingle Collection - 16 water basin tape (loop).ogg",
+  "songs/anosci - Blank VHS Tape Jingle Collection/anosci - Blank VHS Tape Jingle Collection.m3u",
+  "songs/anosci - Blank VHS Tape Jingle Collection/cover.png"
+];

--- a/src/main.js
+++ b/src/main.js
@@ -37,6 +37,7 @@ import { fs, mounts } from "@zenfs/core";
 import { initFileSystem } from "./utils/zenfs-init.js";
 import { RecycleBinManager } from "./apps/zenexplorer/fileoperations/RecycleBinManager.js";
 import { appManager } from "./utils/appManager.js";
+import { songs } from "./config/songs.js";
 
 // Window Management System
 class WindowManagerSystem {
@@ -347,6 +348,50 @@ async function initializeOS() {
         }
         if (logElement && logElement.firstChild) {
           logElement.firstChild.nodeValue = "Loading Doom game data...";
+        }
+        finalizeBootProcessStep(logElement, "OK");
+      }
+    });
+
+    await executeBootStep(async () => {
+      const baseLocalPath = "/C:/My Documents/";
+
+      let needed = false;
+      for (const songFile of songs) {
+        if (!fs.existsSync(baseLocalPath + songFile)) {
+          needed = true;
+          break;
+        }
+      }
+
+      if (needed) {
+        let logElement = startBootProcessStep("Loading songs...");
+        for (const songFile of songs) {
+          const localPath = baseLocalPath + songFile;
+          if (!fs.existsSync(localPath)) {
+            const fileName = songFile.split("/").pop();
+            if (logElement && logElement.firstChild) {
+              logElement.firstChild.nodeValue = `Loading songs: ${fileName}...`;
+            }
+
+            // Ensure directory exists
+            const dir = localPath.substring(0, localPath.lastIndexOf("/"));
+            if (!fs.existsSync(dir)) {
+                await fs.promises.mkdir(dir, { recursive: true });
+            }
+
+            try {
+                const response = await fetch(songFile);
+                if (!response.ok) throw new Error(`HTTP error! status: ${response.status}`);
+                const buffer = await response.arrayBuffer();
+                await fs.promises.writeFile(localPath, new Uint8Array(buffer));
+            } catch (error) {
+                console.error(`Failed to load song: ${songFile}`, error);
+            }
+          }
+        }
+        if (logElement && logElement.firstChild) {
+          logElement.firstChild.nodeValue = "Loading songs...";
         }
         finalizeBootProcessStep(logElement, "OK");
       }

--- a/src/utils/zenfs-init.js
+++ b/src/utils/zenfs-init.js
@@ -67,15 +67,19 @@ export async function initFileSystem(onProgress) {
             { name: "buggyprogram.lnk.json", appId: "buggyprogram" },
             { name: "sheep.lnk.json", appId: "esheep" },
             { name: "Winamp.lnk.json", appId: "webamp" },
+            { name: "songs.lnk.json", targetPath: "/C:/My Documents/songs" },
         ];
 
         for (const shortcut of defaultShortcuts) {
             const lnkPath = `/C:/WINDOWS/Desktop/${shortcut.name}`;
             if (!(await existsAsync(lnkPath))) {
-                await fs.promises.writeFile(lnkPath, JSON.stringify({
+                const lnkContent = {
                     type: "shortcut",
-                    appId: shortcut.appId,
-                }, null, 2));
+                };
+                if (shortcut.appId) lnkContent.appId = shortcut.appId;
+                if (shortcut.targetPath) lnkContent.targetPath = shortcut.targetPath;
+
+                await fs.promises.writeFile(lnkPath, JSON.stringify(lnkContent, null, 2));
             }
         }
 
@@ -112,6 +116,11 @@ export async function initFileSystem(onProgress) {
         // Ensure My Documents directory exists
         if (!(await existsAsync('/C:/My Documents'))) {
             await fs.promises.mkdir('/C:/My Documents');
+        }
+
+        // Ensure My Documents/songs directory exists
+        if (!(await existsAsync('/C:/My Documents/songs'))) {
+            await fs.promises.mkdir('/C:/My Documents/songs');
         }
 
         if (onProgress) onProgress("Initializing Start Menu...");


### PR DESCRIPTION
This change adds the contents of the `public/songs` directory to `C:\My Documents\songs` and creates a "songs" shortcut on the Desktop.

Key changes:
1.  **Configuration**: Added `src/config/songs.js` containing the manifest of song files to be synchronized.
2.  **Filesystem Initialization**: Updated `src/utils/zenfs-init.js` to:
    -   Create the `/C:/My Documents/songs` directory.
    -   Add a `songs.lnk.json` shortcut to the Desktop pointing to the new directory.
3.  **Boot Synchronization**: Enhanced `src/main.js` with a new boot step ("Loading songs...") that fetches each song from the server and writes it to the virtual filesystem if it is missing. This ensures the files are always available every boot.

The changes were verified visually via Playwright screenshots, confirming both the Desktop shortcut and the folder contents in Explorer.

---
*PR created automatically by Jules for task [9565416692402781181](https://jules.google.com/task/9565416692402781181) started by @azayrahmad*