### PR TITLE
Migrate boot screen to xterm.js

### DIFF
--- a/index.html
+++ b/index.html
@@ -158,39 +158,6 @@
                 overflow: hidden;
                 z-index: 9999;
             }
-            #boot-screen-left {
-                flex-grow: 1;
-                margin-right: 20px; /* Some spacing between columns */
-            }
-            #boot-screen-right {
-                width: 130px; /* Approximate width of the Energy Star logo */
-                flex-shrink: 0;
-                display: flex;
-                align-items: flex-end;
-                justify-content: flex-end;
-            }
-            #boot-screen-right img {
-                width: 130px; /* Specific width for the Energy Star logo */
-                height: 130px; /* Specific height for the Energy Star logo */
-            }
-            #bios-info-row {
-                display: flex;
-                align-items: flex-start;
-                margin-bottom: 20px;
-                flex-direction: row;
-            }
-            .bios-text-content {
-                display: flex;
-                flex-direction: column;
-                white-space: pre-wrap;
-                line-height: 1.2;
-            }
-            #bios-text-column {
-                /* Adjusting this from .bios-text-content for more specificity if needed */
-                flex-grow: 1;
-                white-space: pre-wrap;
-                line-height: 1.2;
-            }
             #initial-boot-message {
                 position: absolute;
                 color: inherit;
@@ -201,31 +168,15 @@
                 display: none;
                 height: 100%;
                 width: 100%;
-            }
-            #boot-screen-main-flex-container {
-                display: flex;
-                height: 100%;
-                width: 100%;
-                justify-content: space-between;
-            }
-            #boot-screen-left-column {
-                flex-grow: 1;
-                display: flex;
-                flex-direction: column;
-                height: 100%;
-                overflow: hidden;
+                align-items: center;
+                justify-content: center;
             }
             #boot-terminal {
-                width: 100%;
-                height: 100%;
+                width: 640px;
+                height: 400px;
             }
             #boot-terminal .xterm-viewport {
                 overflow-y: hidden !important;
