### PR TITLE
Redirect My Computer Properties to About App & Add Version Check

### DIFF
--- a/src/apps/about/about-app.js
+++ b/src/apps/about/about-app.js
@@ -34,6 +34,31 @@ export class AboutApp extends Application {
         });
 
         win.$content.html(aboutContent);
+
+        this.checkVersion(win.$content.find('.version-status'));
+
         return win;
+    }
+
+    async checkVersion($status) {
+        try {
+            const response = await fetch('https://api.github.com/repos/azayrahmad/win98-web/releases/latest');
+            if (!response.ok) throw new Error('Failed to fetch version info');
+            const data = await response.json();
+
+            // Extract version number (e.g., "0.5.0" from "v0.5.0" or "win98-web-v0.5.0")
+            const versionMatch = data.tag_name.match(/(\d+\.\d+\.\d+)/);
+            const latestVersion = versionMatch ? versionMatch[1] : data.tag_name.replace(/^v/, '');
+            const currentVersion = import.meta.env.APP_VERSION;
+
+            if (latestVersion === currentVersion) {
+                $status.text('You are using the latest version.');
+            } else {
+                $status.html(`A new version is available: <b>${latestVersion}</b>`);
+            }
+        } catch (error) {
+            console.error('Version check failed:', error);
+            $status.text('Could not check for updates.');
+        }
     }
 }

--- a/src/apps/about/about.js
+++ b/src/apps/about/about.js
@@ -11,6 +11,7 @@ export const aboutContent = `
       <h1>Windows 98 Web Edition version ${version}</h1>
       <p>A web-based operating system based on Windows 98, with some quirks.</p>
       <p>Copyright (C) 1997-2025 Microsoft Corp. All rights reserved.</p>
+      <div class="version-status" style="margin-top: 16px; font-style: italic;">Checking for updates...</div>
     </div>
   </div>
 `;

--- a/src/shell/explorer/interface/context-menu-builder.js
+++ b/src/shell/explorer/interface/context-menu-builder.js
@@ -61,6 +61,16 @@ export class ContextMenuBuilder {
         {
           label: "Properties",
           action: async () => {
+            const isMyComputerSelected = selectedPaths.some(
+              (p) => p === "/" || p === "/Desktop/My Computer",
+            );
+            if (isMyComputerSelected) {
+              const { launchApp } = await import(
+                "../../../system/app-manager.js"
+              );
+              launchApp("about");
+              return;
+            }
             const busyId = `properties-${Math.random()}`;
             requestBusyState(busyId, this.app.win.element);
             try {
@@ -190,6 +200,16 @@ export class ContextMenuBuilder {
         {
           label: "Properties",
           action: async () => {
+            const isMyComputerSelected = selectedPaths.some(
+              (p) => p === "/" || p === "/Desktop/My Computer",
+            );
+            if (isMyComputerSelected) {
+              const { launchApp } = await import(
+                "../../../system/app-manager.js"
+              );
+              launchApp("about");
+              return;
+            }
             const busyId = `properties-${Math.random()}`;
             requestBusyState(busyId, this.app.win.element);
             try {
@@ -285,6 +305,16 @@ export class ContextMenuBuilder {
       {
         label: "Properties",
         action: async () => {
+          if (
+            this.app.currentPath === "/" ||
+            this.app.currentPath === "/Desktop/My Computer"
+          ) {
+            const { launchApp } = await import(
+              "../../../system/app-manager.js"
+            );
+            launchApp("about");
+            return;
+          }
           const busyId = `properties-${Math.random()}`;
           requestBusyState(busyId, this.app.win.element);
           try {

--- a/src/shell/explorer/interface/menu-bar-builder.js
+++ b/src/shell/explorer/interface/menu-bar-builder.js
@@ -240,14 +240,24 @@ export class MenuBarBuilder {
           const selectedPaths = [...selectedIcons].map((icon) =>
             icon.getAttribute("data-path"),
           );
+          const targets =
+            selectedPaths.length > 0 ? selectedPaths : [this.app.currentPath];
+          const isMyComputerSelected = targets.some(
+            (p) => p === "/" || p === "/Desktop/My Computer",
+          );
+
+          if (isMyComputerSelected) {
+            const { launchApp } = await import(
+              "../../../system/app-manager.js"
+            );
+            launchApp("about");
+            return;
+          }
+
           const busyId = `properties-${Math.random()}`;
           requestBusyState(busyId, this.app.win.element);
           try {
-            if (selectedPaths.length > 0) {
-              await PropertiesManager.show(selectedPaths);
-            } else {
-              await PropertiesManager.show([this.app.currentPath]);
-            }
+            await PropertiesManager.show(targets);
           } finally {
             releaseBusyState(busyId, this.app.win.element);
           }

--- a/src/shell/explorer/interface/toolbar-builder.js
+++ b/src/shell/explorer/interface/toolbar-builder.js
@@ -225,13 +225,20 @@ export function getToolbarItems(app) {
     {
       label: "Properties",
       iconName: "properties",
-      action: () => {
+      action: async () => {
         const paths = getSelectedPaths();
-        if (paths.length > 0) {
-          PropertiesManager.show(paths);
-        } else {
-          PropertiesManager.show([app.currentPath]);
+        const targets = paths.length > 0 ? paths : [app.currentPath];
+        const isMyComputerSelected = targets.some(
+          (p) => p === "/" || p === "/Desktop/My Computer",
+        );
+
+        if (isMyComputerSelected) {
+          const { launchApp } = await import("../../../system/app-manager.js");
+          launchApp("about");
+          return;
         }
+
+        PropertiesManager.show(targets);
       },
     },
     "divider",


### PR DESCRIPTION
This change redirects the "Properties" action for "My Computer" to the "About" app, as requested. This applies to the desktop icon, the Explorer background when viewing the root directory, and various menu/toolbar options. Additionally, the "About" app now automatically checks for updates via the GitHub API and displays whether the user is on the latest version or if a new one is available.

---
*PR created automatically by Jules for task [7685893774046411934](https://jules.google.com/task/7685893774046411934) started by @azayrahmad*