### PR TITLE
Move Doom and Wallpaper Initialization to Early Boot Phase

### DIFF
--- a/src/system/os-init.js
+++ b/src/system/os-init.js
@@ -23,7 +23,6 @@ import screensaver from './screensaver-utils.js';
 import { initScreenManager } from './screen-manager.js';
 import { fs, mounts } from "@zenfs/core";
 import { initFileSystem } from './zenfs-init.js';
-import { wallpapers } from '../config/wallpapers.js';
 import { existsAsync } from './zenfs-utils.js';
 import { RecycleBinManager } from '../shell/explorer/file-operations/recycle-bin-manager.js';
 import { appManager } from './app-manager.js';
@@ -167,37 +166,6 @@ export async function initializeOS() {
       finalizeBootProcessStep(logElement, "OK");
     });
 
-    await executeBootStep(async () => {
-      const wallpaperDir = "/C:/WINDOWS";
-      let needed = false;
-      for (const w of wallpapers.default) {
-        if (!(await existsAsync(`${wallpaperDir}/${w.filename}`))) {
-          needed = true;
-          break;
-        }
-      }
-
-      if (needed) {
-        let logElement = startBootProcessStep("Loading wallpapers...");
-        for (const w of wallpapers.default) {
-          const path = `${wallpaperDir}/${w.filename}`;
-          if (!(await existsAsync(path))) {
-            if (logElement && logElement.firstChild) {
-              logElement.firstChild.nodeValue = `Loading wallpaper: ${w.filename}...`;
-            }
-            try {
-              const response = await fetch(w.src);
-              const buffer = await response.arrayBuffer();
-              await fs.promises.writeFile(path, new Uint8Array(buffer));
-            } catch (e) {
-              console.error(`Failed to load wallpaper ${w.filename}:`, e);
-            }
-          }
-        }
-        finalizeBootProcessStep(logElement, "OK");
-      }
-    });
-
     const createAssetLogCallbacks = (logElement, baseMessage) => {
       const onAssetLogStart = (name) => {
         if (logElement && logElement.firstChild) {
@@ -271,38 +239,6 @@ export async function initializeOS() {
         finalizeBootProcessStep(logElement, "OK");
       });
     }
-
-    await executeBootStep(async () => {
-      const doomFiles = ["doom1.wad", "default.cfg"];
-      const baseRemotePath = "games/doom/";
-      const baseLocalPath = "/C:/Program Files/Doom/";
-
-      let needed = false;
-      for (const file of doomFiles) {
-        if (!fs.existsSync(baseLocalPath + file)) {
-          needed = true;
-          break;
-        }
-      }
-
-      if (needed) {
-        let logElement = startBootProcessStep("Loading Doom game data...");
-        for (const file of doomFiles) {
-          if (!fs.existsSync(baseLocalPath + file)) {
-            if (logElement && logElement.firstChild) {
-              logElement.firstChild.nodeValue = `Loading Doom game data: ${file}...`;
-            }
-            const response = await fetch(baseRemotePath + file);
-            const buffer = await response.arrayBuffer();
-            await fs.promises.writeFile(baseLocalPath + file, new Uint8Array(buffer));
-          }
-        }
-        if (logElement && logElement.firstChild) {
-          logElement.firstChild.nodeValue = "Loading Doom game data...";
-        }
-        finalizeBootProcessStep(logElement, "OK");
-      }
-    });
 
     if (!isMSDOSMode) {
       await executeBootStep(async () => {

--- a/src/system/zenfs-init.js
+++ b/src/system/zenfs-init.js
@@ -12,6 +12,7 @@ import startMenuConfig from "../config/start-menu.js";
 import { getStartupApps } from "./startup-manager.js";
 import { apps } from "../config/apps.js";
 import { existsAsync } from "./zenfs-utils.js";
+import { wallpapers } from "../config/wallpapers.js";
 
 let isInitialized = false;
 
@@ -56,12 +57,67 @@ export async function initFileSystem(onProgress) {
       await fs.promises.mkdir("/C:/WINDOWS");
     }
 
+    const wallpaperDir = "/C:/WINDOWS";
+    let wallpapersNeeded = false;
+    for (const w of wallpapers.default) {
+      if (!(await existsAsync(`${wallpaperDir}/${w.filename}`))) {
+        wallpapersNeeded = true;
+        break;
+      }
+    }
+
+    if (wallpapersNeeded) {
+      for (const w of wallpapers.default) {
+        const path = `${wallpaperDir}/${w.filename}`;
+        if (!(await existsAsync(path))) {
+          if (onProgress) onProgress(`Loading wallpaper: ${w.filename}...`);
+          try {
+            const response = await fetch(w.src);
+            const buffer = await response.arrayBuffer();
+            await fs.promises.writeFile(path, new Uint8Array(buffer));
+          } catch (e) {
+            console.error(`Failed to load wallpaper ${w.filename}:`, e);
+          }
+        }
+      }
+    }
+
     // Ensure Program Files/Doom exists
     if (!(await existsAsync("/C:/Program Files"))) {
       await fs.promises.mkdir("/C:/Program Files");
     }
     if (!(await existsAsync("/C:/Program Files/Doom"))) {
       await fs.promises.mkdir("/C:/Program Files/Doom");
+    }
+
+    const doomFiles = ["doom1.wad", "default.cfg"];
+    const doomRemotePath = "games/doom/";
+    const doomLocalPath = "/C:/Program Files/Doom/";
+
+    let doomNeeded = false;
+    for (const file of doomFiles) {
+      if (!(await existsAsync(doomLocalPath + file))) {
+        doomNeeded = true;
+        break;
+      }
+    }
+
+    if (doomNeeded) {
+      for (const file of doomFiles) {
+        if (!(await existsAsync(doomLocalPath + file))) {
+          if (onProgress) onProgress(`Loading Doom game data: ${file}...`);
+          try {
+            const response = await fetch(doomRemotePath + file);
+            const buffer = await response.arrayBuffer();
+            await fs.promises.writeFile(
+              doomLocalPath + file,
+              new Uint8Array(buffer),
+            );
+          } catch (e) {
+            console.error(`Failed to load Doom game data ${file}:`, e);
+          }
+        }
+      }
     }
     // Ensure WINDOWS/Desktop directory exists for the Desktop shell extension
     if (!(await existsAsync("/C:/WINDOWS/Desktop"))) {


### PR DESCRIPTION
The task was to improve the boot process by ensuring all filesystem initialization, specifically Doom game data and wallpapers, occurs during the initial filesystem setup phase. 

I modified `src/system/zenfs-init.js` to include the logic for fetching and saving these assets to the virtual C: drive. I also updated the `onProgress` callback to show status updates on the boot screen. Finally, I removed the old, redundant logic from `src/system/os-init.js`. 

Testing was performed using Playwright to verify that the progress messages appear during the "Initializing file system..." step and that the Doom application still functions correctly after boot.

---
*PR created automatically by Jules for task [18047833561128284635](https://jules.google.com/task/18047833561128284635) started by @azayrahmad*