### PR TITLE
Rename drives to labels when copying/pasting

### DIFF
--- a/e2e/drive_copy_naming.spec.js
+++ b/e2e/drive_copy_naming.spec.js
@@ -1,0 +1,110 @@
+import { test, expect } from '@playwright/test';
+
+test.describe('Drive Copy-Paste Naming', () => {
+    test.beforeEach(async ({ page }) => {
+        test.setTimeout(120000);
+        await page.goto('http://localhost:5173/win98-web/');
+
+        // Wait for the "Press any key to continue" boot prompt
+        await page.waitForTimeout(5000);
+        await page.keyboard.press('Enter');
+
+        // Wait for the desktop to be ready
+        const desktop = page.locator('.desktop');
+        await expect(desktop).toBeVisible({ timeout: 60000 });
+
+        // Ensure launchApp is available
+        await page.waitForFunction(() => typeof window.System?.launchApp === 'function');
+    });
+
+    test('Copying A: drive should paste as "3½ Floppy"', async ({ page }) => {
+        // Launch ZenExplorer to My Computer (root)
+        await page.evaluate(() => {
+            window.System.launchApp('explorer', '/');
+        });
+
+        const explorerWin = page.locator('.window[data-app-id="explorer"]').first();
+        await expect(explorerWin).toBeVisible();
+
+        // Find A: icon
+        const aDriveIcon = explorerWin.locator('.explorer-icon[data-path="/A:"]');
+        await expect(aDriveIcon).toBeVisible();
+
+        // Copy A: drive
+        await aDriveIcon.click({ button: 'right' });
+        await page.getByRole('menuitem', { name: 'Copy', exact: true }).click();
+
+        // Navigate to C:/WINDOWS/Desktop (easier to verify)
+        await page.evaluate(() => {
+            const app = Object.values(window.System.appManager.runningApps).find(a => a.config.id === 'explorer');
+            app.navigateTo('/C:/WINDOWS/Desktop');
+        });
+
+        // Wait for navigation
+        await expect(explorerWin.locator('.sidebar-title')).toHaveText('Desktop');
+
+        // Paste
+        await explorerWin.locator('.explorer-icon-view').click({ button: 'right' });
+        await page.getByRole('menuitem', { name: 'Paste', exact: true }).click();
+
+        // Wait for paste to complete (it might take a while because it tries to copy recursively,
+        // but we only care about the folder being created with the right name initially)
+        // Actually, pasteItems in file-operations.js waits for copyRecursive to finish.
+        // Copying C: might be slow.
+
+        // Let's check for the icon. It should appear once the folder is created.
+        await page.waitForFunction((winSelector) => {
+            const icons = document.querySelectorAll(`${winSelector} .explorer-icon`);
+            const names = Array.from(icons).map(i => i.getAttribute('data-name'));
+            return names.includes('3½ Floppy');
+        }, '.window[data-app-id="explorer"]', { timeout: 30000 });
+
+        const floppyFolder = explorerWin.locator('.explorer-icon[data-name="3½ Floppy"]');
+        await expect(floppyFolder).toBeVisible();
+
+        // Copy A: drive again
+        await page.evaluate(() => {
+            const app = Object.values(window.System.appManager.runningApps).find(a => a.config.id === 'explorer');
+            app.navigateTo('/');
+        });
+        await expect(explorerWin.locator('.sidebar-title')).toHaveText('My Computer');
+        const aDriveIcon2 = explorerWin.locator('.explorer-icon[data-path="/A:"]');
+        await aDriveIcon2.click({ button: 'right' });
+        await page.getByRole('menuitem', { name: 'Copy', exact: true }).click();
+
+        // Navigate back to Desktop
+        await page.evaluate(() => {
+            const app = Object.values(window.System.appManager.runningApps).find(a => a.config.id === 'explorer');
+            app.navigateTo('/C:/WINDOWS/Desktop');
+        });
+        await expect(explorerWin.locator('.sidebar-title')).toHaveText('Desktop');
+
+        // Paste again
+        await explorerWin.locator('.explorer-icon-view').click({ button: 'right' });
+        await page.getByRole('menuitem', { name: 'Paste', exact: true }).click();
+
+        // Check for "Copy of 3½ Floppy"
+        await page.waitForFunction((winSelector) => {
+            const icons = document.querySelectorAll(`${winSelector} .explorer-icon`);
+            const names = Array.from(icons).map(i => i.getAttribute('data-name'));
+            return names.includes('Copy of 3½ Floppy');
+        }, '.window[data-app-id="explorer"]', { timeout: 30000 });
+
+        const copyOfFloppyFolder = explorerWin.locator('.explorer-icon[data-name="Copy of 3½ Floppy"]');
+        await expect(copyOfFloppyFolder).toBeVisible();
+
+        // Paste Shortcut
+        await explorerWin.locator('.explorer-icon-view').click({ button: 'right' });
+        await page.getByRole('menuitem', { name: 'Paste Shortcut', exact: true }).click();
+
+        // Check for "Shortcut to A:.lnk.json" (or "Shortcut to A:")
+        await page.waitForFunction((winSelector) => {
+            const icons = document.querySelectorAll(`${winSelector} .explorer-icon`);
+            const names = Array.from(icons).map(i => i.getAttribute('data-name'));
+            return names.includes('Shortcut to A:.lnk.json');
+        }, '.window[data-app-id="explorer"]', { timeout: 30000 });
+
+        const shortcutToA = explorerWin.locator('.explorer-icon[data-name="Shortcut to A:.lnk.json"]');
+        await expect(shortcutToA).toBeVisible();
+    });
+});

