### PR TITLE
Make boot screen resolution dynamic and mobile responsive

### DIFF
--- a/index.html
+++ b/index.html
@@ -153,7 +153,7 @@
                 font-family: "IBM BIOS", Courier, monospace;
                 font-size: 13px;
                 line-height: 1.5;
-                padding: 1em 2em;
+                padding: 0;
                 box-sizing: border-box;
                 overflow: hidden;
                 z-index: 9999;
@@ -172,8 +172,8 @@
                 justify-content: center;
             }
             #boot-terminal {
-                width: 640px;
-                height: 400px;
+                width: 100%;
+                height: 100%;
             }
             #boot-terminal .xterm-viewport {
                 overflow-y: hidden !important;

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "win98-web",
       "version": "0.5.0",
       "dependencies": {
+        "@xterm/addon-fit": "^0.11.0",
         "@xterm/addon-image": "^0.9.0",
         "@xterm/xterm": "^5.5.0",
         "@zenfs/archives": "^1.3.1",
@@ -2603,6 +2604,12 @@
       "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
       "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@xterm/addon-fit": {
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/@xterm/addon-fit/-/addon-fit-0.11.0.tgz",
+      "integrity": "sha512-jYcgT6xtVYhnhgxh3QgYDnnNMYTcf8ElbxxFzX0IZo+vabQqSPAjC3c1wJrKB5E19VwQei89QCiZZP86DCPF7g==",
       "license": "MIT"
     },
     "node_modules/@xterm/addon-image": {

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "vite-plugin-pwa": "^1.1.0"
   },
   "dependencies": {
+    "@xterm/addon-fit": "^0.11.0",
     "@xterm/addon-image": "^0.9.0",
     "@xterm/xterm": "^5.5.0",
     "@zenfs/archives": "^1.3.1",

--- a/src/system/boot-screen.js
+++ b/src/system/boot-screen.js
@@ -1,5 +1,6 @@
 import { Terminal } from "@xterm/xterm";
 import { ImageAddon } from "@xterm/addon-image";
+import { FitAddon } from "@xterm/addon-fit";
 import "@xterm/xterm/css/xterm.css";
 import { runSetupTUI } from "./setup-utility.js";
 
@@ -40,6 +41,7 @@ async function preloadLogos() {
 
 function drawBIOSHeader() {
     if (!terminal) return;
+    const cols = terminal.cols;
 
     // Award Logo at (1,1)
     if (awardLogo) {
@@ -51,17 +53,18 @@ function drawBIOSHeader() {
     terminal.write("\x1b[2;5HCopyright (C) 1984-85, Award Software, Inc.");
 
     // Energy Star Logo at top right
-    // Terminal is 80 cols. Energy Star is 135px wide.
-    // Assuming ~8px per cell, it's ~17 columns. 80 - 17 = 63.
-    if (energyStarLogo) {
-        terminal.write(`\x1b[1;63H\x1b]1337;File=inline=1;size=${energyStarLogo.size}:${energyStarLogo.base64}\x07`);
+    // Terminal is cols wide. Energy Star is 135px wide.
+    // Assuming ~8px per cell, it's ~17 columns.
+    const energyStarCols = 17;
+    if (energyStarLogo && cols >= energyStarCols + 46) {
+        terminal.write(`\x1b[1;${cols - energyStarCols + 1}H\x1b]1337;File=inline=1;size=${energyStarLogo.size}:${energyStarLogo.base64}\x07`);
     }
 }
 
 function drawBIOSFooter() {
     if (!terminal) return;
-    // Standard boot footer
-    terminal.write("\x1b[25;1H\x1b[0mPress F8 for Startup Menu.");
+    // Standard boot footer at the last row
+    terminal.write(`\x1b[${terminal.rows};1H\x1b[0mPress F8 for Startup Menu.`);
 }
 
 export async function prepareBootScreen() {
@@ -73,8 +76,8 @@ export async function prepareBootScreen() {
     drawBIOSHeader();
     drawBIOSFooter();
 
-    // Set scrolling region for the log: Rows 7 to 24
-    term.write("\x1b[7;24r");
+    // Set scrolling region for the log: Rows 7 to last-1
+    term.write(`\x1b[7;${term.rows - 1}r`);
     // Move cursor to the start of the log area
     term.write("\x1b[7;1H");
 }
@@ -94,15 +97,23 @@ function initTerminal() {
         },
         fontFamily: '"IBM BIOS", Courier, monospace',
         fontSize: 13,
-        rows: 25,
-        cols: 80,
         allowTransparency: true,
     });
 
     const imageAddon = new ImageAddon();
     terminal.loadAddon(imageAddon);
 
+    const fitAddon = new FitAddon();
+    terminal.loadAddon(fitAddon);
+
     terminal.open(container);
+    fitAddon.fit();
+
+    window.addEventListener("resize", () => {
+        if (terminal) {
+            fitAddon.fit();
+        }
+    });
 
     // Ensure cursor is visible and blinking
     terminal.write("\x1b[?25h");

--- a/src/system/setup-utility.js
+++ b/src/system/setup-utility.js
@@ -17,13 +17,14 @@ export async function runSetupTUI(term, onExit) {
         // Choice
         term.write(`Enter a choice: ${selectedOption}`);
 
-        // Footer at the bottom of 80x25 terminal
-        term.write("\x1b[25;1H\x1b[0mF5=Safe mode   Shift+F5=Command prompt   Shift+F8=Step-by-step confirmation [N]");
+        // Footer at the bottom of the terminal
+        term.write(`\x1b[${term.rows};1H\x1b[0mF5=Safe mode   Shift+F5=Command prompt   Shift+F8=Step-by-step confirmation [N]`);
     };
 
     const drawTimer = () => {
-        // Move cursor to row 6, column 30
-        term.write(`\x1b[6;30HTime remaining: ${timeLeft.toString().padStart(2, ' ')}`);
+        // Position timer on row 6, after the choice prompt if possible
+        const timerCol = Math.max(30, Math.min(term.cols - 20, 30));
+        term.write(`\x1b[6;${timerCol}HTime remaining: ${timeLeft.toString().padStart(2, ' ')}`);
         // Move cursor back to just after the choice for the underline cursor
         term.write("\x1b[6;17H");
     };


### PR DESCRIPTION
The boot screen was previously fixed at 640x480px, causing it to be cropped on mobile devices. This PR introduces dynamic resolution for the xterm.js-based boot terminal using the @xterm/addon-fit addon. It ensures the terminal always fills its container and adjusts the number of columns and rows accordingly. The BIOS layout (header, logos, footer) and the Startup Menu are updated to use relative positioning based on these dynamic dimensions. On narrow screens, the Energy Star logo is hidden to prevent overlap with BIOS text.

---
*PR created automatically by Jules for task [886435083791459242](https://jules.google.com/task/886435083791459242) started by @azayrahmad*