### PR TITLE
Integrate ZenFS and Fix Title Handling in Paint App

### DIFF
--- a/src/apps/paint/paint-app.js
+++ b/src/apps/paint/paint-app.js
@@ -1,5 +1,7 @@
 import { Application } from '../../system/application.js';
+import { fs } from "@zenfs/core";
 import { ICONS } from '../../config/icons.js';
+import { ShowFilePicker } from '../../shared/utils/file-picker.js';
 import './paint.css'; // I'll create this file to import all paint styles
 
 export class PaintApp extends Application {
@@ -17,6 +19,119 @@ export class PaintApp extends Application {
     constructor(config) {
         super(config);
         this.initialized = false;
+    }
+
+    _mapFormats(formats) {
+        return formats.map(f => ({
+            label: f.nameWithExtensions || f.name,
+            extensions: f.extensions
+        }));
+    }
+
+    async _getFileFromPath(path) {
+        const buffer = await fs.promises.readFile(path);
+        const name = path.split('/').pop();
+        return new File([buffer], name);
+    }
+
+    _setupSystemHooks() {
+        window.systemHooks = window.systemHooks || {};
+
+        window.systemHooks.showOpenFileDialog = async ({ formats }) => {
+            const path = await ShowFilePicker({
+                title: "Open",
+                mode: "open",
+                fileTypes: this._mapFormats(formats)
+            });
+            if (path) {
+                const file = await this._getFileFromPath(path);
+                return { file, fileHandle: path };
+            }
+            return null;
+        };
+
+        window.systemHooks.showSaveFileDialog = async ({ formats, defaultFileName, getBlob, savedCallbackUnreliable }) => {
+            const path = await ShowFilePicker({
+                title: "Save As",
+                mode: "save",
+                fileTypes: this._mapFormats(formats),
+                suggestedName: defaultFileName
+            });
+            if (path) {
+                const extension = path.split('.').pop().toLowerCase();
+                const format = formats.find(f => f.extensions.includes(extension)) || formats[0];
+                const blob = await getBlob(format.formatID);
+                await fs.promises.writeFile(path, new Uint8Array(await blob.arrayBuffer()));
+
+                savedCallbackUnreliable?.({
+                    newFileName: path.split('/').pop(),
+                    newFileFormatID: format.formatID,
+                    newFileHandle: path,
+                    newBlob: blob,
+                });
+            }
+        };
+
+        window.systemHooks.writeBlobToHandle = async (handle, blob) => {
+            if (typeof handle === 'string') {
+                await fs.promises.writeFile(handle, new Uint8Array(await blob.arrayBuffer()));
+                return true;
+            }
+            return false;
+        };
+
+        window.systemHooks.readBlobFromHandle = async (handle) => {
+            if (typeof handle === 'string') {
+                return await this._getFileFromPath(handle);
+            }
+            throw new Error("Invalid handle");
+        };
+
+        window.systemHooks.updateTitle = (title) => {
+            if (this.win) {
+                this.win.title(title);
+            }
+        };
+    }
+
+    async openFile(data) {
+        let path = data;
+        let file = null;
+
+        if (data && typeof data === 'object') {
+            if (data instanceof File) {
+                file = data;
+            } else {
+                path = data.filePath || data.file || data;
+                if (path instanceof File) {
+                    file = path;
+                }
+            }
+        }
+
+        const { open_from_file, load_image_from_uri } = await import('./src/functions.js');
+
+        if (file) {
+            open_from_file(file, file);
+            return;
+        }
+
+        if (typeof path === 'string') {
+            if (path.startsWith('/') && !path.startsWith('http')) {
+                try {
+                    const file = await this._getFileFromPath(path);
+                    open_from_file(file, path);
+                } catch (e) {
+                    console.error("Failed to open file from ZenFS", e);
+                }
+            } else {
+                try {
+                    load_image_from_uri(path);
+                } catch (e) {
+                    console.error("Failed to load image from URI", e);
+                }
+            }
+        }
     }
 
     _createWindow() {
@@ -38,9 +153,13 @@ export class PaintApp extends Application {
         if (window.$app) {
             this._injectHTML();
             this.win.$content.append(window.$app);
+            this._setupSystemHooks();
             this.initialized = true;
             $(window).trigger("resize");
             this.win.focus();
+            if (data) {
+                this.openFile(data);
+            }
             return;
         }
 
@@ -61,12 +180,38 @@ export class PaintApp extends Application {
         // Load localization first as it provides the global `localize`
         await import('./src/app-localization.js');
 
+        // Setup hooks
+        this._setupSystemHooks();
+
         // Import the main app. This will execute the code.
         // We need to make sure app.js uses window.paintAppContainer
         await import('./src/app.js');
 
         this.initialized = true;
         this.win.focus();
+
+        if (data) {
+            this.openFile(data);
+        }
+
+        // Setup drag and drop
+        this.win.$content.on("dragover", (e) => {
+            const dt = e.originalEvent.dataTransfer;
+            if (dt && dt.types.includes("application/x-zenfs-path")) {
+                e.preventDefault();
+                e.stopPropagation();
+            }
+        });
+
+        this.win.$content.on("drop", async (e) => {
+            const dt = e.originalEvent.dataTransfer;
+            const zenfsPath = dt.getData("application/x-zenfs-path");
+            if (zenfsPath) {
+                e.preventDefault();
+                e.stopPropagation();
+                this.openFile(zenfsPath);
+            }
+        });
     }
 
     async _loadDependencies() {

--- a/src/apps/paint/paint-app.js
+++ b/src/apps/paint/paint-app.js
@@ -179,13 +179,22 @@ export class PaintApp extends Application {
         this._myClose = null;
         this._originalClose = null;
 
+        // Detach the app container from the window before it's destroyed.
+        // This is crucial because jQuery's .remove() (used by $Window)
+        // recursively removes all event handlers from child elements.
+        if (window.$app) {
+            window.$app.detach();
+        }
+
         this._disposePaint();
     }
 
     async _disposePaint() {
         try {
-            const { reset_file, reset_selected_colors, reset_canvas_and_history, set_magnification } = await import('./src/functions.js');
+            const { reset_file, reset_selected_colors, reset_canvas_and_history, set_magnification, deselect } = await import('./src/functions.js');
             const { default_magnification } = await import('./src/app-state.js');
+
+            deselect();
             reset_file();
             reset_selected_colors();
             reset_canvas_and_history();

--- a/src/apps/paint/paint-app.js
+++ b/src/apps/paint/paint-app.js
@@ -2,6 +2,7 @@ import { Application } from '../../system/application.js';
 import { fs } from "@zenfs/core";
 import { ICONS } from '../../config/icons.js';
 import { ShowFilePicker } from '../../shared/utils/file-picker.js';
+import { saved } from './src/app-state.js';
 import './paint.css'; // I'll create this file to import all paint styles
 
 export class PaintApp extends Application {
@@ -92,6 +93,16 @@ export class PaintApp extends Application {
                 this.win.title(title);
             }
         };
+
+        // Override window.close for jspaint
+        const originalClose = window.close;
+        window.close = () => {
+            if (this.win) {
+                this.win.close();
+            } else {
+                originalClose.call(window);
+            }
+        };
     }
 
     async openFile(data) {
@@ -144,9 +155,36 @@ export class PaintApp extends Application {
             icons: this.icon,
         });
 
+        win.on("close", async (e) => {
+            if (!saved) {
+                e.preventDefault();
+                const { are_you_sure } = await import('./src/functions.js');
+                are_you_sure(() => {
+                    win.close(true);
+                });
+            }
+        });
+
         win.element.style.display = 'flex';
         win.$content.addClass("paint-container");
         return win;
+    }
+
+    _onClose() {
+        this._disposePaint();
+    }
+
+    async _disposePaint() {
+        try {
+            const { reset_file, reset_selected_colors, reset_canvas_and_history, set_magnification } = await import('./src/functions.js');
+            const { default_magnification } = await import('./src/app-state.js');
+            reset_file();
+            reset_selected_colors();
+            reset_canvas_and_history();
+            set_magnification(default_magnification);
+        } catch (e) {
+            console.error("Failed to dispose Paint state", e);
+        }
     }
 
     async _onLaunch(data) {

--- a/src/apps/paint/paint-app.js
+++ b/src/apps/paint/paint-app.js
@@ -94,15 +94,16 @@ export class PaintApp extends Application {
         };
 
         // Override window.close for jspaint to use our window component
-        if (!this._originalClose) {
+        if (window.close !== this._myClose) {
             this._originalClose = window.close;
-            window.close = () => {
+            this._myClose = () => {
                 if (this.win && !this.win.closed) {
                     this.win.close();
                 } else if (this._originalClose) {
                     this._originalClose.call(window);
                 }
             };
+            window.close = this._myClose;
         }
     }
 
@@ -157,8 +158,7 @@ export class PaintApp extends Application {
         });
 
         win.on("close", async (e) => {
-            const { saved } = await import('./src/app-state.js');
-            if (!saved) {
+            if (!window.saved) {
                 e.preventDefault();
                 const { are_you_sure } = await import('./src/functions.js');
                 are_you_sure(() => {
@@ -173,10 +173,12 @@ export class PaintApp extends Application {
     }
 
     _onClose() {
-        if (this._originalClose) {
+        if (window.close === this._myClose) {
             window.close = this._originalClose;
-            this._originalClose = null;
         }
+        this._myClose = null;
+        this._originalClose = null;
+
         this._disposePaint();
     }
 
@@ -188,6 +190,15 @@ export class PaintApp extends Application {
             reset_selected_colors();
             reset_canvas_and_history();
             set_magnification(default_magnification);
+
+            // Additional resets to prevent unresponsiveness on relaunch
+            window.pointer_active = false;
+            window.pointer_buttons = 0;
+            window.pointers = [];
+            if (window.$G) {
+                window.$G.triggerHandler("pointerup");
+                window.$G.triggerHandler("blur");
+            }
         } catch (e) {
             console.error("Failed to dispose Paint state", e);
         }
@@ -199,10 +210,14 @@ export class PaintApp extends Application {
             this._setupWindow(this.id, this.isSingleton ? this.id : this.id + Date.now());
         }
 
+        // Update global container reference for the current window
+        window.paintAppContainer = this.win.$content[0];
+
         if (window.$app) {
             this._injectHTML();
             this.win.$content.append(window.$app);
             this._setupSystemHooks();
+            this._setupDragAndDrop();
             this.initialized = true;
             $(window).trigger("resize");
             this.win.focus();
@@ -216,9 +231,6 @@ export class PaintApp extends Application {
             this.win.focus();
             return;
         }
-
-        // Initialize Paint
-        window.paintAppContainer = this.win.$content[0];
 
         // We need to load dependencies that were in <script> tags in index.html
         await this._loadDependencies();
@@ -243,7 +255,11 @@ export class PaintApp extends Application {
             this.openFile(data);
         }
 
-        // Setup drag and drop
+        this._setupDragAndDrop();
+    }
+
+    _setupDragAndDrop() {
+        this.win.$content.off("dragover drop");
         this.win.$content.on("dragover", (e) => {
             const dt = e.originalEvent.dataTransfer;
             if (dt && dt.types.includes("application/x-zenfs-path")) {
@@ -294,7 +310,7 @@ export class PaintApp extends Application {
 
     _injectHTML() {
         // Remove existing fragments if any (to avoid duplicate IDs)
-        this.win.$content.find('#about-paint, #news, svg').remove();
+        this.win.$content.find('#about-paint, #news, #jspaint-svg-filters').remove();
 
         // These are from index.html
         const aboutPaint = document.createElement('div');
@@ -328,6 +344,7 @@ export class PaintApp extends Application {
 
         // SVG filters from index.html
         const svgFilters = document.createElementNS("http://www.w3.org/2000/svg", "svg");
+        svgFilters.id = 'jspaint-svg-filters';
         svgFilters.style.position = "absolute";
         svgFilters.style.pointerEvents = "none";
         svgFilters.style.bottom = "100%";

--- a/src/apps/paint/paint-app.js
+++ b/src/apps/paint/paint-app.js
@@ -2,7 +2,6 @@ import { Application } from '../../system/application.js';
 import { fs } from "@zenfs/core";
 import { ICONS } from '../../config/icons.js';
 import { ShowFilePicker } from '../../shared/utils/file-picker.js';
-import { saved } from './src/app-state.js';
 import './paint.css'; // I'll create this file to import all paint styles
 
 export class PaintApp extends Application {
@@ -94,15 +93,17 @@ export class PaintApp extends Application {
             }
         };
 
-        // Override window.close for jspaint
-        const originalClose = window.close;
-        window.close = () => {
-            if (this.win) {
-                this.win.close();
-            } else {
-                originalClose.call(window);
-            }
-        };
+        // Override window.close for jspaint to use our window component
+        if (!this._originalClose) {
+            this._originalClose = window.close;
+            window.close = () => {
+                if (this.win && !this.win.closed) {
+                    this.win.close();
+                } else if (this._originalClose) {
+                    this._originalClose.call(window);
+                }
+            };
+        }
     }
 
     async openFile(data) {
@@ -156,6 +157,7 @@ export class PaintApp extends Application {
         });
 
         win.on("close", async (e) => {
+            const { saved } = await import('./src/app-state.js');
             if (!saved) {
                 e.preventDefault();
                 const { are_you_sure } = await import('./src/functions.js');
@@ -171,6 +173,10 @@ export class PaintApp extends Application {
     }
 
     _onClose() {
+        if (this._originalClose) {
+            window.close = this._originalClose;
+            this._originalClose = null;
+        }
         this._disposePaint();
     }
 
@@ -188,6 +194,11 @@ export class PaintApp extends Application {
     }
 
     async _onLaunch(data) {
+        if (!this.win) {
+            this.win = this._createWindow();
+            this._setupWindow(this.id, this.isSingleton ? this.id : this.id + Date.now());
+        }
+
         if (window.$app) {
             this._injectHTML();
             this.win.$content.append(window.$app);
@@ -282,6 +293,9 @@ export class PaintApp extends Application {
     }
 
     _injectHTML() {
+        // Remove existing fragments if any (to avoid duplicate IDs)
+        this.win.$content.find('#about-paint, #news, svg').remove();
+
         // These are from index.html
         const aboutPaint = document.createElement('div');
         aboutPaint.id = 'about-paint';

--- a/src/apps/paint/src/functions.js
+++ b/src/apps/paint/src/functions.js
@@ -1096,7 +1096,9 @@ function file_new() {
 		cancel();
 
 		$G.triggerHandler("session-update"); // autosave old session
-		new_local_session();
+		if (typeof new_local_session !== "undefined") {
+			new_local_session();
+		}
 
 		reset_file();
 		reset_selected_colors();

--- a/src/apps/paint/src/functions.js
+++ b/src/apps/paint/src/functions.js
@@ -743,7 +743,7 @@ function make_history_node({
 }
 
 function update_title() {
-	const title = `${file_name} - ${is_pride_month ? "June Solidarity " : ""}${localize("Paint")}`;
+	const title = `${file_name}${window.saved ? "" : " *"} - ${is_pride_month ? "June Solidarity " : ""}${localize("Paint")}`;
 
 	if (window.systemHooks && window.systemHooks.updateTitle) {
 		window.systemHooks.updateTitle(title);

--- a/src/apps/paint/src/functions.js
+++ b/src/apps/paint/src/functions.js
@@ -743,7 +743,11 @@ function make_history_node({
 }
 
 function update_title() {
-	document.title = `${file_name} - ${is_pride_month ? "June Solidarity " : ""}${localize("Paint")}`;
+	const title = `${file_name} - ${is_pride_month ? "June Solidarity " : ""}${localize("Paint")}`;
+
+	if (window.systemHooks && window.systemHooks.updateTitle) {
+		window.systemHooks.updateTitle(title);
+	}
 
 	if (is_pride_month) {
 		$("link[rel~='icon']").attr("href", "/win98-web/apps/paint/images/icons/gay-es-paint-16x16-light-outline.png");
@@ -961,7 +965,9 @@ function open_from_image_info(info, callback, canceled, into_existing_session, f
 
 		if (!into_existing_session) {
 			$G.triggerHandler("session-update"); // autosave old session
-			new_local_session();
+			if (typeof new_local_session !== "undefined") {
+				new_local_session();
+			}
 		}
 
 		reset_file();


### PR DESCRIPTION
The Paint application has been updated to fully integrate with the ZenFS filesystem and respect the OS-like window environment. Key changes include:

1.  **ZenFS Integration**: Overrode the standard "Open", "Save", and "Save As" dialogs in `jspaint` to use the system's `ShowFilePicker` utility. This allows users to directly interact with the virtual ZenFS filesystem.
2.  **Window Title Management**: Refactored the title update logic in `src/apps/paint/src/functions.js` to call a new `updateTitle` hook. The `PaintApp` implements this hook to update the title of its `$Window` instance, and the redundant update to the browser's `document.title` has been removed.
3.  **Enhanced File Loading**: Updated `PaintApp` to handle opening files passed during launch (e.g., from the file explorer) and through drag-and-drop of ZenFS file paths (`application/x-zenfs-path`).
4.  **Format Mapping**: Automatically maps JS Paint's internal image format list to the file types expected by the ZenFS file picker, ensuring all supported formats (PNG, BMP, JPEG, etc.) are available for selection.

These changes ensure a consistent and integrated experience for the Paint app within the Windows 98 Web simulation.

---
*PR created automatically by Jules for task [16424231080033212984](https://jules.google.com/task/16424231080033212984) started by @azayrahmad*