### PR TITLE
Add Favorites menu to Explorer

### DIFF
--- a/src/shell/explorer/explorer-app.js
+++ b/src/shell/explorer/explorer-app.js
@@ -34,6 +34,7 @@ import { RecycleBinExtension } from './extensions/recycle-bin-extension.js';
 import { NetworkNeighborhoodExtension } from './extensions/network-neighborhood-extension.js';
 import { InternetExplorerExtension } from './extensions/internet-explorer-extension.js';
 import { isZenFSPath, getZenFSFileUrl } from '../../system/zenfs-utils.js';
+import { getMenuFromZenFS, FAVORITES_PATH } from '../start-menu/start-menu-utils.js';
 import "./explorer.css";
 
 // Initialize Shell Extensions
@@ -96,6 +97,8 @@ export class ZenExplorerApp extends Application {
     this.retroMode = true;
     this.blobUrl = null;
     this.isInWebMode = false;
+    this._favoritesCache = null;
+    this._favoritesLoading = false;
   }
 
   async launch(data = null) {
@@ -848,8 +851,19 @@ export class ZenExplorerApp extends Application {
 
   async _updateMenuBar() {
     if (!this.win) return;
+
+    // Fetch favorites if not cached
+    if (!this._favoritesCache && !this._favoritesLoading) {
+      this._favoritesLoading = true;
+      getMenuFromZenFS(FAVORITES_PATH).then(items => {
+        this._favoritesCache = items;
+        this._favoritesLoading = false;
+        this._updateMenuBar();
+      });
+    }
+
     const menuBuilder = new MenuBarBuilder(this);
-    this.menuBar = await menuBuilder.build();
+    this.menuBar = menuBuilder.build(this._favoritesCache || []);
     this.win.setMenuBar(this.menuBar);
 
     // Add Animated Logo

--- a/src/shell/explorer/explorer-app.js
+++ b/src/shell/explorer/explorer-app.js
@@ -368,7 +368,7 @@ export class ZenExplorerApp extends Application {
     this.navigateTo(this.currentPath);
 
     // 9. Setup MenuBar (last, as it depends on status bar, icon manager, etc.)
-    this._updateMenuBar();
+    await this._updateMenuBar();
 
     return win;
   }
@@ -595,7 +595,7 @@ export class ZenExplorerApp extends Application {
     document.addEventListener("theme-changed", this._themeHandler);
   }
 
-  _updateMode() {
+  async _updateMode() {
     const isWeb = this.isInWebMode;
     const wasWeb = this.iframe.style.display === "block";
 
@@ -613,7 +613,7 @@ export class ZenExplorerApp extends Application {
       // The resize observer will handle "with-sidebar" class for non-web paths
     }
 
-    this._updateMenuBar();
+    await this._updateMenuBar();
     this._updateToolbar(isWeb !== wasWeb);
   }
 
@@ -623,7 +623,7 @@ export class ZenExplorerApp extends Application {
       isHistoryNav,
       skipMRU,
     );
-    this._updateMode();
+    await this._updateMode();
 
     if (this.iconContainer) {
       this.iconContainer.setAttribute("data-current-path", this.currentPath);
@@ -846,10 +846,10 @@ export class ZenExplorerApp extends Application {
     return this.driveManager.ejectCD();
   }
 
-  _updateMenuBar() {
+  async _updateMenuBar() {
     if (!this.win) return;
     const menuBuilder = new MenuBarBuilder(this);
-    this.menuBar = menuBuilder.build();
+    this.menuBar = await menuBuilder.build();
     this.win.setMenuBar(this.menuBar);
 
     // Add Animated Logo

--- a/src/shell/explorer/interface/menu-bar-builder.js
+++ b/src/shell/explorer/interface/menu-bar-builder.js
@@ -10,23 +10,23 @@ import { PropertiesManager } from '../file-operations/properties-manager.js';
 import UndoManager from '../file-operations/undo-manager.js';
 import { RemovableDiskManager } from '../drives/removable-disk-manager.js';
 import { RecycleBinManager } from '../file-operations/recycle-bin-manager.js';
-import { getMenuFromZenFS, FAVORITES_PATH } from '../../start-menu/start-menu-utils.js';
+import { FAVORITES_PATH } from '../../start-menu/start-menu-utils.js';
 
 export class MenuBarBuilder {
   constructor(app) {
     this.app = app;
   }
 
-  async build() {
+  build(favorites = []) {
     const isWeb = this.app.isWebPath(this.app.currentPath);
-    const favorites = await getMenuFromZenFS(FAVORITES_PATH);
+    const patchedFavorites = this._patchFavoriteActions(favorites);
     try {
       if (isWeb) {
         return new window.MenuBar({
           "&File": this._getIEFileMenuItems(),
           "&Edit": this._getIEEditMenuItems(),
           "&View": this._getIEViewMenuItems(),
-          "F&avorites": favorites,
+          "F&avorites": patchedFavorites,
           "&Go": this._getIEGoMenuItems(),
           "&Help": this._getIEHelpMenuItems(),
         });
@@ -35,7 +35,7 @@ export class MenuBarBuilder {
         "&File": this._getFileMenuItems(),
         "&Edit": this._getEditMenuItems(),
         "&View": this._getViewMenuItems(),
-        "F&avorites": favorites,
+        "F&avorites": patchedFavorites,
         "&Go": this._getGoMenuItems(),
         "&Help": this._getHelpMenuItems(),
       });
@@ -448,5 +448,26 @@ export class MenuBarBuilder {
         },
       },
     ];
+  }
+
+  _patchFavoriteActions(items) {
+    return items.map(item => {
+      const newItem = { ...item };
+      if (newItem.submenu) {
+        newItem.submenu = this._patchFavoriteActions(newItem.submenu);
+      } else if (newItem.appId === "explorer" || newItem.appId === "internet-explorer") {
+        newItem.action = () => {
+          if (newItem.args) {
+            this.app.navigateTo(newItem.args);
+          } else if (newItem.targetPath) {
+            this.app.navigateTo(newItem.targetPath);
+          } else {
+            // Default explorer or IE launch, just let it be or navigate to root/home
+            this.app.navigateTo(newItem.appId === "internet-explorer" ? "azay.rahmad" : "/");
+          }
+        };
+      }
+      return newItem;
+    });
   }
 }

--- a/src/shell/explorer/interface/menu-bar-builder.js
+++ b/src/shell/explorer/interface/menu-bar-builder.js
@@ -10,20 +10,23 @@ import { PropertiesManager } from '../file-operations/properties-manager.js';
 import UndoManager from '../file-operations/undo-manager.js';
 import { RemovableDiskManager } from '../drives/removable-disk-manager.js';
 import { RecycleBinManager } from '../file-operations/recycle-bin-manager.js';
+import { getMenuFromZenFS, FAVORITES_PATH } from '../../start-menu/start-menu-utils.js';
 
 export class MenuBarBuilder {
   constructor(app) {
     this.app = app;
   }
 
-  build() {
+  async build() {
     const isWeb = this.app.isWebPath(this.app.currentPath);
+    const favorites = await getMenuFromZenFS(FAVORITES_PATH);
     try {
       if (isWeb) {
         return new window.MenuBar({
           "&File": this._getIEFileMenuItems(),
           "&Edit": this._getIEEditMenuItems(),
           "&View": this._getIEViewMenuItems(),
+          "F&avorites": favorites,
           "&Go": this._getIEGoMenuItems(),
           "&Help": this._getIEHelpMenuItems(),
         });
@@ -32,6 +35,7 @@ export class MenuBarBuilder {
         "&File": this._getFileMenuItems(),
         "&Edit": this._getEditMenuItems(),
         "&View": this._getViewMenuItems(),
+        "F&avorites": favorites,
         "&Go": this._getGoMenuItems(),
         "&Help": this._getHelpMenuItems(),
       });

--- a/src/shell/start-menu/start-menu-utils.js
+++ b/src/shell/start-menu/start-menu-utils.js
@@ -59,11 +59,15 @@ export async function loadLnk(path, iconSize = 16) {
         label: label,
         icon: app ? app.icon[iconSize] : ICONS.file[iconSize],
         action: () => launchApp(data.appId, data.args),
+        appId: data.appId,
+        args: data.args,
       };
     } else if (data.targetPath) {
       const targetName = data.targetPath.split("/").pop();
       let icon = ICONS.file[iconSize];
       let action = () => {};
+      let appId = "explorer";
+      let args = data.targetPath;
 
       try {
         const stats = await ShellManager.stat(data.targetPath);
@@ -73,11 +77,15 @@ export async function loadLnk(path, iconSize = 16) {
         } else {
           const association = getAssociation(targetName);
           if (association) {
+            appId = association.appId;
+            args = ShellManager.getRealPath(data.targetPath);
             icon = association.icon[iconSize];
-            action = () => launchApp(association.appId, ShellManager.getRealPath(data.targetPath));
+            action = () => launchApp(appId, args);
           } else {
+            appId = "notepad";
+            args = ShellManager.getRealPath(data.targetPath);
             icon = ICONS.file[iconSize];
-            action = () => launchApp("notepad", ShellManager.getRealPath(data.targetPath));
+            action = () => launchApp(appId, args);
           }
         }
       } catch (e) {
@@ -88,6 +96,9 @@ export async function loadLnk(path, iconSize = 16) {
         label: label,
         icon: icon,
         action: action,
+        appId,
+        args,
+        targetPath: data.targetPath,
       };
     }
 


### PR DESCRIPTION
This change adds a "Favorites" menu to the Windows Explorer application, positioned after the "View" menu. The menu is populated with the contents of the `/C:/WINDOWS/Favorites` directory, matching the items shown in the Start Menu's Favorites. The implementation ensures that the menu is available in both standard and Internet Explorer modes. The Explorer application's menu bar building process was updated to be asynchronous to support dynamic fetching of favorites from ZenFS.

---
*PR created automatically by Jules for task [18065513961684750184](https://jules.google.com/task/18065513961684750184) started by @azayrahmad*