### PR TITLE
Add BSOD-style 404 page

### DIFF
--- a/404.html
+++ b/404.html
@@ -1,0 +1,108 @@
+<!doctype html>
+<html lang="en">
+    <head>
+        <meta charset="UTF-8" />
+        <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+        <title>Windows 98 - Not Found</title>
+        <style>
+            @font-face {
+                font-family: "IBM BIOS";
+                src: url("./src/assets/fonts/Web437_IBM_VGA_8x14.woff") format("woff");
+            }
+            body {
+                background-color: #0000aa;
+                margin: 0;
+                padding: 0;
+                overflow: hidden;
+                display: flex;
+                align-items: center;
+                justify-content: center;
+                height: 100vh;
+                color: #ffffff;
+                font-family: "IBM BIOS", Courier, monospace;
+            }
+            #terminal {
+                width: 100%;
+                height: 100%;
+            }
+            /* Hide xterm scrollbar */
+            .xterm-viewport {
+                overflow: hidden !important;
+            }
+        </style>
+    </head>
+    <body>
+        <div id="terminal"></div>
+        <script type="module">
+            import { Terminal } from "@xterm/xterm";
+            import "@xterm/xterm/css/xterm.css";
+
+            const term = new Terminal({
+                cursorStyle: "underline",
+                cursorBlink: true,
+                theme: {
+                    background: "#0000aa",
+                    foreground: "#ffffff",
+                },
+                fontFamily: '"IBM BIOS", Courier, monospace',
+                fontSize: 18,
+                rows: 25,
+                cols: 80,
+                allowTransparency: false,
+            });
+
+            const container = document.getElementById("terminal");
+            term.open(container);
+
+            // Initial clear
+            term.write("\x1b[2J\x1b[H");
+
+            const lines = [
+                "",
+                "",
+                "",
+                "      A problem has been detected and Windows has been shut down to prevent",
+                "      damage to your computer.",
+                "",
+                "      The error was: NOT_FOUND (404)",
+                "",
+                "      If this is the first time you've seen this stop error screen,",
+                "      restart your computer. If this screen appears again, follow",
+                "      these steps:",
+                "",
+                "      Check to make sure any new hardware or software is properly installed.",
+                "      If this is a new installation, ask your hardware or software manufacturer",
+                "      for any Windows updates you might need.",
+                "",
+                "      Technical information:",
+                "",
+                "      *** STOP: 0x00000404 (0x00000000, 0x00000000, 0x00000000, 0x00000000)",
+                "",
+                "",
+                "      Press any key to return to the main page."
+            ];
+
+            term.write(lines.join("\r\n"));
+
+            const goToMain = () => {
+                const baseUrl = import.meta.env.BASE_URL || "/win98-web/";
+                window.location.href = baseUrl;
+            };
+
+            term.onKey(goToMain);
+            window.addEventListener("keydown", (e) => {
+                // Prevent F12 etc from redirecting if possible, but user said "any key"
+                goToMain();
+            });
+            window.addEventListener("click", goToMain);
+
+            term.focus();
+
+            // Handle resize
+            window.addEventListener("resize", () => {
+                // term.fit() would be better but we don't have the addon loaded here
+                // for simplicity we just keep it as is
+            });
+        </script>
+    </body>
+</html>

--- a/404.html
+++ b/404.html
@@ -24,10 +24,17 @@
             #terminal {
                 width: 100%;
                 height: 100%;
+                display: flex;
+                align-items: center;
+                justify-content: center;
+                background-color: #0000aa;
             }
-            /* Hide xterm scrollbar */
             .xterm-viewport {
                 overflow: hidden !important;
+            }
+            /* Ensure the xterm terminal itself has the correct background */
+            .xterm-screen {
+                background-color: #0000aa !important;
             }
         </style>
     </head>
@@ -43,46 +50,46 @@
                 theme: {
                     background: "#0000aa",
                     foreground: "#ffffff",
+                    blue: "#0000aa", // Map ANSI blue to our BSOD blue
                 },
                 fontFamily: '"IBM BIOS", Courier, monospace',
                 fontSize: 18,
                 rows: 25,
                 cols: 80,
-                allowTransparency: false,
+                allowTransparency: true,
             });
 
             const container = document.getElementById("terminal");
             term.open(container);
 
             // Initial clear
