### PR TITLE
Fix Paint app relaunch and Exit issues

### DIFF
--- a/src/apps/paint/paint-app.js
+++ b/src/apps/paint/paint-app.js
@@ -238,6 +238,7 @@ export class PaintApp extends Application {
             this._setupDragAndDrop();
             this.initialized = true;
             $(window).trigger("resize");
+            $(window).trigger("option-changed");
             this.win.focus();
             if (data) {
                 this.openFile(data);

--- a/src/apps/paint/src/menus.js
+++ b/src/apps/paint/src/menus.js
@@ -251,7 +251,7 @@ const menus = {
 						// API contract is containing page can override window.close()
 						// Note that e.g. (()=>{}).bind().toString() gives "function () { [native code] }"
 						// so the window.close() must not use bind() (not that that's common practice anyway)
-						const close_overridden = frameElement && window.close && !/\{\s*\[native code\]\s*\}/.test(window.close.toString());
+						const close_overridden = window.close && !/\{\s*\[native code\]\s*\}/.test(window.close.toString());
 						if (close_overridden || window.is_electron_app) {
 							window.close();
 							return;


### PR DESCRIPTION
This PR fixes two issues in the Paint application:
1. **Transparent swatches on relaunch:** When Paint was closed and then relaunched, the foreground and background color swatches appeared transparent. This was because the swatches were being updated to 0x0 size while the application was detached from the DOM during disposal. I fixed this by triggering the `option-changed` event after re-attaching the application container upon relaunch, which forces a re-render with correct dimensions.
2. **"File > Exit" redirection:** The "Exit" menu item was redirecting users to 98.js.org instead of closing the window. This was due to a restrictive check that required `frameElement` to be present for `window.close()` to be called. Since Paint is integrated directly without an iframe, `frameElement` is null. I removed this check while keeping the safeguard that ensures `window.close` is overridden before calling it.

Verification:
- Created and ran a Playwright script that confirmed swatches have non-zero dimensions after relaunch.
- Verified that "File > Exit" closes the Paint window without redirecting.
- Visual verification via screenshots confirmed correct rendering.

---
*PR created automatically by Jules for task [10788314038691323302](https://jules.google.com/task/10788314038691323302) started by @azayrahmad*