### PR TITLE
Update Flash Player to use ZenFS and fix file association

### DIFF
--- a/src/apps/flash-player/flash-player-app.js
+++ b/src/apps/flash-player/flash-player-app.js
@@ -1,6 +1,8 @@
 import { Application } from '../../system/application.js';
 import { ICONS } from '../../config/icons.js';
 import { ShowDialogWindow } from '../../shared/components/dialog-window.js';
+import { ShowFilePicker } from "../../shared/utils/file-picker.js";
+import { SPECIAL_FOLDER_PATHS } from "../../config/special-folders.js";
 import "./flashplayer.css";
 import { isZenFSPath, getZenFSFileAsBlob } from '../../system/zenfs-utils.js';
 
@@ -72,17 +74,18 @@ export class FlashPlayerApp extends Application {
     }
   }
 
-  openFile() {
-    const input = document.createElement("input");
-    input.type = "file";
-    input.accept = ".swf";
-    input.onchange = (e) => {
-      const file = e.target.files[0];
-      if (file) {
-        this.loadSwf(file);
-      }
-    };
-    input.click();
+  async openFile() {
+    const path = await ShowFilePicker({
+      initialPath: SPECIAL_FOLDER_PATHS["my-documents"],
+      fileTypes: [
+        { label: "Flash Movies (*.swf)", extensions: ["swf"] },
+        { label: "All Files (*.*)", extensions: ["*"] },
+      ],
+    });
+
+    if (path) {
+      this.loadSwf(path);
+    }
   }
 
   loadSwf(fileData) {

--- a/src/config/file-associations.js
+++ b/src/config/file-associations.js
@@ -200,7 +200,7 @@ export const fileAssociations = {
   // Flash files
   swf: {
     name: "Shockwave Flash Movie",
-    appId: "flashplayer",
+    appId: "flash-player",
     icon: ICONS.swfFile,
   },
   // DOS Executables


### PR DESCRIPTION
This change updates the Flash Player application to use the system's `ShowFilePicker` utility, enabling users to open `.swf` files from the virtual ZenFS filesystem. It also fixes the file association for `.swf` files by correcting the `appId` in the configuration to match the actual ID of the Flash Player application. Visual verification was performed to ensure the file picker works correctly and defaults to the 'My Documents' folder.

---
*PR created automatically by Jules for task [15486291883224260758](https://jules.google.com/task/15486291883224260758) started by @azayrahmad*