### PR TITLE
Fix overlapping cards in FreeCell foundation

### DIFF
--- a/src/apps/freecell/free-cell-app.js
+++ b/src/apps/freecell/free-cell-app.js
@@ -800,23 +800,21 @@ export class FreeCellApp extends Application {
 
   async startAutoMove() {
     this.isAnimating = true;
-    let moves;
-    while ((moves = this.game.findAllFoundationMoves()).length > 0) {
-      for (const move of moves) {
-        if (!this.options.get("quickPlay")) {
-          // Hide the original card
-          move.card.element.style.opacity = "0";
+    let move;
+    while ((move = this.game.findNextFoundationMove())) {
+      if (!this.options.get("quickPlay")) {
+        // Hide the original card
+        move.card.element.style.opacity = "0";
 
-          // Animate the move
-          await this.animateMove([move.card], move.toType, move.toIndex);
-        }
-
-        // Update the game state
-        this.game.moveCard(move.card, move.from, move.toType, move.toIndex);
-
-        // Re-render the board to reflect the move
-        this.render();
+        // Animate the move
+        await this.animateMove([move.card], move.toType, move.toIndex);
       }
+
+      // Update the game state
+      this.game.moveCard(move.card, move.from, move.toType, move.toIndex);
+
+      // Re-render the board to reflect the move
+      this.render();
     }
     this.isAnimating = false;
 

--- a/src/apps/freecell/game.js
+++ b/src/apps/freecell/game.js
@@ -116,7 +116,7 @@ export class Game {
 
   hasLegalMoves() {
     // 1. Check for moves to the foundation piles
-    if (this.findAllFoundationMoves().length > 0) {
+    if (this.findNextFoundationMove()) {
       return true;
     }
 
@@ -243,8 +243,12 @@ export class Game {
     return true;
   }
 
-  findAllFoundationMoves() {
-    const moves = [];
+  /**
+   * Finds the first available move to the foundation.
+   * By returning only one move at a time, we ensure that auto-moves
+   * are processed sequentially and each card finds its correct slot.
+   */
+  findNextFoundationMove() {
     const candidates = [];
 
     // Gather candidate cards from free cells
@@ -266,18 +270,17 @@ export class Game {
     for (const candidate of candidates) {
       for (let i = 0; i < this.foundationPiles.length; i++) {
         if (this.isFoundationMoveValid(candidate.card, this.foundationPiles[i])) {
-          moves.push({
+          return {
             card: candidate.card,
             from: candidate.from,
             toType: 'foundation',
             toIndex: i
-          });
-          break; // Move to the next candidate once a valid foundation is found
+          };
         }
       }
     }
 
-    return moves;
+    return null;
   }
 
   // --- Supermoves (moving a stack of cards) ---


### PR DESCRIPTION
The FreeCell foundation overlapping issue was caused by the batch processing of foundation moves. When two or more cards were eligible for an empty foundation (e.g., two Aces), they both identified the same first empty slot as their destination.

By refactoring the logic to find and execute only one move at a time, we ensure that each subsequent move calculation takes into account the slots already filled by previous moves. This results in the cards being placed in separate slots as intended.

Verified the fix with both a logic simulation script and a visual Playwright screenshot showing two Aces in separate foundation slots.

---
*PR created automatically by Jules for task [8274903840313570177](https://jules.google.com/task/8274903840313570177) started by @azayrahmad*