--- a/src/shell/explorer/file-operations/file-operations.js
+++ b/src/shell/explorer/file-operations/file-operations.js
@@ -6,7 +6,7 @@ import {
 import { ShowDialogWindow } from '../../../shared/components/dialog-window.js';
 import { showInputDialog } from '../interface/input-dialog.js';
 import { handleFileSystemError } from './error-handler.js';
-import { joinPath, normalizePath, getPathName, getParentPath } from '../navigation/path-utils.js';
+import { joinPath, normalizePath, getPathName, getParentPath, getDriveLabel } from '../navigation/path-utils.js';
 import { ShellManager } from '../extensions/shell-manager.js';
 import ClipboardManager from './clipboard-manager.js';
 import { RecycleBinManager } from './recycle-bin-manager.js';
@@ -197,6 +197,15 @@ export class FileOperations {
     }
 
     async getUniquePastePath(destPath, originalName, operation, sourcePath = null) {
+        let effectiveName = originalName;
+
+        if (operation !== "shortcut" && sourcePath) {
+            const driveLabel = getDriveLabel(sourcePath);
+            if (driveLabel) {
+                effectiveName = driveLabel;
+            }
+        }
+
         if (operation === "shortcut") {
             const cleanName = originalName.replace(".lnk.json", "").replace(".lnk", "");
             let candidateName = `Shortcut to ${cleanName}.lnk.json`;
@@ -215,7 +224,7 @@ export class FileOperations {
             } catch (e) { return checkPath; }
         }
 
-        let checkPath = normalizePath(joinPath(destPath, originalName));
+        let checkPath = normalizePath(joinPath(destPath, effectiveName));
 
         if (operation === "cut" && sourcePath && normalizePath(sourcePath) === normalizePath(checkPath)) {
             return checkPath;
@@ -227,14 +236,14 @@ export class FileOperations {
             return checkPath;
         }
         if (operation === "cut") {
-            let name = originalName;
+            let name = effectiveName;
             let counter = 1;
-            const extensionIndex = originalName.lastIndexOf('.');
+            const extensionIndex = effectiveName.lastIndexOf('.');
             const hasExtension = extensionIndex > 0;
-            const baseName = hasExtension ? originalName.substring(0, extensionIndex) : originalName;
-            const ext = hasExtension ? originalName.substring(extensionIndex) : '';
+            const baseName = hasExtension ? effectiveName.substring(0, extensionIndex) : effectiveName;
+            const ext = hasExtension ? effectiveName.substring(extensionIndex) : '';
             while (true) {
-                name = hasExtension ? `${baseName} (${counter})${ext}` : `${originalName} (${counter})`;
+                name = hasExtension ? `${baseName} (${counter})${ext}` : `${effectiveName} (${counter})`;
                 checkPath = normalizePath(joinPath(destPath, name));
                 try {
                     await fs.promises.stat(checkPath);
@@ -244,10 +253,10 @@ export class FileOperations {
         } else {
             const copyNOfRegex = /^Copy \((\d+)\) of (.*)$/;
             const copyOfRegex = /^Copy of (.*)$/;
-            let baseName = originalName;
+            let baseName = effectiveName;
             let match;
-            if ((match = originalName.match(copyNOfRegex))) baseName = match[2];
-            else if ((match = originalName.match(copyOfRegex))) baseName = match[1];
+            if ((match = effectiveName.match(copyNOfRegex))) baseName = match[2];
+            else if ((match = effectiveName.match(copyOfRegex))) baseName = match[1];
             let candidateName = `Copy of ${baseName}`;
             checkPath = normalizePath(joinPath(destPath, candidateName));
             try {

--- a/src/shell/explorer/navigation/path-utils.js
+++ b/src/shell/explorer/navigation/path-utils.js
@@ -90,3 +90,28 @@ export function getDisplayName(path) {
     }
     return name || path;
 }
+
+/**
+ * Get the human-readable label for a drive without the drive letter
+ * @param {string} path - Path to get label for
+ * @returns {string|null} - Label if it's a drive, null otherwise
+ */
+export function getDriveLabel(path) {
+    if (!path) return null;
+    const name = getPathName(path);
+
+    if (!name || !name.match(/^[A-Z]:$/i) || path === "My Computer") return null;
+
+    if (name.match(/^A:$/i)) {
+        return FloppyManager.getLabel() || "3½ Floppy";
+    }
+    if (name.match(/^E:$/i)) {
+        return CDManager.getLabel() || "CD-ROM";
+    }
+    if (name.match(/^C:$/i)) {
+        return "Local Disk";
+    }
+
+    const letter = name.charAt(0).toUpperCase();
+    return RemovableDiskManager.getLabel(letter) || "Removable Disk";
+}


### PR DESCRIPTION
Renamed drives to their labels when pasted as folders, while keeping drive letters for shortcuts. Added a new E2E test to verify the fix.

---
*PR created automatically by Jules for task [1390665194550325999](https://jules.google.com/task/1390665194550325999) started by @azayrahmad*