### PR TITLE
Enable touch-based drag and drop for icons

### DIFF
--- a/e2e/touch_drag.spec.js
+++ b/e2e/touch_drag.spec.js
@@ -1,0 +1,77 @@
+import { test, expect } from '@playwright/test';
+
+test.describe('Touch Drag and Drop', () => {
+  test.beforeEach(async ({ page }) => {
+    // Go to the desktop
+    await page.goto('http://localhost:5173/win98-web/');
+    // Wait for the OS to initialize (azOS Ready!)
+    await page.waitForSelector('text=azOS Ready!', { timeout: 30000 });
+    // Wait for splash screen to hide
+    await page.waitForSelector('#splash-screen', { state: 'hidden' });
+    // Wait for boot mode to be removed from screen
+    await page.waitForSelector('#screen:not(.boot-mode)');
+  });
+
+  test('should dismiss context menu and start dragging on touch move', async ({ page }) => {
+    const icon = page.locator('.desktop .explorer-icon[data-name="My Computer"]');
+    await expect(icon).toBeVisible();
+
+    // 1. Trigger context menu on the icon
+    // Using dispatchEvent to simulate touch-hold behavior that triggers contextmenu
+    await icon.dispatchEvent('contextmenu', { clientX: 100, clientY: 100 });
+    // Use first() to avoid strict mode violation if there are submenus
+    await expect(page.locator('.menu-popup-wrapper').first()).toBeVisible();
+
+    const iconRect = await icon.boundingBox();
+    const startX = iconRect.x + iconRect.width / 2;
+    const startY = iconRect.y + iconRect.height / 2;
+
+    // 2. Start touch sequence
+    await icon.dispatchEvent('touchstart', {
+      touches: [{ identifier: 0, clientX: startX, clientY: startY }]
+    });
+
+    // 3. Move beyond threshold (10px)
+    // We move 20px to be sure
+    const moveX = startX + 20;
+    const moveY = startY + 20;
+    await icon.dispatchEvent('touchmove', {
+      touches: [{ identifier: 0, clientX: moveX, clientY: moveY }]
+    });
+
+    // 4. Context menu should be gone
+    await expect(page.locator('.menu-popup-wrapper')).not.toBeVisible();
+
+    // 5. Drag ghost should be present and move
+    // Dispatch another move to ensure DragDropManager's listener (on document) picks it up
+    await page.dispatchEvent('body', 'touchmove', {
+      touches: [{ identifier: 0, clientX: moveX + 10, clientY: moveY + 10 }]
+    });
+
+    const ghost = page.locator('.drag-ghost');
+    await expect(ghost).toBeAttached();
+
+    // Check that ghost position is updated (approximately)
+    const ghostRect = await ghost.boundingBox();
+    // ghost.style.left = `${x - this.offsetX}px`;
+    // where offsetX = x - rect.left. So ghost left should be icon rect.left + movement.
+    // Here movement is 20px.
+    expect(ghostRect.x).toBeGreaterThan(iconRect.x);
+    expect(ghostRect.y).toBeGreaterThan(iconRect.y);
+
+    // 6. Complete drag
+    const endX = startX + 100;
+    const endY = startY + 100;
+
+    await icon.dispatchEvent('touchmove', {
+      touches: [{ identifier: 0, clientX: endX, clientY: endY }]
+    });
+
+    await page.dispatchEvent('body', 'touchend', {
+      changedTouches: [{ identifier: 0, clientX: endX, clientY: endY }]
+    });
+
+    // 7. Ghost should be gone
+    await expect(page.locator('.drag-ghost')).not.toBeVisible();
+  });
+});

