### PR TITLE
Improve Start Menu with Category-based Configuration

### DIFF
--- a/src/apps/buy-me-a-coffee/buy-me-acoffee-app.js
+++ b/src/apps/buy-me-a-coffee/buy-me-acoffee-app.js
@@ -6,7 +6,7 @@ export class BuyMeACoffeeApp extends IFrameApplication {
     id: "buy-me-a-coffee",
     title: "Buy me a coffee",
     description: "Support the developer.",
-    icon: ICONS["buy-me-a-coffee"],
+    icon: ICONS["buy-me-a-coffee"], category: "",
     width: 300,
     height: 650,
     resizable: false,

--- a/src/apps/calculator/calculator-app.js
+++ b/src/apps/calculator/calculator-app.js
@@ -13,7 +13,7 @@ export class CalculatorApp extends Application {
     id: "calculator",
     title: "Calculator",
     description: "Perform calculations.",
-    icon: ICONS.calculator,
+    icon: ICONS.calculator, category: "Accessories",
     width: 260,
     height: 280,
     resizable: false,

--- a/src/apps/clippy/clippy-app.js
+++ b/src/apps/clippy/clippy-app.js
@@ -8,7 +8,7 @@ export class ClippyApp extends Application {
         id: "clippy",
         title: "Assistant",
         description: "Your friendly assistant.",
-        icon: ICONS.clippy,
+        icon: ICONS.clippy, category: "Accessories",
         hasTray: true,
         isSingleton: true,
         tray: {

--- a/src/apps/command-prompt/command-prompt-app.js
+++ b/src/apps/command-prompt/command-prompt-app.js
@@ -10,7 +10,7 @@ export class CommandPromptApp extends Application {
     id: "command-prompt",
     title: "MS-DOS Prompt",
     description: "Starts a new MS-DOS prompt.",
-    icon: ICONS.msdos,
+    icon: ICONS.msdos, category: "",
     width: 640,
     height: 480,
     resizable: true,

--- a/src/apps/defrag/defrag-app.js
+++ b/src/apps/defrag/defrag-app.js
@@ -9,7 +9,7 @@ export class DefragApp extends Application {
     id: "defrag",
     title: "Disk Defragmenter",
     description: "Defragments your disk for optimal performance.",
-    icon: ICONS.defrag,
+    icon: ICONS.defrag, category: "Accessories/System Tools",
     width: 400,
     height: 300,
     resizable: true,

--- a/src/apps/diablo/diablo-app.js
+++ b/src/apps/diablo/diablo-app.js
@@ -7,7 +7,7 @@ export class DiabloApp extends Application {
         id: "diablo",
         title: "Diablo",
         description: "Play the classic game Diablo.",
-        icon: ICONS.diablo,
+        icon: ICONS.diablo, category: "",
         width: 800,
         height: 600,
         resizable: true,

--- a/src/apps/doom/doom-app.js
+++ b/src/apps/doom/doom-app.js
@@ -24,7 +24,7 @@ export class DoomApp extends Application {
     id: "doom",
     title: "Doom",
     description: "Play the classic game Doom.",
-    icon: ICONS.doom,
+    icon: ICONS.doom, category: "",
     width: 640,
     height: 400,
     resizable: true,

--- a/src/apps/dos-box/dos-box-app.js
+++ b/src/apps/dos-box/dos-box-app.js
@@ -10,6 +10,7 @@ export class DosBoxApp extends Application {
       title: "DOSBox",
       description: "DOSBox-X Emulator",
       icon: ICONS.msdos,
+      category: "",
       width: 640,
       height: 480,
       resizable: true,
@@ -21,6 +22,7 @@ export class DosBoxApp extends Application {
       title: "Wolfenstein 3D",
       description: "Play Wolfenstein 3D",
       icon: ICONS.msdos,
+      category: "Accessories/Games",
       width: 640,
       height: 480,
     }

--- a/src/apps/dx-ball/dx-ball-app.js
+++ b/src/apps/dx-ball/dx-ball-app.js
@@ -7,7 +7,7 @@ export class DXBallApp extends Application {
     id: "dx-ball",
     title: "DX-Ball",
     description: "The classic Breakout game.",
-    icon: ICONS.dxball,
+    icon: ICONS.dxball, category: ["Accessories/Games", ""],
     width: 654, // Adjusted for typical window borders to avoid scrollbars at 640x480
     height: 520,
     resizable: true,

--- a/src/apps/esheep/esheep-app.js
+++ b/src/apps/esheep/esheep-app.js
@@ -7,7 +7,7 @@ export class ESheepApp extends Application {
         id: "esheep",
         title: "eSheep",
         description: "A classic desktop pet.",
-        icon: ICONS.esheep,
+        icon: ICONS.esheep, category: "",
         hasTray: true,
         isSingleton: true,
         tray: {

--- a/src/apps/flash-player/flash-player-app.js
+++ b/src/apps/flash-player/flash-player-app.js
@@ -8,7 +8,7 @@ export class FlashPlayerApp extends Application {
   static config = {
     id: "flash-player",
     title: "Flash Player",
-    icon: ICONS.flashPlayer,
+    icon: ICONS.flashPlayer, category: "Accessories/Entertainment",
     width: 550,
     height: 400,
     resizable: true,

--- a/src/apps/freecell/free-cell-app.js
+++ b/src/apps/freecell/free-cell-app.js
@@ -18,7 +18,7 @@ export class FreeCellApp extends Application {
     width: 632,
     height: 446,
     resizable: false,
-    icon: ICONS.freecell,
+    icon: ICONS.freecell, category: "Accessories/Games",
   };
 
   async _createWindow() {

--- a/src/apps/image-viewer/image-viewer-app.js
+++ b/src/apps/image-viewer/image-viewer-app.js
@@ -11,7 +11,7 @@ export class ImageViewerApp extends Application {
     id: "image-viewer",
     title: "Image Viewer",
     description: "View images.",
-    icon: ICONS.imageViewer,
+    icon: ICONS.imageViewer, category: "Accessories",
     width: 400,
     height: 300,
     resizable: true,

--- a/src/apps/keen/keen-app.js
+++ b/src/apps/keen/keen-app.js
@@ -6,7 +6,7 @@ export class KeenApp extends IFrameApplication {
     id: "keen",
     title: "Commander Keen",
     description: "Play the classic game Commander Keen.",
-    icon: ICONS.keen,
+    icon: ICONS.keen, category: "",
     width: 640,
     height: 480,
     resizable: false,

--- a/src/apps/media-player/media-player-app.js
+++ b/src/apps/media-player/media-player-app.js
@@ -11,7 +11,7 @@ export class MediaPlayerApp extends Application {
     id: "media-player",
     title: "Media Player",
     description: "Play audio and video files.",
-    icon: ICONS.mediaPlayer,
+    icon: ICONS.mediaPlayer, category: "Accessories/Entertainment",
     width: 480,
     height: 360,
     resizable: true,

--- a/src/apps/minesweeper/minesweeper-app.js
+++ b/src/apps/minesweeper/minesweeper-app.js
@@ -13,7 +13,7 @@ export class MinesweeperApp extends Application {
     id: "minesweeper",
     title: "Minesweeper",
     description: "Play the classic game of Minesweeper.",
-    icon: ICONS.minesweeper,
+    icon: ICONS.minesweeper, category: "Accessories/Games",
     width: 200,
     height: 280,
     resizable: false,

--- a/src/apps/notepad/notepad-app.js
+++ b/src/apps/notepad/notepad-app.js
@@ -18,7 +18,7 @@ export class NotepadApp extends Application {
         id: "notepad",
         title: "Notepad",
         description: "A simple text editor.",
-        icon: ICONS.notepad,
+        icon: ICONS.notepad, category: "Accessories",
         width: 600,
         height: 400,
         resizable: true,

--- a/src/apps/paint/paint-app.js
+++ b/src/apps/paint/paint-app.js
@@ -6,7 +6,7 @@ export class PaintApp extends Application {
         id: "paint",
         title: "Paint",
         description: "Create and edit images.",
-        icon: ICONS.paint,
+        icon: ICONS.paint, category: "Accessories",
         width: 800,
         height: 600,
         resizable: true,

--- a/src/apps/pdf-viewer/pdf-viewer-app.js
+++ b/src/apps/pdf-viewer/pdf-viewer-app.js
@@ -8,7 +8,7 @@ export class PdfViewerApp extends Application {
     id: "pdf-viewer",
     title: "PDF Viewer",
     description: "View PDF documents.",
-    icon: ICONS.pdf,
+    icon: ICONS.pdf, category: "",
     width: 800,
     height: 600,
     resizable: true,

--- a/src/apps/pinball/pinball-app.js
+++ b/src/apps/pinball/pinball-app.js
@@ -7,7 +7,7 @@ export class PinballApp extends IFrameApplication {
     id: "pinball",
     title: "Space Cadet Pinball",
     description: "Play a classic game of pinball.",
-    icon: ICONS.pinball,
+    icon: ICONS.pinball, category: "Accessories/Games",
     width: 600,
     height: 400,
     resizable: false,

--- a/src/apps/prince-of-persia/prince-of-persia-app.js
+++ b/src/apps/prince-of-persia/prince-of-persia-app.js
@@ -9,7 +9,7 @@ export class PrinceOfPersiaApp extends Application {
   static config = {
     id: "prince-of-persia",
     title: "Prince of Persia",
-    icon: ICONS.princeofpersia,
+    icon: ICONS.princeofpersia, category: "",
     width: 640,
     height: 420,
     resizable: true,

--- a/src/apps/quake/quake-app.js
+++ b/src/apps/quake/quake-app.js
@@ -6,7 +6,7 @@ export class QuakeApp extends Application {
     static config = {
         id: 'quake',
         title: 'Quake',
-        icon: ICONS.quake,
+        icon: ICONS.quake, category: "",
         width: 640,
         height: 480,
         resizable: true,

--- a/src/apps/sim-city-2000/sim-city2000-app.js
+++ b/src/apps/sim-city-2000/sim-city2000-app.js
@@ -6,7 +6,7 @@ export class SimCity2000App extends IFrameApplication {
     id: "sim-city-2000",
     title: "SimCity 2000 Demo",
     description: "Play the SimCity 2000 demo.",
-    icon: ICONS.simcity2000,
+    icon: ICONS.simcity2000, category: "",
     gameUrl: "games/dos/simcity2000/index.html",
     width: 640,
     height: 480,

--- a/src/apps/solitaire/solitaire-app.js
+++ b/src/apps/solitaire/solitaire-app.js
@@ -29,7 +29,7 @@ export class SolitaireApp extends Application {
     width: 700,
     height: 600,
     resizable: true,
-    icon: ICONS.solitaire,
+    icon: ICONS.solitaire, category: "Accessories/Games",
   };
 
   async _createWindow() {

--- a/src/apps/spider-solitaire/spider-solitaire-app.js
+++ b/src/apps/spider-solitaire/spider-solitaire-app.js
@@ -19,7 +19,7 @@ export class SpiderSolitaireApp extends Application {
     width: 880,
     height: 550,
     resizable: true,
-    icon: ICONS.spidersolitaire,
+    icon: ICONS.spidersolitaire, category: "Accessories/Games",
   };
 
   async _createWindow() {

--- a/src/apps/tip-of-the-day/tip-of-the-day-app.js
+++ b/src/apps/tip-of-the-day/tip-of-the-day-app.js
@@ -10,7 +10,7 @@ export class TipOfTheDayApp extends Application {
         id: "tip-of-the-day",
         title: "Tip of the Day",
         description: "Provides useful tips about using the system.",
-        icon: ICONS.tip,
+        icon: ICONS.tip, category: "",
         width: 400,
         height: 300,
         resizable: false,

--- a/src/apps/webamp/webamp-app.js
+++ b/src/apps/webamp/webamp-app.js
@@ -19,7 +19,7 @@ export class WebampApp extends Application {
     id: "webamp",
     title: "Winamp",
     description: "A classic music player.",
-    icon: ICONS.webamp,
+    icon: ICONS.webamp, category: "",
     hasTaskbarButton: true,
     isSingleton: true,
     tray: {

--- a/src/apps/wordpad/word-pad-app.js
+++ b/src/apps/wordpad/word-pad-app.js
@@ -11,7 +11,7 @@ export class WordPadApp extends Application {
     id: "wordpad",
     title: "WordPad",
     description: "A simple rich text editor.",
-    icon: ICONS.wordpad,
+    icon: ICONS.wordpad, category: "Accessories",
     width: 600,
     height: 400,
     resizable: true,

--- a/src/config/apps.js
+++ b/src/config/apps.js
@@ -70,7 +70,7 @@ const systemApps = [
   {
     id: "internet-explorer",
     title: "Internet Explorer",
-    description: "Browse the web.",
+    description: "Browse the web.", category: "",
     get icon() {
       return getIcon("internet-explorer");
     },

--- a/src/config/start-menu.js
+++ b/src/config/start-menu.js
@@ -1,47 +1,7 @@
-import { apps } from './apps.js';
 import { launchApp } from '../system/app-manager.js';
 import { ShowRunDialog } from '../shell/run-dialog.js';
 import { ICONS } from './icons.js';
 import { START_MENU_PATH, FAVORITES_PATH } from '../shell/start-menu/start-menu-utils.js';
-
-const startMenuAppIds = [
-  "explorer",
-  "webamp",
-  "tip-of-the-day",
-  "internet-explorer",
-  "keen",
-  "command-prompt",
-  "buy-me-a-coffee",
-  "pdf-viewer",
-  "doom",
-  "sim-city-2000",
-  "diablo",
-  "esheep",
-  "quake",
-  "prince-of-persia",
-  "dx-ball",
-];
-const accessoriesAppIds = [
-  "notepad",
-  "clippy",
-  "paint",
-  "image-viewer",
-  "wordpad",
-  "calculator",
-];
-
-function getAppList(appListIds) {
-  return appListIds
-    .map((id) => apps.find((app) => app.id === id))
-    .filter((app) => app)
-    .sort((a, b) => a.title.localeCompare(b.title))
-    .map((app) => ({
-      label: app.title,
-      icon: app.icon[16],
-      appId: app.id,
-      action: () => launchApp(app.id),
-    }));
-}
 
 const startMenuConfig = [
   {
@@ -56,29 +16,6 @@ const startMenuConfig = [
         icon: ICONS.programs[16],
         submenu: [],
       },
-      {
-        label: "Accessories",
-        icon: ICONS.programs[16],
-        submenu: [
-          {
-            label: "Games",
-            icon: ICONS.programs[16],
-            submenu: getAppList(["pinball", "minesweeper", "solitaire", "spider-solitaire", "freecell", "dx-ball"]),
-          },
-          {
-            label: "Entertainment",
-            icon: ICONS.programs[16],
-            submenu: getAppList(["media-player", "flash-player"]),
-          },
-          {
-            label: "System Tools",
-            icon: ICONS.programs[16],
-            submenu: getAppList(["defrag"]),
-          },
-          ...getAppList(accessoriesAppIds),
-        ],
-      },
-      ...getAppList(startMenuAppIds),
     ],
   },
   {

--- a/src/shell/explorer/explorer-app.js
+++ b/src/shell/explorer/explorer-app.js
@@ -75,7 +75,7 @@ export class ZenExplorerApp extends Application {
     id: "explorer",
     title: "Windows Explorer",
     description: "Browse files and folders.",
-    icon: ICONS.windowsExplorer,
+    icon: ICONS.windowsExplorer, category: "",
     width: 640,
     height: 480,
     resizable: true,

--- a/src/shell/start-menu/start-menu-utils.js
+++ b/src/shell/start-menu/start-menu-utils.js
@@ -134,6 +134,42 @@ export async function getPinnedItemsFromZenFS(path = PINNED_PATH) {
 }
 
 /**
+ * Refreshes the Programs menu by ensuring shortcuts exist for all apps with a category.
+ */
+export async function refreshPrograms() {
+  if (!(await existsAsync(START_MENU_PATH))) {
+    await fs.promises.mkdir(START_MENU_PATH, { recursive: true });
+  }
+
+  for (const app of apps) {
+    if (app.category !== undefined) {
+      const categories = Array.isArray(app.category) ? app.category : [app.category];
+
+      for (const category of categories) {
+        let targetDir = START_MENU_PATH;
+        if (category) {
+          targetDir += `/${category}`;
+        }
+
+        if (!(await existsAsync(targetDir))) {
+          await fs.promises.mkdir(targetDir, { recursive: true });
+        }
+
+        const lnkPath = `${targetDir}/${app.title}.lnk.json`;
+        if (!(await existsAsync(lnkPath))) {
+          const lnkData = {
+            type: "shortcut",
+            appId: app.id,
+            args: app.args || null,
+          };
+          await fs.promises.writeFile(lnkPath, JSON.stringify(lnkData, null, 2));
+        }
+      }
+    }
+  }
+}
+
+/**
  * Recursively builds a menu structure from a ZenFS directory
  * @param {string} path - The ZenFS directory path
  * @returns {Promise<Array>} Array of menu items

--- a/src/shell/taskbar/taskbar.js
+++ b/src/shell/taskbar/taskbar.js
@@ -197,6 +197,25 @@ class Taskbar {
     this.addTrackedEventListener(startButton, "click", () => {
       this.startMenu.toggle();
     });
+
+    this.addTrackedEventListener(startButton, "contextmenu", (e) => {
+      e.preventDefault();
+      e.stopPropagation();
+
+      const contextMenuItems = [
+        {
+          label: "Refresh Start Menu items",
+          action: async () => {
+            const { refreshPrograms } = await import(
+              "../start-menu/start-menu-utils.js"
+            );
+            await refreshPrograms();
+          },
+        },
+      ];
+
+      new window.ContextMenu(contextMenuItems, e);
+    });
   }
 
   /**

--- a/src/system/zenfs-init.js
+++ b/src/system/zenfs-init.js
@@ -5,7 +5,6 @@ import {
   PINNED_PATH,
   START_MENU_PATH,
   FAVORITES_PATH,
-  refreshPrograms,
 } from "../shell/start-menu/start-menu-utils.js";
 import { migrateShortcuts } from "./migrate-shortcuts.js";
 import startMenuConfig from "../config/start-menu.js";
@@ -182,10 +181,9 @@ export async function initFileSystem(onProgress) {
       );
     }
 
-    const startMenuPathExists = await existsAsync(START_MENU_PATH);
-    await refreshPrograms();
+    if (!(await existsAsync(START_MENU_PATH))) {
+      await fs.promises.mkdir(START_MENU_PATH, { recursive: true });
 
-    if (!startMenuPathExists) {
       // Migrate startup apps from localStorage to ZenFS
       const startupApps = await getStartupApps();
       if (startupApps.length > 0) {

--- a/src/system/zenfs-init.js
+++ b/src/system/zenfs-init.js
@@ -5,6 +5,7 @@ import {
   PINNED_PATH,
   START_MENU_PATH,
   FAVORITES_PATH,
+  refreshPrograms,
 } from "../shell/start-menu/start-menu-utils.js";
 import { migrateShortcuts } from "./migrate-shortcuts.js";
 import startMenuConfig from "../config/start-menu.js";
@@ -181,14 +182,10 @@ export async function initFileSystem(onProgress) {
       );
     }
 
-    if (!(await existsAsync(START_MENU_PATH))) {
-      const programsConfig = startMenuConfig.find(
-        (item) => item.label === "Programs",
-      );
-      if (programsConfig && programsConfig.submenu) {
-        await migrateToZenFS(programsConfig.submenu, START_MENU_PATH);
-      }
+    const startMenuPathExists = await existsAsync(START_MENU_PATH);
+    await refreshPrograms();
 
+    if (!startMenuPathExists) {
       // Migrate startup apps from localStorage to ZenFS
       const startupApps = await getStartupApps();
       if (startupApps.length > 0) {


### PR DESCRIPTION
Improved the Start Menu by making it fully dynamic and category-based. 

Key changes:
1.  **Dynamic Programs Menu**: The hardcoded "Programs" tree in `src/config/start-menu.js` has been replaced with a dynamic system that populates from the ZenFS directory `/C:/WINDOWS/Start Menu/Programs`.
2.  **Application Categories**: Added a `category` property to all apps in `src/apps/` and system apps in `src/config/apps.js`. This property determines where the app's shortcut will appear (e.g., "Accessories/Games").
3.  **Automatic Synchronization**: A new `refreshPrograms` utility in `src/shell/start-menu/start-menu-utils.js` automatically scans all registered apps and ensures their shortcuts exist in ZenFS. This utility runs on every boot.
4.  **Manual Refresh**: Added a context menu to the Start button with a "Refresh Start Menu items" option, allowing users to manually trigger the synchronization process.

This refactor makes the Start Menu much more flexible and easier to maintain as new applications are added to the system.

---
*PR created automatically by Jules for task [11798494205307144270](https://jules.google.com/task/11798494205307144270) started by @azayrahmad*