-            term.write("\x1b[2J\x1b[H");
+            term.write("\x1b[H\x1b[2J");
+
+            // Draw centered "Windows" header in white block
+            // Use ANSI 47 for white background, 34 for blue text
+            const headerPadding = " ".repeat(35);
+            term.write("\x1b[1;1H" + headerPadding + "\x1b[47m\x1b[34m Windows \x1b[0m\r\n\r\n");
 
             const lines = [
                 "",
+                "      A fatal exception 0E has occurred at 0028:C001F32F in VXD VMM(01) +",
+                "      0001F32F. The current application will be terminated.",
+                "",
+                "      *  Press any key to restart your computer.",
+                "      *  Press CTRL+ALT+DEL again to restart your computer. You will lose",
+                "         any unsaved information in all applications.",
                 "",
                 "",
-                "      A problem has been detected and Windows has been shut down to prevent",
-                "      damage to your computer.",
-                "",
-                "      The error was: NOT_FOUND (404)",
-                "",
-                "      If this is the first time you've seen this stop error screen,",
-                "      restart your computer. If this screen appears again, follow",
-                "      these steps:",
-                "",
-                "      Check to make sure any new hardware or software is properly installed.",
-                "      If this is a new installation, ask your hardware or software manufacturer",
-                "      for any Windows updates you might need.",
-                "",
-                "      Technical information:",
-                "",
-                "      *** STOP: 0x00000404 (0x00000000, 0x00000000, 0x00000000, 0x00000000)",
                 "",
                 "",
-                "      Press any key to return to the main page."
+                "",
+                "",
+                "",
+                "",
+                "                           Press any key to continue "
             ];
 
-            term.write(lines.join("\r\n"));
+            term.write("\x1b[37m" + lines.join("\r\n"));
 
             const goToMain = () => {
                 const baseUrl = import.meta.env.BASE_URL || "/win98-web/";
@@ -90,19 +97,11 @@
             };
 
             term.onKey(goToMain);
-            window.addEventListener("keydown", (e) => {
-                // Prevent F12 etc from redirecting if possible, but user said "any key"
-                goToMain();
-            });
+            window.addEventListener("keydown", goToMain);
             window.addEventListener("click", goToMain);
+            window.addEventListener("touchstart", goToMain);
 
             term.focus();
-
-            // Handle resize
-            window.addEventListener("resize", () => {
-                // term.fit() would be better but we don't have the addon loaded here
-                // for simplicity we just keep it as is
-            });
         </script>
     </body>
 </html>

--- a/src/system/os-init.js
+++ b/src/system/os-init.js
@@ -41,10 +41,17 @@ export async function initializeOS() {
     : '';
 
   window.activeProfile = null;
-  if (profileName && profiles[profileName]) {
-    window.activeProfile = profiles[profileName];
-    await setTheme(window.activeProfile.theme);
-    await setColorScheme(window.activeProfile.colorScheme);
+  const ignoredProfiles = ["", "index.html", "404.html"];
+  if (profileName && !ignoredProfiles.includes(profileName)) {
+    if (profiles[profileName]) {
+      window.activeProfile = profiles[profileName];
+      await setTheme(window.activeProfile.theme);
+      await setColorScheme(window.activeProfile.colorScheme);
+    } else {
+      window.location.href =
+        (import.meta.env.BASE_URL || "/win98-web/") + "404.html";
+      return;
+    }
   }
 
   let setupEntered = false;

--- a/vite.config.js
+++ b/vite.config.js
@@ -20,6 +20,14 @@ export default defineConfig({
       host: "localhost",
     },
   },
+  build: {
+    rollupOptions: {
+      input: {
+        main: resolve(__dirname, "index.html"),
+        404: resolve(__dirname, "404.html"),
+      },
+    },
+  },
   plugins: [
     VitePWA({
       registerType: "autoUpdate",


### PR DESCRIPTION
I have implemented a nostalgic BSOD-style 404 page for the project. 

Key changes:
1.  **New 404 Page**: Created `404.html` in the root directory. It uses `xterm.js` to render a pixel-perfect Windows 98 Blue Screen of Death. It features the "IBM BIOS" font and includes a "Press any key" listener that redirects back to the main page.
2.  **Vite Build Configuration**: Updated `vite.config.js` to include `404.html` in the Rollup inputs. This ensures the page is correctly bundled and assets like the font and `xterm.js` are processed.
3.  **Routing Logic**: Updated `src/system/os-init.js` to handle invalid profile paths. Any path under `/win98-web/` that is not a defined profile (currently only `resume`) and not a standard file will now trigger a redirect to `404.html`.

I verified the implementation by running a production build and using a Playwright script to confirm the redirection and visual appearance.

---
*PR created automatically by Jules for task [9586342760571889555](https://jules.google.com/task/9586342760571889555) started by @azayrahmad*