--- a/src/shell/desktop/desktop.js
+++ b/src/shell/desktop/desktop.js
@@ -581,12 +581,13 @@ export async function initDesktop(profile = null) {
 
   desktopController.iconManager = new IconManager(desktop, {
     iconSelector: ".explorer-icon",
-    onDragStart: (e, icon, selectedIcons) => {
+    onDragStart: (e, icon, selectedIcons, x, y, isTouch) => {
       DragDropManager.startDrag(
         selectedIcons,
         desktopController,
-        e.clientX,
-        e.clientY,
+        x !== undefined ? x : e.clientX,
+        y !== undefined ? y : e.clientY,
+        isTouch
       );
     },
     onItemContext: (e, icon) => {

--- a/src/shell/desktop/icon-manager.js
+++ b/src/shell/desktop/icon-manager.js
@@ -214,9 +214,56 @@ export class IconManager {
       this.handleIconMouseDown(e, icon),
     );
     icon.addEventListener("click", (e) => this.handleIconClick(e, icon));
+    icon.addEventListener("touchstart", (e) => this.handleTouchStart(e, icon), { passive: false });
+    icon.addEventListener("touchmove", (e) => this.handleTouchMove(e, icon), { passive: false });
+    icon.addEventListener("touchend", (e) => this.handleTouchEnd(e, icon));
 
     // Allow context menu events to propagate to the container for onItemContext handling
     // icon.addEventListener("contextmenu", e => e.stopPropagation());
+  }
+
+  handleTouchStart(e, icon) {
+    if (e.touches.length !== 1) return;
+    this.touchStartX = e.touches[0].clientX;
+    this.touchStartY = e.touches[0].clientY;
+    this.touchIcon = icon;
+    this.isTouchDragging = false;
+
+    // Select the icon on touch start if it's not already selected
+    if (!this.selectedIcons.has(icon)) {
+      this.setSelection(new Set([icon]));
+    }
+  }
+
+  handleTouchMove(e, icon) {
+    if (this.isTouchDragging) return;
+    if (e.touches.length !== 1) return;
+
+    const touchX = e.touches[0].clientX;
+    const touchY = e.touches[0].clientY;
+    const dist = Math.sqrt(
+      Math.pow(touchX - this.touchStartX, 2) +
+        Math.pow(touchY - this.touchStartY, 2),
+    );
+
+    if (dist > 10) {
+      this.isTouchDragging = true;
+      this.wasDragged = true;
+      e.stopPropagation();
+
+      // Dismiss context menu
+      const existingMenus = document.querySelectorAll(".menu-popup-wrapper");
+      existingMenus.forEach((menu) => menu.remove());
+
+      if (this.options.onDragStart) {
+        this.options.onDragStart(e, icon, [...this.selectedIcons], this.touchStartX, this.touchStartY, true);
+      }
+    }
+  }
+
+  handleTouchEnd(e, icon) {
+    this.isTouchDragging = false;
+    this.touchIcon = null;
   }
 
   handleIconMouseDown(e, icon) {
@@ -239,7 +286,7 @@ export class IconManager {
         document.removeEventListener("mousemove", onMouseMove);
         this.wasDragged = true;
         if (this.options.onDragStart) {
-          this.options.onDragStart(e, icon, [...this.selectedIcons]);
+          this.options.onDragStart(e, icon, [...this.selectedIcons], startX, startY, false);
         }
       }
     };

--- a/src/shell/explorer/explorer-app.js
+++ b/src/shell/explorer/explorer-app.js
@@ -399,8 +399,14 @@ export class ZenExplorerApp extends Application {
   _setupIconManager() {
     this.iconManager = new IconManager(this.iconContainer, {
       iconSelector: ".explorer-icon",
-      onDragStart: (e, icon, selectedIcons) => {
-        DragDropManager.startDrag(selectedIcons, this, e.clientX, e.clientY);
+      onDragStart: (e, icon, selectedIcons, x, y, isTouch) => {
+        DragDropManager.startDrag(
+          selectedIcons,
+          this,
+          x !== undefined ? x : e.clientX,
+          y !== undefined ? y : e.clientY,
+          isTouch
+        );
       },
       onItemContext: (e, icon) => {
         const menuItems = this.contextMenuBuilder.buildItemMenu(e, icon);

--- a/src/shell/explorer/file-operations/drag-drop-manager.js
+++ b/src/shell/explorer/file-operations/drag-drop-manager.js
@@ -15,9 +15,10 @@ export class DragDropManager {
         this.offsetY = 0;
     }
 
-    startDrag(iconElements, sourceApp, x, y) {
+    startDrag(iconElements, sourceApp, x, y, isTouch = false) {
         if (this.isDragging) return;
         this.isDragging = true;
+        this.isTouchDrag = isTouch;
         this.draggedItems = iconElements.map(el => {
             const rect = el.getBoundingClientRect();
             return {
@@ -38,8 +39,15 @@ export class DragDropManager {
         this._createGhost(iconElements, x, y);
         this._boundMouseMove = this._handleMouseMove.bind(this);
         this._boundMouseUp = this._handleMouseUp.bind(this);
-        document.addEventListener('mousemove', this._boundMouseMove);
-        document.addEventListener('mouseup', this._boundMouseUp);
+
+        if (this.isTouchDrag) {
+            document.addEventListener('touchmove', this._boundMouseMove, { passive: false });
+            document.addEventListener('touchend', this._boundMouseUp);
+            document.addEventListener('touchcancel', this._boundMouseUp);
+        } else {
+            document.addEventListener('mousemove', this._boundMouseMove);
+            document.addEventListener('mouseup', this._boundMouseUp);
+        }
         document.body.classList.add('dragging');
     }
 
@@ -69,15 +77,22 @@ export class DragDropManager {
 
     _handleMouseMove(e) {
         if (!this.isDragging) return;
-        if (this.ghostElement) {
-            this.ghostElement.style.left = `${e.clientX - this.offsetX}px`;
-            this.ghostElement.style.top = `${e.clientY - this.offsetY}px`;
+        const x = e.touches ? e.touches[0].clientX : e.clientX;
+        const y = e.touches ? e.touches[0].clientY : e.clientY;
+
+        if (this.isTouchDrag && e.cancelable) {
+            e.preventDefault();
         }
-        this._updateDropTarget(e);
+
+        if (this.ghostElement) {
+            this.ghostElement.style.left = `${x - this.offsetX}px`;
+            this.ghostElement.style.top = `${y - this.offsetY}px`;
+        }
+        this._updateDropTarget(x, y);
     }
 
-    _updateDropTarget(e) {
-        const elements = document.elementsFromPoint(e.clientX, e.clientY);
+    _updateDropTarget(x, y) {
+        const elements = document.elementsFromPoint(x, y);
         let newTarget = null;
         for (const el of elements) {
             const icon = el.closest('.explorer-icon');
@@ -114,11 +129,16 @@ export class DragDropManager {
             offsetX: this.offsetX,
             offsetY: this.offsetY
         };
-        this._performDrop(e, e.ctrlKey, dragData);
+
+        const isCopy = e.ctrlKey;
+        const x = (e.changedTouches && e.changedTouches[0]) ? e.changedTouches[0].clientX : e.clientX;
+        const y = (e.changedTouches && e.changedTouches[0]) ? e.changedTouches[0].clientY : e.clientY;
+
+        this._performDrop(x, y, isCopy, dragData);
         this._cleanup();
     }
 
-    async _performDrop(e, isCopy, dragData) {
+    async _performDrop(x, y, isCopy, dragData) {
         const { sourceApp, draggedItems, dropTarget, offsetX, offsetY } = dragData;
         if (!dropTarget || !sourceApp) return;
         let destinationPath = null;
@@ -138,8 +158,8 @@ export class DragDropManager {
 
         if (container) {
             const rect = container.getBoundingClientRect();
-            dropX = e.clientX - rect.left + (container.scrollLeft || 0) - offsetX;
-            dropY = e.clientY - rect.top + (container.scrollTop || 0) - offsetY;
+            dropX = x - rect.left + (container.scrollLeft || 0) - offsetX;
+            dropY = y - rect.top + (container.scrollTop || 0) - offsetY;
         }
         const sourceDir = sourcePaths[0].substring(0, sourcePaths[0].lastIndexOf('/')) || '/';
         if (!isCopy && destinationPath === sourceDir) {
@@ -197,11 +217,20 @@ export class DragDropManager {
         this.ghostElement = null;
         if (this.dropTarget) this.dropTarget.classList.remove('drop-target-highlight');
         this.dropTarget = null;
-        document.removeEventListener('mousemove', this._boundMouseMove);
-        document.removeEventListener('mouseup', this._boundMouseUp);
+
+        if (this.isTouchDrag) {
+            document.removeEventListener('touchmove', this._boundMouseMove);
+            document.removeEventListener('touchend', this._boundMouseUp);
+            document.removeEventListener('touchcancel', this._boundMouseUp);
+        } else {
+            document.removeEventListener('mousemove', this._boundMouseMove);
+            document.removeEventListener('mouseup', this._boundMouseUp);
+        }
+
         document.body.classList.remove('dragging');
         this.draggedItems = [];
         this.sourceApp = null;
+        this.isTouchDrag = false;
     }
 }
 export default new DragDropManager();


### PR DESCRIPTION
This change enables drag and drop functionality for touch devices on desktop and explorer icons. When a user performs a long-press (triggering a context menu) and then starts dragging, the context menu is automatically dismissed and the icon follows the user's finger. A movement threshold of 10 pixels is used to distinguish between a tap/hold and a drag. Visual feedback is provided via the existing "ghost" element which now correctly follows touch points.

---
*PR created automatically by Jules for task [16021179076981044561](https://jules.google.com/task/16021179076981044561) started by @azayrahmad*