### PR TITLE
Add README and Changelog to About App

### DIFF
--- a/src/apps/about/about-app.js
+++ b/src/apps/about/about-app.js
@@ -1,135 +1,149 @@
-import { Application } from '../../system/application.js';
-import { aboutContent } from './about.js';
-import './about.css';
-import { ICONS } from '../../config/icons.js';
-import { renderHTML } from '../../shared/utils/dom-utils.js';
+import { Application } from "../../system/application.js";
+import { aboutContent } from "./about.js";
+import "./about.css";
+import { ICONS } from "../../config/icons.js";
+import { renderHTML } from "../../shared/utils/dom-utils.js";
 
-import readmeMarkdown from '../../../README.md?raw';
-import changelogMarkdown from '../../../CHANGELOG.md?raw';
+import readmeMarkdown from "../../../README.md?raw";
+import changelogMarkdown from "../../../CHANGELOG.md?raw";
 
 export class AboutApp extends Application {
-    static config = {
-        id: "about",
-        title: "About",
-        description: "Displays information about this application.",
-        summary: "<b>azOS Second Edition</b><br>Copyright © 2024",
-        icon: ICONS.windowsUpdate,
-        width: 400,
-        height: 280,
-        resizable: false,
-        minimizeButton: false,
-        maximizeButton: false,
-        isSingleton: true,
-    };
+  static config = {
+    id: "about",
+    title: "About",
+    description: "Displays information about this application.",
+    summary: "<b>azOS Second Edition</b><br>Copyright © 2024",
+    icon: ICONS.windowsUpdate,
+    width: 400,
+    height: 280,
+    resizable: false,
+    minimizeButton: false,
+    maximizeButton: false,
+    isSingleton: true,
+  };
 
-    constructor(config) {
-        super(config);
-    }
+  constructor(config) {
+    super(config);
+  }
 
-    _createWindow() {
-        const win = new $Window({
-            title: this.title,
-            outerWidth: this.width,
-            outerHeight: this.height,
-            resizable: this.resizable,
-            minimizeButton: this.minimizeButton,
-            maximizeButton: this.maximizeButton,
-            icons: this.icon,
-        });
+  _createWindow() {
+    const win = new $Window({
+      title: this.title,
+      outerWidth: this.width,
+      outerHeight: this.height,
+      resizable: this.resizable,
+      minimizeButton: this.minimizeButton,
+      maximizeButton: this.maximizeButton,
+      icons: ICONS.windows,
+    });
 
-        win.$content.html(aboutContent);
+    win.$content.html(aboutContent);
 
-        this.checkVersion(win.$content.find('.version-status'));
+    this.checkVersion(win.$content.find(".version-status"));
 
-        win.$content.find('#about-readme').on('click', () => this.openFile(readmeMarkdown, 'README'));
-        win.$content.find('#about-changelog').on('click', () => this.openFile(changelogMarkdown, 'Changelog'));
+    win.$content
+      .find("#about-readme")
+      .on("click", () => this.openFile(readmeMarkdown, "README"));
+    win.$content
+      .find("#about-changelog")
+      .on("click", () => this.openFile(changelogMarkdown, "Changelog"));
 
-        return win;
-    }
+    return win;
+  }
 
-    async openFile(markdown, title) {
-        const html = marked.parse(markdown);
-        const win = new $Window({
-            title: title,
-            width: 600,
-            height: 400,
-            resizable: true,
-            maximizeButton: true,
-            icons: ICONS.help,
-        });
+  async openFile(markdown, title) {
+    const html = marked.parse(markdown);
+    const win = new $Window({
+      title: title,
+      outerWidth: 600,
+      outerHeight: 400,
+      resizable: true,
+      maximizeButton: true,
+      icons: ICONS.windows,
+    });
 
-        const contentArea = document.createElement('div');
-        contentArea.className = 'about-file-content';
-        contentArea.style.height = '100%';
-        contentArea.style.padding = '8px';
-        contentArea.style.display = 'flex';
-        contentArea.style.flexDirection = 'column';
+    const contentArea = document.createElement("div");
+    contentArea.className = "about-file-content";
+    contentArea.style.height = "100%";
+    contentArea.style.padding = "8px";
+    contentArea.style.display = "flex";
+    contentArea.style.flexDirection = "column";
 
-        win.$content.append(contentArea);
-        renderHTML(contentArea, html, 'sunken-panel');
+    win.$content.append(contentArea);
+    renderHTML(contentArea, html, "sunken-panel");
 
-        const sunkenPanel = contentArea.querySelector('.sunken-panel');
-        if (sunkenPanel) {
-            sunkenPanel.style.flexGrow = '1';
-            sunkenPanel.style.overflowY = 'auto';
-            sunkenPanel.style.padding = '16px';
-            sunkenPanel.style.backgroundColor = 'white';
+    const sunkenPanel = contentArea.querySelector(".sunken-panel");
+    if (sunkenPanel) {
+      sunkenPanel.style.flexGrow = "1";
+      sunkenPanel.style.overflowY = "auto";
+      sunkenPanel.style.padding = "16px";
+      sunkenPanel.style.backgroundColor = "white";
 
-            // Ensure headings have IDs for anchor links
-            sunkenPanel.querySelectorAll('h1, h2, h3, h4, h5, h6').forEach(h => {
-                if (!h.id) {
-                    h.id = h.textContent.toLowerCase().replace(/[^\w]+/g, '-').replace(/^-+|-+$/g, '');
-                }
-            });
-
-            // Make external links open in new tab
-            sunkenPanel.querySelectorAll('a').forEach(a => {
-                const href = a.getAttribute('href');
-                if (href && /^https?:\/\//.test(href)) {
-                    a.target = '_blank';
-                    a.rel = 'noopener noreferrer';
-                }
-            });
-
-            // Handle anchor links scrolling within the panel
-            sunkenPanel.addEventListener('click', (e) => {
-                const link = e.target.closest('a');
-                if (link) {
-                    const href = link.getAttribute('href');
-                    if (href && href.startsWith('#')) {
-                        e.preventDefault();
-                        const id = href.substring(1);
-                        const targetEl = sunkenPanel.querySelector(`[id="${id}"], [name="${id}"]`);
-                        if (targetEl) {
-                            targetEl.scrollIntoView();
-                        }
-                    }
-                }
-            });
+      // Ensure headings have IDs for anchor links
+      sunkenPanel.querySelectorAll("h1, h2, h3, h4, h5, h6").forEach((h) => {
+        if (!h.id) {
+          h.id = h.textContent
+            .toLowerCase()
+            .replace(/[^\w]+/g, "-")
+            .replace(/^-+|-+$/g, "");
         }
+      });
 
-        win.center();
-    }
+      // Make external links open in new tab
+      sunkenPanel.querySelectorAll("a").forEach((a) => {
+        const href = a.getAttribute("href");
+        if (href && /^https?:\/\//.test(href)) {
+          a.target = "_blank";
+          a.rel = "noopener noreferrer";
+        }
+      });
 
-    async checkVersion($status) {
-        try {
-            const response = await fetch('https://api.github.com/repos/azayrahmad/win98-web/releases/latest');
-            if (!response.ok) throw new Error('Failed to fetch version info');
-            const data = await response.json();
-
-            // Extract version number (e.g., "0.5.0" from "v0.5.0" or "win98-web-v0.5.0")
-            const versionMatch = data.tag_name.match(/(\d+\.\d+\.\d+)/);
-            const latestVersion = versionMatch ? versionMatch[1] : data.tag_name.replace(/^v/, '');
-            const currentVersion = import.meta.env.APP_VERSION;
-
-            if (latestVersion === currentVersion) {
-                $status.text('You are using the latest version.');
-            } else {
-                $status.html(`A new version is available: <b>${latestVersion}</b>`);
+      // Handle anchor links scrolling within the panel
+      sunkenPanel.addEventListener("click", (e) => {
+        const link = e.target.closest("a");
+        if (link) {
+          const href = link.getAttribute("href");
+          if (href && href.startsWith("#")) {
+            e.preventDefault();
+            const id = href.substring(1);
+            const targetEl = sunkenPanel.querySelector(
+              `[id="${id}"], [name="${id}"]`,
+            );
+            if (targetEl) {
+              targetEl.scrollIntoView();
             }
-        } catch (error) {
-            console.error('Version check failed:', error);
-            $status.text('Could not check for updates.');
+          }
         }
+      });
     }
+
+    win.center();
+    win.focus();
+  }
+
+  async checkVersion($status) {
+    try {
+      const response = await fetch(
+        "https://api.github.com/repos/azayrahmad/win98-web/releases/latest",
+      );
+      if (!response.ok) throw new Error("Failed to fetch version info");
+      const data = await response.json();
+
+      // Extract version number (e.g., "0.5.0" from "v0.5.0" or "win98-web-v0.5.0")
+      const versionMatch = data.tag_name.match(/(\d+\.\d+\.\d+)/);
+      const latestVersion = versionMatch
+        ? versionMatch[1]
+        : data.tag_name.replace(/^v/, "");
+      const currentVersion = import.meta.env.APP_VERSION;
+
+      if (latestVersion === currentVersion) {
+        $status.text("You are using the latest version.");
+      } else {
+        $status.html(`A new version is available: <b>${latestVersion}</b>`);
+      }
+    } catch (error) {
+      console.error("Version check failed:", error);
+      $status.text("Could not check for updates.");
+    }
+  }
 }

--- a/src/apps/about/about-app.js
+++ b/src/apps/about/about-app.js
@@ -74,6 +74,38 @@ export class AboutApp extends Application {
             sunkenPanel.style.overflowY = 'auto';
             sunkenPanel.style.padding = '16px';
             sunkenPanel.style.backgroundColor = 'white';
+
+            // Ensure headings have IDs for anchor links
+            sunkenPanel.querySelectorAll('h1, h2, h3, h4, h5, h6').forEach(h => {
+                if (!h.id) {
+                    h.id = h.textContent.toLowerCase().replace(/[^\w]+/g, '-').replace(/^-+|-+$/g, '');
+                }
+            });
+
+            // Make external links open in new tab
+            sunkenPanel.querySelectorAll('a').forEach(a => {
+                const href = a.getAttribute('href');
+                if (href && /^https?:\/\//.test(href)) {
+                    a.target = '_blank';
+                    a.rel = 'noopener noreferrer';
+                }
+            });
+
+            // Handle anchor links scrolling within the panel
+            sunkenPanel.addEventListener('click', (e) => {
+                const link = e.target.closest('a');
+                if (link) {
+                    const href = link.getAttribute('href');
+                    if (href && href.startsWith('#')) {
+                        e.preventDefault();
+                        const id = href.substring(1);
+                        const targetEl = sunkenPanel.querySelector(`[id="${id}"], [name="${id}"]`);
+                        if (targetEl) {
+                            targetEl.scrollIntoView();
+                        }
+                    }
+                }
+            });
         }
 
         win.center();

--- a/src/apps/about/about-app.js
+++ b/src/apps/about/about-app.js
@@ -2,6 +2,10 @@ import { Application } from '../../system/application.js';
 import { aboutContent } from './about.js';
 import './about.css';
 import { ICONS } from '../../config/icons.js';
+import { renderHTML } from '../../shared/utils/dom-utils.js';
+
+import readmeMarkdown from '../../../README.md?raw';
+import changelogMarkdown from '../../../CHANGELOG.md?raw';
 
 export class AboutApp extends Application {
     static config = {
@@ -11,7 +15,7 @@ export class AboutApp extends Application {
         summary: "<b>azOS Second Edition</b><br>Copyright © 2024",
         icon: ICONS.windowsUpdate,
         width: 400,
-        height: 216,
+        height: 280,
         resizable: false,
         minimizeButton: false,
         maximizeButton: false,
@@ -37,7 +41,42 @@ export class AboutApp extends Application {
 
         this.checkVersion(win.$content.find('.version-status'));
 
+        win.$content.find('#about-readme').on('click', () => this.openFile(readmeMarkdown, 'README'));
+        win.$content.find('#about-changelog').on('click', () => this.openFile(changelogMarkdown, 'Changelog'));
+
         return win;
+    }
+
+    async openFile(markdown, title) {
+        const html = marked.parse(markdown);
+        const win = new $Window({
+            title: title,
+            width: 600,
+            height: 400,
+            resizable: true,
+            maximizeButton: true,
+            icons: ICONS.help,
+        });
+
+        const contentArea = document.createElement('div');
+        contentArea.className = 'about-file-content';
+        contentArea.style.height = '100%';
+        contentArea.style.padding = '8px';
+        contentArea.style.display = 'flex';
+        contentArea.style.flexDirection = 'column';
+
+        win.$content.append(contentArea);
+        renderHTML(contentArea, html, 'sunken-panel');
+
+        const sunkenPanel = contentArea.querySelector('.sunken-panel');
+        if (sunkenPanel) {
+            sunkenPanel.style.flexGrow = '1';
+            sunkenPanel.style.overflowY = 'auto';
+            sunkenPanel.style.padding = '16px';
+            sunkenPanel.style.backgroundColor = 'white';
+        }
+
+        win.center();
     }
 
     async checkVersion($status) {

--- a/src/apps/about/about.css
+++ b/src/apps/about/about.css
@@ -1,3 +1,70 @@
 .about-content h1 {
   font-size: var(--font-size-base);
 }
+
+.about-buttons {
+  display: flex;
+  justify-content: center;
+  gap: 8px;
+  padding: 16px;
+}
+
+.about-buttons button {
+  min-width: 80px;
+}
+
+.about-file-content {
+  box-sizing: border-box;
+}
+
+.about-file-content .sunken-panel {
+  user-select: text;
+  display: block;
+  width: 100%;
+  box-sizing: border-box;
+}
+
+.about-file-content h1,
+.about-file-content h2,
+.about-file-content h3,
+.about-file-content h4,
+.about-file-content h5,
+.about-file-content h6 {
+  display: block;
+  font-weight: bold;
+  margin-top: 1em;
+  margin-bottom: 0.5em;
+}
+
+.about-file-content h1 { font-size: 1.5em; }
+.about-file-content h2 { font-size: 1.3em; }
+.about-file-content h3 { font-size: 1.1em; }
+
+.about-file-content p,
+.about-file-content li {
+  font-size: var(--font-size-base);
+  line-height: 1.4;
+}
+
+.about-file-content ul {
+  padding-left: 20px;
+  margin-bottom: 1em;
+}
+
+.about-file-content code {
+  font-family: monospace;
+  background-color: #eee;
+  padding: 0 2px;
+}
+
+.about-file-content pre {
+  background-color: #eee;
+  padding: 10px;
+  overflow: auto;
+  border: 1px inset;
+}
+
+.about-file-content img {
+  max-width: 100%;
+  height: auto;
+}

--- a/src/apps/about/about.js
+++ b/src/apps/about/about.js
@@ -14,4 +14,8 @@ export const aboutContent = `
       <div class="version-status" style="margin-top: 16px; font-style: italic;">Checking for updates...</div>
     </div>
   </div>
+  <div class="about-buttons">
+    <button id="about-readme">README</button>
+    <button id="about-changelog">Changelog</button>
+  </div>
 `;


### PR DESCRIPTION
This change adds two buttons to the "About" application that allow users to view the project's README and Changelog files. The contents are rendered as HTML from the source Markdown files and displayed in new windows with a classic sunken panel and scrollable area. The windows are resizable and maximizable to accommodate the long content.

---
*PR created automatically by Jules for task [14640355062925016350](https://jules.google.com/task/14640355062925016350) started by @azayrahmad*