### PR TITLE
Ensure maximized windows resize when screen resizes

### DIFF
--- a/public/os-gui/$Window.js
+++ b/public/os-gui/$Window.js
@@ -1647,7 +1647,26 @@ You can also disable this warning by passing {iframes: {ignoreCrossOrigin: true}
       $w.applyBounds();
     };
 
-    $G.on("resize", $w.bringTitleBarInBounds);
+    $w.onResize = () => {
+      $w.bringTitleBarInBounds();
+      if ($w.hasClass("maximized")) {
+        const screen = document.getElementById("desktop-area");
+        if (screen) {
+          const screenRect = screen.getBoundingClientRect();
+          $w.css({
+            width: screenRect.width,
+            height: screenRect.height,
+          });
+        }
+      }
+    };
+    $G.on("resize", $w.onResize);
+
+    const desktopArea = document.getElementById("desktop-area");
+    if (desktopArea && window.ResizeObserver) {
+      $w.desktopResizeObserver = new ResizeObserver($w.onResize);
+      $w.desktopResizeObserver.observe(desktopArea);
+    }
 
     /** @type {number} */
     var drag_offset_x;
@@ -2131,6 +2150,8 @@ You can also disable this warning by passing {iframes: {ignoreCrossOrigin: true}
 
       // MUST be after any events are triggered!
       $w.remove();
+      $G.off("resize", $w.onResize);
+      $w.desktopResizeObserver?.disconnect();
       document.removeEventListener("fullscreenchange", handleFullscreenChange);
 
       // TODO: support modals, which should focus what was focused before the modal was opened.

--- a/src/system/screen-manager.js
+++ b/src/system/screen-manager.js
@@ -58,6 +58,7 @@ function setResolution(resolutionId) {
 
   currentResolutionId = resolutionId;
   saveResolution(resolutionId);
+  window.dispatchEvent(new Event("resize"));
 }
 
 function saveResolution(resolutionId) {


### PR DESCRIPTION
This change ensures that any window in a maximized state will automatically resize to fill the desktop area if the screen size changes. This covers both browser window resizing (in "fit" resolution mode) and manual resolution changes (e.g., from Display Properties).

The implementation uses `ResizeObserver` to detect changes to the `#desktop-area` size, which provides a smooth experience even during CSS transitions of the `#screen` element. It also ensures that the "before maximize" state is preserved, so restoring a window after a screen resize still returns it to its original unmaximized dimensions.

---
*PR created automatically by Jules for task [5951370862825020481](https://jules.google.com/task/5951370862825020481) started by @azayrahmad*