### PR TITLE
Make Webamp a windowed app

### DIFF
--- a/src/apps/webamp/webamp-app.js
+++ b/src/apps/webamp/webamp-app.js
@@ -29,6 +29,10 @@ export class WebampApp extends Application {
     this.webampContainer = null;
   }
 
+  _getWindowId(filePath) {
+    return "webamp-app-window";
+  }
+
   _revokeBlobUrls() {
     this.blobUrls.forEach((url) => URL.revokeObjectURL(url));
     this.blobUrls = [];
@@ -36,6 +40,7 @@ export class WebampApp extends Application {
 
   _createWindow() {
     const win = new $Window({
+      id: "webamp-app-window",
       title: this.title,
       icons: this.icon,
       resizable: false,
@@ -53,7 +58,11 @@ export class WebampApp extends Application {
     return win;
   }
 
-  async _onLaunch(filePath) {
+  _onLaunch(filePath) {
+    this._doLaunch(filePath);
+  }
+
+  async _doLaunch(filePath) {
     const handleFile = async (path) => {
       if (!path) return;
       if (!this.webampInstance) return;
@@ -147,9 +156,17 @@ export class WebampApp extends Application {
       return;
     }
 
-    return new Promise((resolve, reject) => {
-      this.webampContainer = this.win.$content[0];
-      this.webampContainer.id = "webamp-container";
+    try {
+      // Create container in body initially, then move it to the window
+      // Webamp sometimes has issues rendering directly into deeply nested elements
+      const container = document.createElement("div");
+      container.id = "webamp-container";
+      document.body.appendChild(container);
+      this.webampContainer = container;
+
+      // Ensure no stale webamp nodes exist before rendering
+      const staleWebamp = document.getElementById("webamp");
+      if (staleWebamp) staleWebamp.remove();
 
       const initialTracks = [
         {
@@ -189,14 +206,82 @@ export class WebampApp extends Application {
           this.webampInstance
             .renderWhenReady(this.webampContainer)
             .then(() => {
+              // Move the entire container into our window
+              this.win.$content.append(this.webampContainer);
+
+              // Reset container positioning to be relative to the window content area
+              this.webampContainer.style.position = "absolute";
+              this.webampContainer.style.left = "0";
+              this.webampContainer.style.top = "0";
+
+              // Ensure Webamp root is inside the container
+              const webampNode = document.getElementById("webamp");
+              if (webampNode && webampNode.parentElement !== this.webampContainer) {
+                this.webampContainer.appendChild(webampNode);
+              }
+
+              // Webamp windows (Main, EQ, PL) are absolutely positioned.
+              // When reparented, we want them to be at 0,0 relative to our window content area.
+              const resetWebampPositions = () => {
+                const windows = ["#main-window", "#equalizer-window", "#playlist-window"];
+                windows.forEach(selector => {
+                  const el = document.querySelector(selector);
+                  if (el) {
+                    el.style.left = "0px";
+                    el.style.top = "0px";
+                  }
+                });
+              };
+              resetWebampPositions();
+
+              // Sync focus state
+              this.win.onFocus(() => {
+                const webampNode = document.getElementById("webamp");
+                if (webampNode) webampNode.classList.remove("webamp-inactive");
+              });
+              this.win.onBlur(() => {
+                const webampNode = document.getElementById("webamp");
+                if (webampNode) webampNode.classList.add("webamp-inactive");
+              });
+
+              // Initial focus state
+              const webampNodeInitial = document.getElementById("webamp");
+              if (webampNodeInitial) {
+                if (this.win.element.classList.contains("focused")) {
+                  webampNodeInitial.classList.remove("webamp-inactive");
+                } else {
+                  webampNodeInitial.classList.add("webamp-inactive");
+                }
+              }
+
+              // Support Shade Mode and Resizing of the system window to match Webamp
+              const updateWindowSize = () => {
+                const mainWin = document.getElementById("main-window");
+                if (mainWin) {
+                  const isShade = mainWin.classList.contains("shade");
+                  this.win.setDimensions({
+                    outerWidth: 275,
+                    outerHeight: isShade ? 14 : 116
+                  });
+                }
+              };
+
+              const mainWin = document.getElementById("main-window");
+              if (mainWin) {
+                this.shadeObserver = new MutationObserver(updateWindowSize);
+                this.shadeObserver.observe(mainWin, { attributes: true, attributeFilter: ["class"] });
+                updateWindowSize();
+              }
+
               this.showWebamp();
               handleFile(filePath);
-              resolve();
             })
-            .catch(reject);
+            .catch(err => console.error("WebampApp: render error", err));
         })
-        .catch(reject);
-    });
+        .catch(err => console.error("WebampApp: import error", err));
+    } catch (err) {
+      console.error("WebampApp: launch error", err);
+    }
   }
 
   showWebamp() {
@@ -221,6 +306,11 @@ export class WebampApp extends Application {
   _cleanup() {
     this._revokeBlobUrls();
     this.webampContainer = null;
+
+    if (this.shadeObserver) {
+      this.shadeObserver.disconnect();
+      this.shadeObserver = null;
+    }
 
     if (this.webampInstance) {
       this.webampInstance.dispose();

--- a/src/apps/webamp/webamp-app.js
+++ b/src/apps/webamp/webamp-app.js
@@ -1,18 +1,8 @@
 import { Application } from '../../system/application.js';
-import {
-  createTaskbarButton,
-  removeTaskbarButton,
-  updateTaskbarButton,
-} from '../../shell/taskbar/taskbar.js';
 import { ICONS } from '../../config/icons.js';
-import { appManager } from '../../system/app-manager.js';
 import { getWebampMenuItems } from './webamp.js';
 import { isZenFSPath, getZenFSFileUrl, getZenFSFileAsText } from '../../system/zenfs-utils.js';
-
-let webampInstance = null;
-let webampContainer = null;
-let webampTaskbarButton = null;
-let isMinimized = false;
+import './webamp.css';
 
 export class WebampApp extends Application {
   static config = {
@@ -35,6 +25,8 @@ export class WebampApp extends Application {
     super(config);
     this.hasTaskbarButton = true;
     this.blobUrls = [];
+    this.webampInstance = null;
+    this.webampContainer = null;
   }
 
   _revokeBlobUrls() {
@@ -43,14 +35,28 @@ export class WebampApp extends Application {
   }
 
   _createWindow() {
-    // Webamp doesn't use a standard OS-GUI window, it renders directly to the body.
-    // We manage its container and lifecycle here.
-    return null; // Return null to prevent default window creation.
+    const win = new $Window({
+      title: this.title,
+      icons: this.icon,
+      resizable: false,
+      maximizable: false,
+      width: 275,
+      height: 116,
+    });
+    win.element.classList.add("webamp-window");
+
+    // Disable window animations for Webamp
+    win.animateTitlebar = (from, to, callback) => {
+      if (callback) callback();
+    };
+
+    return win;
   }
 
   async _onLaunch(filePath) {
     const handleFile = async (path) => {
       if (!path) return;
+      if (!this.webampInstance) return;
 
       if (path instanceof File) {
         const track = {
@@ -60,7 +66,7 @@ export class WebampApp extends Application {
           },
           url: URL.createObjectURL(path),
         };
-        webampInstance.setTracksToPlay([track]);
+        this.webampInstance.setTracksToPlay([track]);
         return;
       }
 
@@ -101,7 +107,7 @@ export class WebampApp extends Application {
                 url: url,
               };
             }));
-            webampInstance.setTracksToPlay(tracks);
+            this.webampInstance.setTracksToPlay(tracks);
           } catch (error) {
             console.error("Error loading M3U playlist:", error);
           }
@@ -120,7 +126,7 @@ export class WebampApp extends Application {
             },
             url: url,
           };
-          webampInstance.setTracksToPlay([track]);
+          this.webampInstance.setTracksToPlay([track]);
         }
       } else if (path && typeof path === "object") {
         // Handle virtual file object (e.g. from briefcase)
@@ -131,32 +137,19 @@ export class WebampApp extends Application {
           },
           url: path.contentUrl || path.content,
         };
-        webampInstance.setTracksToPlay([track]);
+        this.webampInstance.setTracksToPlay([track]);
       }
     };
 
-    if (webampInstance) {
+    if (this.webampInstance) {
       this.showWebamp();
       handleFile(filePath);
       return;
     }
 
     return new Promise((resolve, reject) => {
-      webampContainer = document.createElement("div");
-      webampContainer.id = "webamp-container";
-      webampContainer.style.position = "absolute";
-      webampContainer.style.zIndex = $Window.Z_INDEX++;
-      webampContainer.style.left = "50px";
-      webampContainer.style.top = "50px";
-      document.body.appendChild(webampContainer);
-
-      webampContainer.addEventListener(
-        "mousedown",
-        () => {
-          webampContainer.style.zIndex = $Window.Z_INDEX++;
-        },
-        true,
-      );
+      this.webampContainer = this.win.$content[0];
+      this.webampContainer.id = "webamp-container";
 
       const initialTracks = [
         {
@@ -172,7 +165,7 @@ export class WebampApp extends Application {
         .then((Webamp) => {
           const { default: WebampClass } = Webamp;
 
-          webampInstance = new WebampClass({
+          this.webampInstance = new WebampClass({
             availableSkins: [
               {
                 url: "https://archive.org/cors/winampskin_Expensive_Hi-Fi_1_2/ExpensiveHi-Fi.wsz",
@@ -190,16 +183,15 @@ export class WebampApp extends Application {
             initialTracks,
           });
 
-          webampInstance.onMinimize(() => this.minimizeWebamp());
-          webampInstance.onClose(() => appManager.closeApp(this.id));
+          this.webampInstance.onMinimize(() => this.win.minimize());
+          this.webampInstance.onClose(() => this.win.close());
 
-          webampInstance
-            .renderWhenReady(webampContainer)
+          this.webampInstance
+            .renderWhenReady(this.webampContainer)
             .then(() => {
-              this.setupTaskbarButton();
               this.showWebamp();
               handleFile(filePath);
-              resolve(); // Resolve the promise once Webamp is ready
+              resolve();
             })
             .catch(reject);
         })
@@ -207,68 +199,32 @@ export class WebampApp extends Application {
     });
   }
 
-  setupTaskbarButton() {
-    const taskbarButtonId = "webamp-taskbar-button";
-    webampTaskbarButton = createTaskbarButton(
-      taskbarButtonId,
-      ICONS.webamp,
-      "Winamp",
-    );
-
-    if (webampTaskbarButton) {
-      webampTaskbarButton.addEventListener("click", (event) => {
-        event.preventDefault();
-        event.stopPropagation();
-        if (isMinimized) {
-          this.showWebamp();
-        } else {
-          this.minimizeWebamp();
-        }
-      });
-    }
-  }
-
   showWebamp() {
-    const webampElement = document.getElementById("webamp");
-    if (!webampElement) return;
-
-    webampElement.style.display = "block";
-    webampElement.style.visibility = "visible";
-    isMinimized = false;
-    webampContainer.style.zIndex = $Window.Z_INDEX++;
-    if (webampTaskbarButton) {
-      updateTaskbarButton("webamp-taskbar-button", true, false);
+    if (this.win) {
+      this.win.unminimize();
+      this.win.focus();
     }
   }
 
   minimizeWebamp() {
-    const webampElement = document.getElementById("webamp");
-    if (!webampElement) return;
+    if (this.win) {
+      this.win.minimize();
+    }
+  }
 
-    webampElement.style.display = "none";
-    webampElement.style.visibility = "hidden";
-    isMinimized = true;
-    if (webampTaskbarButton) {
-      updateTaskbarButton("webamp-taskbar-button", false, true);
+  close() {
+    if (this.win) {
+      this.win.close();
     }
   }
 
   _cleanup() {
     this._revokeBlobUrls();
-    if (webampContainer) {
-      webampContainer.remove();
-      webampContainer = null;
-    }
+    this.webampContainer = null;
 
-    if (webampInstance) {
-      webampInstance.dispose();
-      webampInstance = null;
+    if (this.webampInstance) {
+      this.webampInstance.dispose();
+      this.webampInstance = null;
     }
-
-    if (webampTaskbarButton) {
-      removeTaskbarButton("webamp-taskbar-button");
-      webampTaskbarButton = null;
-    }
-    isMinimized = false;
   }
 }

--- a/src/apps/webamp/webamp.css
+++ b/src/apps/webamp/webamp.css
@@ -2,6 +2,7 @@
     background: transparent !important;
     border: none !important;
     box-shadow: none !important;
+    pointer-events: none !important;
 }
 
 .webamp-window .window-titlebar {
@@ -13,11 +14,20 @@
     margin: 0 !important;
     overflow: visible !important;
     background: transparent !important;
+    pointer-events: auto !important;
 }
 
-/* Ensure Webamp container doesn't have its own positioning that conflicts with the window */
 #webamp-container {
-    position: relative !important;
+    position: absolute !important;
     top: 0 !important;
     left: 0 !important;
+}
+
+#webamp {
+    position: absolute !important;
+}
+
+#webamp.webamp-inactive .window,
+#webamp.webamp-inactive .gen-window {
+    filter: saturate(0.5) brightness(0.9);
 }

--- a/src/apps/webamp/webamp.css
+++ b/src/apps/webamp/webamp.css
@@ -1,0 +1,23 @@
+.webamp-window {
+    background: transparent !important;
+    border: none !important;
+    box-shadow: none !important;
+}
+
+.webamp-window .window-titlebar {
+    display: none !important;
+}
+
+.webamp-window .window-content {
+    padding: 0 !important;
+    margin: 0 !important;
+    overflow: visible !important;
+    background: transparent !important;
+}
+
+/* Ensure Webamp container doesn't have its own positioning that conflicts with the window */
+#webamp-container {
+    position: relative !important;
+    top: 0 !important;
+    left: 0 !important;
+}


### PR DESCRIPTION
This change transforms Webamp from a custom floating element into a standard windowed application within the azOS framework. By utilizing the base Application class's window management and a standard $Window instance with a hidden frame, Webamp now correctly participates in the system's focus tracking, z-ordering, and taskbar synchronization. 

Key changes:
1. Created `src/apps/webamp/webamp.css` to hide the title bar, borders, and shadows of the Webamp window.
2. Updated `WebampApp` to return a `$Window` from `_createWindow`.
3. Overrode `win.animateTitlebar` to satisfy the "no animation" requirement.
4. Hooked Webamp's internal minimize and close events to the system window's methods.
5. Removed redundant manual taskbar button management.
6. Moved singleton state into instance properties for better encapsulation.

---
*PR created automatically by Jules for task [755494253140618030](https://jules.google.com/task/755494253140618030) started by @azayrahmad*