### PR TITLE
Increase PWA precache size limit to 15MB

### DIFF
--- a/vite.config.js
+++ b/vite.config.js
@@ -49,7 +49,7 @@ export default defineConfig({
         ],
       },
       workbox: {
-        maximumFileSizeToCacheInBytes: 5 * 1024 * 1024, // 5MB
+        maximumFileSizeToCacheInBytes: 15 * 1024 * 1024, // 15MB
       },
     }),
   ],


### PR DESCRIPTION
Increased the `maximumFileSizeToCacheInBytes` in `vite.config.js` from 5MB to 15MB. This allows larger files (specifically the ~11MB DOSBox WASM binary) to be included in the Service Worker's precache manifest, enabling full offline support for the system's DOS emulation features as requested. Verified the fix by running a production build and confirming no size-related warnings/errors were reported.

---
*PR created automatically by Jules for task [12712729295202492334](https://jules.google.com/task/12712729295202492334) started by @azayrahmad*