### PR TITLE
Improve removable disk handling: labels and persistence

### DIFF
--- a/src/shell/explorer/drives/drive-manager.js
+++ b/src/shell/explorer/drives/drive-manager.js
@@ -9,6 +9,7 @@ import {
 import { FloppyManager } from './floppy-manager.js';
 import { CDManager } from './cd-manager.js';
 import { RemovableDiskManager } from './removable-disk-manager.js';
+import { saveDiskHandle, removeDiskHandle } from '../../../system/removable-disk-persistence.js';
 
 export class DriveManager {
   constructor(app) {
@@ -178,6 +179,7 @@ export class DriveManager {
         const diskFs = await WebAccess.create({ handle });
         mount(mountPoint, diskFs);
         RemovableDiskManager.mount(letter, handle.name);
+        await saveDiskHandle(letter, handle);
         document.dispatchEvent(new CustomEvent("removable-disk-change"));
       } finally {
         releaseBusyState(busyRequesterId, this.app.win.element);
@@ -200,6 +202,7 @@ export class DriveManager {
       try {
         umount(mountPoint);
         RemovableDiskManager.unmount(letter);
+        await removeDiskHandle(letter);
 
         try {
           if (fs.existsSync(mountPoint)) {

--- a/src/shell/explorer/navigation/path-utils.js
+++ b/src/shell/explorer/navigation/path-utils.js
@@ -84,7 +84,8 @@ export function getDisplayName(path) {
     if (name && name.match(/^[A-Z]:$/i)) {
         const letter = name.charAt(0).toUpperCase();
         if (RemovableDiskManager.isMounted(letter)) {
-            return `Removable Disk (${letter}:)`;
+            const label = RemovableDiskManager.getLabel(letter);
+            return label ? `${label} (${letter}:)` : `Removable Disk (${letter}:)`;
         }
         return `(${name.toUpperCase()})`;
     }

--- a/src/system/removable-disk-persistence.js
+++ b/src/system/removable-disk-persistence.js
@@ -1,0 +1,84 @@
+/**
+ * Utility to persist FileSystemDirectoryHandles for removable disks in IndexedDB
+ */
+
+const DB_NAME = 'removable-disks-db';
+const STORE_NAME = 'removable-disks';
+
+/**
+ * Opens the IndexedDB for removable disks
+ * @returns {Promise<IDBDatabase>}
+ */
+function openDB() {
+    return new Promise((resolve, reject) => {
+        const request = indexedDB.open(DB_NAME, 1);
+        request.onupgradeneeded = (e) => {
+            const db = e.target.result;
+            if (!db.objectStoreNames.contains(STORE_NAME)) {
+                db.createObjectStore(STORE_NAME);
+            }
+        };
+        request.onsuccess = (e) => resolve(e.target.result);
+        request.onerror = (e) => reject(e.target.error);
+    });
+}
+
+/**
+ * Saves a directory handle for a specific drive letter
+ * @param {string} letter - Drive letter (e.g., 'F')
+ * @param {FileSystemDirectoryHandle} handle
+ * @returns {Promise<void>}
+ */
+export async function saveDiskHandle(letter, handle) {
+    const db = await openDB();
+    return new Promise((resolve, reject) => {
+        const tx = db.transaction(STORE_NAME, 'readwrite');
+        const store = tx.objectStore(STORE_NAME);
+        const request = store.put(handle, letter.toUpperCase());
+        request.onsuccess = () => resolve();
+        request.onerror = () => reject(request.error);
+    });
+}
+
+/**
+ * Removes a directory handle for a specific drive letter
+ * @param {string} letter - Drive letter (e.g., 'F')
+ * @returns {Promise<void>}
+ */
+export async function removeDiskHandle(letter) {
+    const db = await openDB();
+    return new Promise((resolve, reject) => {
+        const tx = db.transaction(STORE_NAME, 'readwrite');
+        const store = tx.objectStore(STORE_NAME);
+        const request = store.delete(letter.toUpperCase());
+        request.onsuccess = () => resolve();
+        request.onerror = () => reject(request.error);
+    });
+}
+
+/**
+ * Retrieves all persisted directory handles
+ * @returns {Promise<Object>} Mapping of drive letter to handle
+ */
+export async function getAllDiskHandles() {
+    const db = await openDB();
+    return new Promise((resolve, reject) => {
+        const tx = db.transaction(STORE_NAME, 'readonly');
+        const store = tx.objectStore(STORE_NAME);
+
+        const handles = {};
+        const cursorRequest = store.openCursor();
+
+        cursorRequest.onsuccess = (e) => {
+            const cursor = e.target.result;
+            if (cursor) {
+                handles[cursor.key] = cursor.value;
+                cursor.continue();
+            } else {
+                resolve(handles);
+            }
+        };
+
+        cursorRequest.onerror = () => reject(cursorRequest.error);
+    });
+}

--- a/src/system/zenfs-init.js
+++ b/src/system/zenfs-init.js
@@ -1,5 +1,5 @@
 import { resolveMountConfig, InMemory, fs } from "@zenfs/core";
-import { IndexedDB } from "@zenfs/dom";
+import { IndexedDB, WebAccess } from "@zenfs/dom";
 import {
   migrateToZenFS,
   refreshPrograms,
@@ -13,6 +13,8 @@ import { getStartupApps } from "./startup-manager.js";
 import { apps } from "../config/apps.js";
 import { existsAsync } from "./zenfs-utils.js";
 import { wallpapers } from "../config/wallpapers.js";
+import { getAllDiskHandles } from "./removable-disk-persistence.js";
+import { RemovableDiskManager } from "../shell/explorer/drives/removable-disk-manager.js";
 
 let isInitialized = false;
 
@@ -304,6 +306,27 @@ export async function initFileSystem(onProgress) {
       if (favoritesConfig && favoritesConfig.submenu) {
         await migrateToZenFS(favoritesConfig.submenu, FAVORITES_PATH);
       }
+    }
+
+    if (onProgress) onProgress("Restoring removable disks...");
+    try {
+      const savedHandles = await getAllDiskHandles();
+      for (const [letter, handle] of Object.entries(savedHandles)) {
+        try {
+          const mountPoint = `/${letter}:`;
+          if (!(await existsAsync(mountPoint))) {
+            await fs.promises.mkdir(mountPoint);
+          }
+          const diskFs = await WebAccess.create({ handle });
+          fs.mount(mountPoint, diskFs);
+          RemovableDiskManager.mount(letter, handle.name);
+          console.log(`Restored removable disk ${letter}: (${handle.name})`);
+        } catch (e) {
+          console.warn(`Failed to restore removable disk ${letter}:`, e);
+        }
+      }
+    } catch (e) {
+      console.error("Failed to load persisted removable disks:", e);
     }
 
     isInitialized = true;


### PR DESCRIPTION
This change improves the user experience for removable disks in the Windows 98 web simulation. 
1. The drive label (the name of the folder picked from the host system) is now displayed alongside the drive letter in the Explorer (e.g., "My Backup (F:)").
2. Removable disks are now persisted using the File System Access API. Directory handles are stored in IndexedDB and automatically re-mounted during the system boot process. Browsers will prompt for re-authorization if needed when the drives are accessed.

---
*PR created automatically by Jules for task [3063907726026617795](https://jules.google.com/task/3063907726026617795) started by @azayrahmad*