### PR TITLE
Fix Start Menu submenus closing prematurely on touch devices

### DIFF
--- a/public/os-gui/MenuPopup.js
+++ b/public/os-gui/MenuPopup.js
@@ -16,7 +16,7 @@
     this.itemElements = [];
 
     const menu_popup_el = E("menu", {
-      class: "menu-popup",
+      class: `menu-popup ${options.className || ""}`,
       id: `menu-popup-${uid()}`,
       tabIndex: "-1",
       role: "menu",
@@ -201,7 +201,7 @@
             "point-right",
             get_direction() === "rtl",
           );
-          submenu_popup_el = E("div", { class: "menu-popup-wrapper" });
+          submenu_popup_el = E("div", { class: `menu-popup-wrapper ${options.className || ""}` });
           const submenu_popup = new MenuPopup(item.submenu, {
             ...options,
             parentMenuPopup: this,

--- a/src/shell/start-menu/start-menu.js
+++ b/src/shell/start-menu/start-menu.js
@@ -171,12 +171,16 @@ class StartMenu {
       }
 
       const menuWrapper = document.createElement("div");
-      menuWrapper.className = "menu-popup-wrapper";
+      menuWrapper.className = "menu-popup-wrapper start-menu-popup";
 
       activeMenu = new window.MenuPopup(submenuItems, {
+        className: "start-menu-popup",
         parentMenuPopup: null,
         handleKeyDown: (e) => e.key === "Escape" && closeAndCleanup(),
-        closeMenus: closeAndCleanup,
+        closeMenus: () => {
+          closeAndCleanup();
+          this.hide();
+        },
         setActiveMenuPopup: (menu) => {
           activeMenu = menu;
         },
@@ -268,12 +272,16 @@ class StartMenu {
       }
 
       const menuWrapper = document.createElement("div");
-      menuWrapper.className = "menu-popup-wrapper";
+      menuWrapper.className = "menu-popup-wrapper start-menu-popup";
 
       activeMenu = new window.MenuPopup(submenuItems, {
+        className: "start-menu-popup",
         parentMenuPopup: null,
         handleKeyDown: (e) => e.key === "Escape" && closeAndCleanup(),
-        closeMenus: closeAndCleanup,
+        closeMenus: () => {
+          closeAndCleanup();
+          this.hide();
+        },
         setActiveMenuPopup: (menu) => {
           activeMenu = menu;
         },
@@ -595,7 +603,8 @@ class StartMenu {
     if (
       this.isVisible &&
       !startMenu.contains(event.target) &&
-      !startButton.contains(event.target)
+      !startButton.contains(event.target) &&
+      !event.target.closest(".start-menu-popup")
     ) {
       this.hide();
     }


### PR DESCRIPTION
This change addresses a bug where tapping on Start Menu subitems (like "Accessories") on touch devices would cause the entire Start Menu to close. 

Key changes:
- `public/os-gui/MenuPopup.js`: Added support for `options.className` to tag menu elements and their wrappers.
- `src/shell/start-menu/start-menu.js`: 
    - Passed `start-menu-popup` class to all submenus.
    - Updated `handleOutsideClick` to exclude elements with the `start-menu-popup` class from closing the menu.
    - Updated `closeMenus` callback to call `this.hide()`, ensuring the main menu closes when an application is launched from a submenu.

Verified with a Playwright script simulating touch/click interactions.

---
*PR created automatically by Jules for task [9955268564670530366](https://jules.google.com/task/9955268564670530366) started by @azayrahmad*