-            }
-            #bios-logo-column {
-                width: 20px;
-                flex-shrink: 0;
-                margin-right: 10px;
             }
             .blinking-cursor {
                 animation: blink 1s step-end infinite;
@@ -249,37 +200,7 @@
                     <div class="loading-banner"></div>
                 </div>
                 <div id="boot-screen-content">
-                    <div id="boot-screen-main-flex-container">
-                        <!-- Left Column for boot text -->
-                        <div id="boot-screen-left-column">
-                            <!-- Award BIOS info row -->
-                            <div id="bios-info-row">
-                                <div id="bios-logo-column">
-                                    <img
-                                        src="/img/award.png"
-                                        alt="Award BIOS Logo"
-                                    />
-                                </div>
-                                <div id="bios-text-column">
-                                    Award Modular BIOS v4.51PG, An Energy Star
-                                    Ally<br />
-                                    Copyright (C) 1984-85, Award Software, Inc.
-                                </div>
-                            </div>
-                            <!-- Browser Info (will be updated by main.js) -->
-                            <!--<div id="browser-info" style="margin-top: 10px"></div>-->
-                            <!-- Boot Log (will be updated by main.js) -->
-                            <div id="boot-terminal" style="flex-grow: 1; margin-top: 10px;"></div>
-                            <div id="boot-screen-footer" style="font-family: 'IBM BIOS', monospace;">
-                                Press F8 for Startup Menu.
-                            </div>
-                        </div>
-
-                        <!-- Right Column for Energy Star logo -->
-                        <div id="boot-screen-right-column" style="margin-left: 20px;">
-                            <img src="/img/energystar.png" alt="Energy Star" />
-                        </div>
-                    </div>
+                    <div id="boot-terminal"></div>
                 </div>
             </div>
             <svg style="position: absolute; pointer-events: none; bottom: 100%">

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "win98-web",
       "version": "0.4.0",
       "dependencies": {
+        "@xterm/addon-image": "^0.9.0",
         "@xterm/xterm": "^5.5.0",
         "@zenfs/archives": "^1.3.1",
         "@zenfs/core": "^2.4.4",
@@ -2602,6 +2603,12 @@
       "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
       "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@xterm/addon-image": {
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/@xterm/addon-image/-/addon-image-0.9.0.tgz",
+      "integrity": "sha512-oYWA8/QAr5/Emwl1xL7WCoOqeG3IZfpzEz/OVq1j4Oi9934TQmHiyubClikRf0D/jL3JNiNuz/Lsqx0kXQ02BA==",
       "license": "MIT"
     },
     "node_modules/@xterm/xterm": {

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "vite-plugin-pwa": "^1.1.0"
   },
   "dependencies": {
+    "@xterm/addon-image": "^0.9.0",
     "@xterm/xterm": "^5.5.0",
     "@zenfs/archives": "^1.3.1",
     "@zenfs/core": "^2.4.4",

--- a/src/system/boot-screen.js
+++ b/src/system/boot-screen.js
@@ -1,9 +1,83 @@
 import { Terminal } from "@xterm/xterm";
+import { ImageAddon } from "@xterm/addon-image";
 import "@xterm/xterm/css/xterm.css";
 import { runSetupTUI } from "./setup-utility.js";
 
 let terminal = null;
 let setupMode = false;
+let awardLogo = null;
+let energyStarLogo = null;
+
+async function getBase64Image(url) {
+    const response = await fetch(url);
+    const blob = await response.blob();
+    const size = blob.size;
+    return new Promise((resolve, reject) => {
+        const reader = new FileReader();
+        reader.onloadend = () => resolve({
+            base64: reader.result.split(",")[1],
+            size: size
+        });
+        reader.onerror = reject;
+        reader.readAsDataURL(blob);
+    });
+}
+
+async function preloadLogos() {
+    if (awardLogo && energyStarLogo) return;
+    const BASE_URL = import.meta.env.BASE_URL || "/";
+    const awardUrl = `${BASE_URL}img/award.png`.replace(/\/+/g, "/");
+    const energyStarUrl = `${BASE_URL}img/energystar.png`.replace(/\/+/g, "/");
+    try {
+        [awardLogo, energyStarLogo] = await Promise.all([
+            getBase64Image(awardUrl),
+            getBase64Image(energyStarUrl),
+        ]);
+    } catch (e) {
+        console.error("Failed to preload boot logos", e);
+    }
+}
+
+function drawBIOSHeader() {
+    if (!terminal) return;
+
+    // Award Logo at (1,1)
+    if (awardLogo) {
+        terminal.write(`\x1b[1;1H\x1b]1337;File=inline=1;size=${awardLogo.size}:${awardLogo.base64}\x07`);
+    }
+
+    // BIOS Text next to Award Logo
+    terminal.write("\x1b[1;5HAward Modular BIOS v4.51PG, An Energy Star Ally");
+    terminal.write("\x1b[2;5HCopyright (C) 1984-85, Award Software, Inc.");
+
+    // Energy Star Logo at top right
+    // Terminal is 80 cols. Energy Star is 135px wide.
+    // Assuming ~8px per cell, it's ~17 columns. 80 - 17 = 63.
+    if (energyStarLogo) {
+        terminal.write(`\x1b[1;63H\x1b]1337;File=inline=1;size=${energyStarLogo.size}:${energyStarLogo.base64}\x07`);
+    }
+}
+
+function drawBIOSFooter() {
+    if (!terminal) return;
+    // Standard boot footer
+    terminal.write("\x1b[25;1H\x1b[0mPress F8 for Startup Menu.");
+}
+
+export async function prepareBootScreen() {
+    const term = initTerminal();
+    if (!term) return;
+
+    await preloadLogos();
+    term.write("\x1b[2J\x1b[H"); // Clear screen and home
+    drawBIOSHeader();
+    drawBIOSFooter();
+
+    // Set scrolling region for the log: Rows 7 to 24
+    term.write("\x1b[7;24r");
+    // Move cursor to the start of the log area
+    term.write("\x1b[7;1H");
+}
 
 function initTerminal() {
     if (terminal) return terminal;
@@ -24,6 +98,9 @@ function initTerminal() {
         cols: 80,
         allowTransparency: true,
     });
+
+    const imageAddon = new ImageAddon();
+    terminal.loadAddon(imageAddon);
 
     terminal.open(container);
 
@@ -77,11 +154,16 @@ function startBootProcessStep(message) {
     const term = initTerminal();
     if (term) {
         term.write("\x1b[?25h"); // Show cursor
+
+        // If we haven't set the scrolling region yet, we should probably do it.
+        // But prepareBootScreen should have been called.
+
         term.write(message);
         return {
             get firstChild() {
                 return {
                     set nodeValue(val) {
+                        // Use \r to return to start of line, then \x1b[2K to clear line
                         term.write('\r\x1b[2K' + val);
                     }
                 };
@@ -162,18 +244,15 @@ function promptToContinue() {
 function showSetupScreen() {
     setupMode = true;
     const term = initTerminal();
-    const biosInfoRow = document.getElementById("bios-info-row");
-    const rightColumn = document.getElementById("boot-screen-right-column");
-    const footer = document.getElementById("boot-screen-footer");
-
-    if (biosInfoRow) biosInfoRow.style.display = "none";
-    if (rightColumn) rightColumn.style.display = "none";
-    if (footer) footer.style.display = "none";
 
     if (term) {
+        // Reset scrolling region to full screen before entering setup
+        term.write("\x1b[r");
         term.write("\x1b[2J\x1b[H"); // Clear screen and home cursor
         runSetupTUI(term, () => {
             setupMode = false;
+            // Optionally restore boot screen if we were to return,
+            // but setup usually ends in reboot.
         });
     }
 }

--- a/src/system/os-init.js
+++ b/src/system/os-init.js
@@ -13,6 +13,7 @@ import {
   finalizeBootProcessStep,
   promptToContinue,
   showSetupScreen,
+  prepareBootScreen,
 } from './boot-screen.js';
 import { preloadThemeAssets } from './asset-preloader.js';
 import { launchApp } from './app-manager.js';
@@ -107,22 +108,14 @@ export async function initializeOS() {
       }
     }
 
-    await executeBootStep(() => {
+    await executeBootStep(async () => {
       playSound("Default"); // POST Beep
       document.body.classList.add("booting");
       document.getElementById("screen").classList.add("boot-mode");
       document.getElementById("initial-boot-message").style.display = "none";
       document.getElementById("boot-screen-content").style.display = "flex";
 
-      const biosTextColumn = document.getElementById("bios-text-column");
-      if (biosTextColumn) {
-        biosTextColumn.innerHTML = `Award Modular BIOS v4.51PG, An Energy Star Ally<br/>Copyright (C) 1984-85, Award Software, Inc.`;
-      }
-
-      const browserInfoEl = document.getElementById("browser-info");
-      if (browserInfoEl) {
-        // browserInfoEl.textContent = `Client: ${navigator.userAgent}`;
-      }
+      await prepareBootScreen();
     });
 
     function loadCustomApps() {

--- a/src/system/setup-utility.js
+++ b/src/system/setup-utility.js
@@ -18,7 +18,7 @@ export async function runSetupTUI(term, onExit) {
         term.write(`Enter a choice: ${selectedOption}`);
 
         // Footer at the bottom of 80x25 terminal
-        term.write("\x1b[25;1HF5=Safe mode   Shift+F5=Command prompt   Shift+F8=Step-by-step confirmation [N]");
+        term.write("\x1b[25;1H\x1b[0mF5=Safe mode   Shift+F5=Command prompt   Shift+F8=Step-by-step confirmation [N]");
     };
 
     const drawTimer = () => {


### PR DESCRIPTION
This change migrates the entire boot screen experience into xterm.js. It uses the @xterm/addon-image package to render the Award and Energy Star logos directly in the terminal using iTerm's inline image protocol. The BIOS text and footer are also moved into the terminal, and scrolling regions are used to ensure the boot log doesn't overwrite the static header and footer. Redundant HTML and CSS for the boot screen have been removed.

---
*PR created automatically by Jules for task [3484022207531795298](https://jules.google.com/task/3484022207531795298) started by @azayrahmad*