### PR TITLE
Implement 1s delayed close for submenus

### DIFF
--- a/public/os-gui/MenuPopup.js
+++ b/public/os-gui/MenuPopup.js
@@ -31,10 +31,52 @@
 
     this.element = menu_popup_el;
     let submenus = [];
+    let close_tid;
+
+    const close_submenus_at_this_level = () => {
+      for (const { submenu_popup, submenu_popup_el, item_el } of submenus) {
+        submenu_popup.close(false);
+        submenu_popup_el.classList.remove("open");
+        item_el.setAttribute("aria-expanded", "false");
+      }
+      menu_popup_el.focus({ preventScroll: true });
+    };
 
     menu_popup_el.addEventListener("keydown", options.handleKeyDown);
 
+    menu_popup_el.addEventListener("pointerover", (event) => {
+      const hovered_item_el = event.target.closest(".menu-item");
+      if (
+        hovered_item_el &&
+        hovered_item_el.classList.contains("has-submenu")
+      ) {
+        if (close_tid) {
+          clearTimeout(close_tid);
+          close_tid = null;
+        }
+        return;
+      }
+      // If we are over a non-submenu item, a separator, or the menu itself
+      if (!close_tid) {
+        const any_submenu_open = submenus.some((s) =>
+          s.submenu_popup_el.classList.contains("open"),
+        );
+        if (any_submenu_open) {
+          close_tid = setTimeout(() => {
+            if (!window.debugKeepMenusOpen) {
+              close_submenus_at_this_level();
+            }
+            close_tid = null;
+          }, 1000);
+        }
+      }
+    });
+
     menu_popup_el.addEventListener("pointerleave", () => {
+      if (close_tid) {
+        clearTimeout(close_tid);
+        close_tid = null;
+      }
       for (const submenu of submenus) {
         if (submenu.submenu_popup_el.classList.contains("open")) {
           this.highlight(submenu.item_el);
@@ -302,20 +344,7 @@
             submenu_popup_el,
             submenu_popup,
           });
-          function close_submenus_at_this_level() {
-            for (const {
-              submenu_popup,
-              submenu_popup_el,
-              item_el,
-            } of submenus) {
-              submenu_popup.close(false);
-              submenu_popup_el.classList.remove("open");
-              item_el.setAttribute("aria-expanded", "false");
-            }
-            menu_popup_el.focus({ preventScroll: true });
-          }
           let open_tid;
-          let close_tid;
           submenu_popup_el.addEventListener("pointerenter", () => {
             if (open_tid) {
               clearTimeout(open_tid);
@@ -341,26 +370,6 @@
             if (open_tid) {
               clearTimeout(open_tid);
               open_tid = null;
-            }
-          });
-          menu_popup_el.addEventListener("pointerenter", (event) => {
-            if (event.target.closest(".menu-item") === item_el) {
-              return;
-            }
-            if (!close_tid) {
-              if (submenu_popup_el.classList.contains("open")) {
-                close_tid = setTimeout(() => {
-                  if (!window.debugKeepMenusOpen) {
-                    close_submenus_at_this_level();
-                  }
-                }, 500);
-              }
-            }
-          });
-          menu_popup_el.addEventListener("pointerleave", () => {
-            if (close_tid) {
-              clearTimeout(close_tid);
-              close_tid = null;
             }
           });
           item_el.addEventListener("pointerdown", () => {

--- a/src/shell/start-menu/start-menu.js
+++ b/src/shell/start-menu/start-menu.js
@@ -37,6 +37,7 @@ class StartMenu {
     this.isVisible = false;
     this.eventListeners = new Map();
     this.openSubmenus = [];
+    this.submenuCloseTimeout = null;
   }
 
   /**
@@ -134,11 +135,55 @@ class StartMenu {
     this.bindKeyboardEvents();
     this.bindOutsideClickEvents();
     this.bindMenuItems();
+    this.bindHoverDelay();
+  }
+
+  bindHoverDelay() {
+    const startMenu = document.querySelector(SELECTORS.START_MENU);
+    if (!startMenu) return;
+
+    this.addTrackedEventListener(startMenu, "pointerover", (e) => {
+      const menuItem = e.target.closest(".start-menu-item");
+      const hasSubmenu = menuItem?.classList.contains("has-submenu");
+
+      if (!menuItem || !hasSubmenu) {
+        // Trigger delayed close if there are open submenus
+        if (this.openSubmenus.length > 0 && !this.submenuCloseTimeout) {
+          this.submenuCloseTimeout = setTimeout(() => {
+            this.closeAllSubmenus();
+            this.submenuCloseTimeout = null;
+          }, 1000);
+        }
+      } else {
+        // We are hovering an item with a submenu.
+        // The item's own pointerenter will handle opening/clearing.
+        if (this.submenuCloseTimeout) {
+          clearTimeout(this.submenuCloseTimeout);
+          this.submenuCloseTimeout = null;
+        }
+      }
+    });
+
+    this.addTrackedEventListener(startMenu, "pointerleave", () => {
+      if (this.submenuCloseTimeout) {
+        clearTimeout(this.submenuCloseTimeout);
+        this.submenuCloseTimeout = null;
+      }
+    });
+  }
+
+  closeAllSubmenus() {
+    this.openSubmenus.forEach((menu) => {
+      menu.close();
+      if (menu.wrapperElement && menu.wrapperElement.parentElement) {
+        menu.wrapperElement.remove();
+      }
+    });
+    this.openSubmenus = [];
   }
 
   attachSubmenu(menuItem, submenuItems) {
     let activeMenu = null;
-    let closeTimeout;
 
     const closeAndCleanup = () => {
       if (!activeMenu) return;
@@ -156,19 +201,14 @@ class StartMenu {
     };
 
     const openMenu = () => {
-      clearTimeout(closeTimeout);
+      if (this.submenuCloseTimeout) {
+        clearTimeout(this.submenuCloseTimeout);
+        this.submenuCloseTimeout = null;
+      }
       if (activeMenu) return;
 
       // Close any other open submenus immediately
-      if (this.openSubmenus.length > 0) {
-        [...this.openSubmenus].forEach((menu) => {
-          menu.close();
-          if (menu.wrapperElement && menu.wrapperElement.parentElement) {
-            menu.wrapperElement.remove();
-          }
-        });
-        this.openSubmenus = [];
-      }
+      this.closeAllSubmenus();
 
       const menuWrapper = document.createElement("div");
       menuWrapper.className = "menu-popup-wrapper start-menu-popup";
@@ -220,7 +260,10 @@ class StartMenu {
       if (typeof window.playSound === "function") window.playSound("MenuPopup");
       this.openSubmenus.push(activeMenu);
       this.addTrackedEventListener(menuWrapper, "pointerenter", () => {
-        clearTimeout(closeTimeout);
+        if (this.submenuCloseTimeout) {
+          clearTimeout(this.submenuCloseTimeout);
+          this.submenuCloseTimeout = null;
+        }
       });
     };
 
@@ -229,7 +272,6 @@ class StartMenu {
 
   attachDynamicSubmenu(menuItem, getSubmenuItems) {
     let activeMenu = null;
-    let closeTimeout;
     let isLoading = false;
 
     const closeAndCleanup = () => {
@@ -248,19 +290,14 @@ class StartMenu {
     };
 
     const openMenu = async () => {
-      clearTimeout(closeTimeout);
+      if (this.submenuCloseTimeout) {
+        clearTimeout(this.submenuCloseTimeout);
+        this.submenuCloseTimeout = null;
+      }
       if (isLoading || activeMenu) return;
 
       isLoading = true;
-      if (this.openSubmenus.length > 0) {
-        [...this.openSubmenus].forEach((menu) => {
-          menu.close();
-          if (menu.wrapperElement && menu.wrapperElement.parentElement) {
-            menu.wrapperElement.remove();
-          }
-        });
-        this.openSubmenus = [];
-      }
+      this.closeAllSubmenus();
 
       let submenuItems;
       try {
@@ -322,7 +359,10 @@ class StartMenu {
       this.openSubmenus.push(activeMenu);
       isLoading = false;
       this.addTrackedEventListener(menuWrapper, "pointerenter", () => {
-        clearTimeout(closeTimeout);
+        if (this.submenuCloseTimeout) {
+          clearTimeout(this.submenuCloseTimeout);
+          this.submenuCloseTimeout = null;
+        }
       });
     };
 
@@ -513,13 +553,7 @@ class StartMenu {
     startButton.setAttribute("aria-pressed", "false");
     this.isVisible = false;
 
-    this.openSubmenus.forEach((menu) => {
-      menu.close();
-      if (menu.wrapperElement && menu.wrapperElement.parentElement) {
-        menu.wrapperElement.remove();
-      }
-    });
-    this.openSubmenus = [];
+    this.closeAllSubmenus();
   }
 
   /**


### PR DESCRIPTION
This change implements a 1-second delay for closing submenus when the user hovers over a non-submenu item, a separator, or the menu background. This applies to both right-click/top-bar menus (MenuPopup) and the Windows Start Menu. The switching between items that both have submenus remains immediate for a smooth navigation experience. The logic was centralized and refactored in both components for better consistency and performance.

---
*PR created automatically by Jules for task [13321589313385119488](https://jules.google.com/task/13321589313385119488) started by @azayrahmad*