### PR TITLE
fix(webamp): align container behavior with window stacking

### DIFF
--- a/src/apps/webamp/webamp-app.js
+++ b/src/apps/webamp/webamp-app.js
@@ -14,6 +14,7 @@ let webampContainer = null;
 let webampTaskbarButton = null;
 let webampTaskbarClickHandler = null;
 let webampFocusHandler = null;
+let webampElementMouseDownHandler = null;
 let isMinimized = false;
 
 const focusWebampContainer = () => {
@@ -28,13 +29,18 @@ const focusWebampContainer = () => {
   }
 };
 
-const isWebampTarget = (target) => {
-  if (!target) return false;
+const isWebampEvent = (event) => {
+  const path = event?.composedPath?.() || [];
 
-  return Boolean(
-    target.closest?.("#webamp") ||
-    target.closest?.("#webamp-container"),
-  );
+  return path.some((node) => (
+    node?.id === "webamp" ||
+    node?.id === "webamp-container"
+  ));
+};
+
+const isWebampTaskbarEvent = (event) => {
+  const path = event?.composedPath?.() || [];
+  return path.includes(webampTaskbarButton);
 };
 
 export class WebampApp extends Application {
@@ -228,6 +234,7 @@ export class WebampApp extends Application {
               this._centerWebampContainer();
               this.setupTaskbarButton();
               this._setupFocusTracking();
+              this._setupWebampElementFocus();
               this.showWebamp();
               handleFile(filePath);
               resolve(); // Resolve the promise once Webamp is ready
@@ -244,7 +251,7 @@ export class WebampApp extends Application {
     webampFocusHandler = (event) => {
       if (isMinimized) return;
 
-      if (isWebampTarget(event.target)) {
+      if (isWebampEvent(event)) {
         focusWebampContainer();
         if (webampTaskbarButton) {
           updateTaskbarButton("webamp", true, false);
@@ -252,7 +259,7 @@ export class WebampApp extends Application {
         return;
       }
 
-      if (webampTaskbarButton?.contains(event.target)) {
+      if (isWebampTaskbarEvent(event)) {
         return;
       }
 
@@ -262,6 +269,22 @@ export class WebampApp extends Application {
     };
 
     document.addEventListener("mousedown", webampFocusHandler, true);
+  }
+
+  _setupWebampElementFocus() {
+    const webampElement = document.getElementById("webamp");
+    if (!webampElement || webampElementMouseDownHandler) return;
+
+    webampElementMouseDownHandler = () => {
+      if (isMinimized) return;
+
+      focusWebampContainer();
+      if (webampTaskbarButton) {
+        updateTaskbarButton("webamp", true, false);
+      }
+    };
+
+    webampElement.addEventListener("mousedown", webampElementMouseDownHandler, true);
   }
 
   setupTaskbarButton() {
@@ -350,6 +373,12 @@ export class WebampApp extends Application {
       document.removeEventListener("mousedown", webampFocusHandler, true);
       webampFocusHandler = null;
     }
+
+    const webampElement = document.getElementById("webamp");
+    if (webampElement && webampElementMouseDownHandler) {
+      webampElement.removeEventListener("mousedown", webampElementMouseDownHandler, true);
+    }
+    webampElementMouseDownHandler = null;
 
     isMinimized = false;
   }

--- a/src/apps/webamp/webamp-app.js
+++ b/src/apps/webamp/webamp-app.js
@@ -16,7 +16,14 @@ let isMinimized = false;
 
 const focusWebampContainer = () => {
   if (!webampContainer) return;
-  webampContainer.style.zIndex = $Window.Z_INDEX++;
+
+  const zIndex = $Window.Z_INDEX++;
+  webampContainer.style.zIndex = zIndex;
+
+  const webampElement = document.getElementById("webamp");
+  if (webampElement) {
+    webampElement.style.zIndex = zIndex;
+  }
 };
 
 export class WebampApp extends Application {
@@ -220,7 +227,7 @@ export class WebampApp extends Application {
   }
 
   setupTaskbarButton() {
-    const taskbarButtonId = "webamp-taskbar-button";
+    const taskbarButtonId = "webamp";
     webampTaskbarButton = createTaskbarButton(
       taskbarButtonId,
       ICONS.webamp,
@@ -243,23 +250,35 @@ export class WebampApp extends Application {
   showWebamp() {
     if (!webampContainer) return;
 
+    const webampElement = document.getElementById("webamp");
+
     webampContainer.style.display = "block";
     webampContainer.style.visibility = "visible";
+    if (webampElement) {
+      webampElement.style.display = "block";
+      webampElement.style.visibility = "visible";
+    }
     isMinimized = false;
     focusWebampContainer();
     if (webampTaskbarButton) {
-      updateTaskbarButton("webamp-taskbar-button", true, false);
+      updateTaskbarButton("webamp", true, false);
     }
   }
 
   minimizeWebamp() {
     if (!webampContainer) return;
 
+    const webampElement = document.getElementById("webamp");
+
     webampContainer.style.display = "none";
     webampContainer.style.visibility = "hidden";
+    if (webampElement) {
+      webampElement.style.display = "none";
+      webampElement.style.visibility = "hidden";
+    }
     isMinimized = true;
     if (webampTaskbarButton) {
-      updateTaskbarButton("webamp-taskbar-button", false, true);
+      updateTaskbarButton("webamp", false, true);
     }
   }
 
@@ -276,7 +295,7 @@ export class WebampApp extends Application {
     }
 
     if (webampTaskbarButton) {
-      removeTaskbarButton("webamp-taskbar-button");
+      removeTaskbarButton("webamp");
       webampTaskbarButton = null;
     }
     isMinimized = false;

--- a/src/apps/webamp/webamp-app.js
+++ b/src/apps/webamp/webamp-app.js
@@ -14,6 +14,11 @@ let webampContainer = null;
 let webampTaskbarButton = null;
 let isMinimized = false;
 
+const focusWebampContainer = () => {
+  if (!webampContainer) return;
+  webampContainer.style.zIndex = $Window.Z_INDEX++;
+};
+
 export class WebampApp extends Application {
   static config = {
     id: "webamp",
@@ -46,6 +51,16 @@ export class WebampApp extends Application {
     // Webamp doesn't use a standard OS-GUI window, it renders directly to the body.
     // We manage its container and lifecycle here.
     return null; // Return null to prevent default window creation.
+  }
+
+  _centerWebampContainer() {
+    if (!webampContainer) return;
+
+    const webampElement = webampContainer.querySelector("#webamp") || webampContainer;
+    const { width, height } = webampElement.getBoundingClientRect();
+
+    webampContainer.style.left = `${Math.max(0, Math.round((window.innerWidth - width) / 2))}px`;
+    webampContainer.style.top = `${Math.max(0, Math.round((window.innerHeight - height) / 2))}px`;
   }
 
   async _onLaunch(filePath) {
@@ -145,16 +160,12 @@ export class WebampApp extends Application {
       webampContainer = document.createElement("div");
       webampContainer.id = "webamp-container";
       webampContainer.style.position = "absolute";
-      webampContainer.style.zIndex = $Window.Z_INDEX++;
-      webampContainer.style.left = "50px";
-      webampContainer.style.top = "50px";
+      focusWebampContainer();
       document.body.appendChild(webampContainer);
 
       webampContainer.addEventListener(
         "mousedown",
-        () => {
-          webampContainer.style.zIndex = $Window.Z_INDEX++;
-        },
+        focusWebampContainer,
         true,
       );
 
@@ -196,6 +207,7 @@ export class WebampApp extends Application {
           webampInstance
             .renderWhenReady(webampContainer)
             .then(() => {
+              this._centerWebampContainer();
               this.setupTaskbarButton();
               this.showWebamp();
               handleFile(filePath);
@@ -229,24 +241,22 @@ export class WebampApp extends Application {
   }
 
   showWebamp() {
-    const webampElement = document.getElementById("webamp");
-    if (!webampElement) return;
+    if (!webampContainer) return;
 
-    webampElement.style.display = "block";
-    webampElement.style.visibility = "visible";
+    webampContainer.style.display = "block";
+    webampContainer.style.visibility = "visible";
     isMinimized = false;
-    webampContainer.style.zIndex = $Window.Z_INDEX++;
+    focusWebampContainer();
     if (webampTaskbarButton) {
       updateTaskbarButton("webamp-taskbar-button", true, false);
     }
   }
 
   minimizeWebamp() {
-    const webampElement = document.getElementById("webamp");
-    if (!webampElement) return;
+    if (!webampContainer) return;
 
-    webampElement.style.display = "none";
-    webampElement.style.visibility = "hidden";
+    webampContainer.style.display = "none";
+    webampContainer.style.visibility = "hidden";
     isMinimized = true;
     if (webampTaskbarButton) {
       updateTaskbarButton("webamp-taskbar-button", false, true);

--- a/src/apps/webamp/webamp-app.js
+++ b/src/apps/webamp/webamp-app.js
@@ -12,6 +12,8 @@ import { isZenFSPath, getZenFSFileUrl, getZenFSFileAsText } from '../../system/z
 let webampInstance = null;
 let webampContainer = null;
 let webampTaskbarButton = null;
+let webampTaskbarClickHandler = null;
+let webampFocusHandler = null;
 let isMinimized = false;
 
 const focusWebampContainer = () => {
@@ -24,6 +26,15 @@ const focusWebampContainer = () => {
   if (webampElement) {
     webampElement.style.zIndex = zIndex;
   }
+};
+
+const isWebampTarget = (target) => {
+  if (!target) return false;
+
+  return Boolean(
+    target.closest?.("#webamp") ||
+    target.closest?.("#webamp-container"),
+  );
 };
 
 export class WebampApp extends Application {
@@ -216,6 +227,7 @@ export class WebampApp extends Application {
             .then(() => {
               this._centerWebampContainer();
               this.setupTaskbarButton();
+              this._setupFocusTracking();
               this.showWebamp();
               handleFile(filePath);
               resolve(); // Resolve the promise once Webamp is ready
@@ -224,6 +236,32 @@ export class WebampApp extends Application {
         })
         .catch(reject);
     });
+  }
+
+  _setupFocusTracking() {
+    if (webampFocusHandler) return;
+
+    webampFocusHandler = (event) => {
+      if (isMinimized) return;
+
+      if (isWebampTarget(event.target)) {
+        focusWebampContainer();
+        if (webampTaskbarButton) {
+          updateTaskbarButton("webamp", true, false);
+        }
+        return;
+      }
+
+      if (webampTaskbarButton?.contains(event.target)) {
+        return;
+      }
+
+      if (webampTaskbarButton) {
+        updateTaskbarButton("webamp", false, false);
+      }
+    };
+
+    document.addEventListener("mousedown", webampFocusHandler, true);
   }
 
   setupTaskbarButton() {
@@ -235,15 +273,19 @@ export class WebampApp extends Application {
     );
 
     if (webampTaskbarButton) {
-      webampTaskbarButton.addEventListener("click", (event) => {
+      webampTaskbarClickHandler = (event) => {
         event.preventDefault();
         event.stopPropagation();
+        event.stopImmediatePropagation();
+
         if (isMinimized) {
           this.showWebamp();
         } else {
           this.minimizeWebamp();
         }
-      });
+      };
+
+      webampTaskbarButton.addEventListener("click", webampTaskbarClickHandler, true);
     }
   }
 
@@ -294,10 +336,21 @@ export class WebampApp extends Application {
       webampInstance = null;
     }
 
+    if (webampTaskbarButton && webampTaskbarClickHandler) {
+      webampTaskbarButton.removeEventListener("click", webampTaskbarClickHandler, true);
+      webampTaskbarClickHandler = null;
+    }
+
     if (webampTaskbarButton) {
       removeTaskbarButton("webamp");
       webampTaskbarButton = null;
     }
+
+    if (webampFocusHandler) {
+      document.removeEventListener("mousedown", webampFocusHandler, true);
+      webampFocusHandler = null;
+    }
+
     isMinimized = false;
   }
 }

--- a/src/apps/webamp/webamp-app.js
+++ b/src/apps/webamp/webamp-app.js
@@ -15,6 +15,7 @@ let webampTaskbarButton = null;
 let webampTaskbarClickHandler = null;
 let webampFocusHandler = null;
 let webampElementMouseDownHandler = null;
+let webampMenuObserver = null;
 let isMinimized = false;
 
 const focusWebampContainer = () => {
@@ -41,6 +42,18 @@ const isWebampEvent = (event) => {
 const isWebampTaskbarEvent = (event) => {
   const path = event?.composedPath?.() || [];
   return path.includes(webampTaskbarButton);
+};
+
+const bringWebampMenusToFront = () => {
+  const webampElement = document.getElementById("webamp");
+  if (!webampElement) return;
+
+  const webampZIndex = Number.parseInt(webampElement.style.zIndex || "0", 10) || 0;
+  const menuZIndex = webampZIndex + 1;
+
+  document.querySelectorAll(".webamp-context-menu").forEach((menuElement) => {
+    menuElement.style.zIndex = String(menuZIndex);
+  });
 };
 
 export class WebampApp extends Application {
@@ -235,6 +248,7 @@ export class WebampApp extends Application {
               this.setupTaskbarButton();
               this._setupFocusTracking();
               this._setupWebampElementFocus();
+              this._setupWebampMenuLayering();
               this.showWebamp();
               handleFile(filePath);
               resolve(); // Resolve the promise once Webamp is ready
@@ -287,6 +301,32 @@ export class WebampApp extends Application {
     webampElement.addEventListener("mousedown", webampElementMouseDownHandler, true);
   }
 
+  _setupWebampMenuLayering() {
+    if (webampMenuObserver) return;
+
+    webampMenuObserver = new MutationObserver((mutations) => {
+      const hasMenuMutation = mutations.some((mutation) => (
+        [...mutation.addedNodes].some((node) => (
+          node instanceof Element && (
+            node.matches?.(".webamp-context-menu") ||
+            node.querySelector?.(".webamp-context-menu")
+          )
+        ))
+      ));
+
+      if (!hasMenuMutation) return;
+
+      requestAnimationFrame(() => {
+        bringWebampMenusToFront();
+      });
+    });
+
+    webampMenuObserver.observe(document.body, {
+      childList: true,
+      subtree: true,
+    });
+  }
+
   setupTaskbarButton() {
     const taskbarButtonId = "webamp";
     webampTaskbarButton = createTaskbarButton(
@@ -328,6 +368,8 @@ export class WebampApp extends Application {
     if (webampTaskbarButton) {
       updateTaskbarButton("webamp", true, false);
     }
+
+    bringWebampMenusToFront();
   }
 
   minimizeWebamp() {
@@ -379,6 +421,11 @@ export class WebampApp extends Application {
       webampElement.removeEventListener("mousedown", webampElementMouseDownHandler, true);
     }
     webampElementMouseDownHandler = null;
+
+    if (webampMenuObserver) {
+      webampMenuObserver.disconnect();
+      webampMenuObserver = null;
+    }
 
     isMinimized = false;
   }


### PR DESCRIPTION
### Motivation
- Webamp renders outside the standard `$Window` system and started at a hardcoded top-left position, which caused z-index, minimize/restore, and taskbar interactions to behave differently than other windows.
- The goal is to make Webamp follow the same stacking and minimize/restore semantics as regular OS-GUI windows and open centered on screen.

### Description
- Added a shared focus helper `focusWebampContainer` that raises `webampContainer.style.zIndex` using `$Window.Z_INDEX++` so focus/restore/click follow the window stacking flow.
- Implemented `_centerWebampContainer()` and invoke it after `renderWhenReady` so Webamp is centered on initial open instead of positioned at `50px,50px`.
- Switched minimize/restore to toggle the outer `webampContainer` visibility and display (instead of only manipulating the internal `#webamp` element) so taskbar state and restoration match standard window behavior.
- Replaced inline z-index handling and event handlers to call the new focus helper and ensured the container is appended before interaction hooks are attached.

### Testing
- Ran `npm run build` which completed successfully with Vite build output and produced `dist/` artifacts; build passed.
- Started the dev server (`npm run dev`) and the server reported ready on the expected host/port.
- Attempted automated UI validation with Playwright scripts to capture a screenshot of the opened Webamp, but the browser-based runs failed due to environment instability: the first run timed out and later attempts ended with a Chromium crash (`SIGSEGV`), so no screenshot validation succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698c0f90624c8332973bda84a51306d3)