### PR TITLE
Auto-eject inaccessible removable disks

### DIFF
--- a/src/shell/explorer/drives/drive-manager.js
+++ b/src/shell/explorer/drives/drive-manager.js
@@ -10,6 +10,7 @@ import { FloppyManager } from './floppy-manager.js';
 import { CDManager } from './cd-manager.js';
 import { RemovableDiskManager } from './removable-disk-manager.js';
 import { saveDiskHandle, removeDiskHandle } from '../../../system/removable-disk-persistence.js';
+import { DriveService } from '../../../system/drive-service.js';
 
 export class DriveManager {
   constructor(app) {
@@ -65,16 +66,12 @@ export class DriveManager {
    * Eject floppy
    */
   async ejectFloppy() {
-    if (mounts.has("/A:")) {
-      const busyId = "floppy-eject";
-      requestBusyState(busyId, this.app.win.element);
-      try {
-        umount("/A:");
-        FloppyManager.clear();
-        document.dispatchEvent(new CustomEvent("floppy-change"));
-      } finally {
-        releaseBusyState(busyId, this.app.win.element);
-      }
+    const busyId = "floppy-eject";
+    requestBusyState(busyId, this.app.win.element);
+    try {
+      await DriveService.ejectDrive("A");
+    } finally {
+      releaseBusyState(busyId, this.app.win.element);
     }
   }
 
@@ -140,16 +137,12 @@ export class DriveManager {
    * Eject CD
    */
   async ejectCD() {
-    if (mounts.has("/E:")) {
-      const busyId = "cd-eject";
-      requestBusyState(busyId, this.app.win.element);
-      try {
-        umount("/E:");
-        CDManager.clear();
-        document.dispatchEvent(new CustomEvent("cd-change"));
-      } finally {
-        releaseBusyState(busyId, this.app.win.element);
-      }
+    const busyId = "cd-eject";
+    requestBusyState(busyId, this.app.win.element);
+    try {
+      await DriveService.ejectDrive("E");
+    } finally {
+      releaseBusyState(busyId, this.app.win.element);
     }
   }
 
@@ -195,27 +188,12 @@ export class DriveManager {
    * Eject Removable Disk
    */
   async ejectRemovableDisk(letter) {
-    const mountPoint = `/${letter}:`;
-    if (mounts.has(mountPoint)) {
-      const busyId = `removable-eject-${letter}`;
-      requestBusyState(busyId, this.app.win.element);
-      try {
-        umount(mountPoint);
-        RemovableDiskManager.unmount(letter);
-        await removeDiskHandle(letter);
-
-        try {
-          if (fs.existsSync(mountPoint)) {
-            await fs.promises.rmdir(mountPoint);
-          }
-        } catch (err) {
-          console.warn(`Failed to remove mount point ${mountPoint}:`, err);
-        }
-
-        document.dispatchEvent(new CustomEvent("removable-disk-change"));
-      } finally {
-        releaseBusyState(busyId, this.app.win.element);
-      }
+    const busyId = `removable-eject-${letter}`;
+    requestBusyState(busyId, this.app.win.element);
+    try {
+      await DriveService.ejectDrive(letter);
+    } finally {
+      releaseBusyState(busyId, this.app.win.element);
     }
   }
 }

--- a/src/shell/explorer/extensions/shell-manager.js
+++ b/src/shell/explorer/extensions/shell-manager.js
@@ -1,5 +1,6 @@
 import { fs } from "@zenfs/core";
 import { getParentPath } from '../navigation/path-utils.js';
+import { DriveService } from '../../../system/drive-service.js';
 
 /**
  * VirtualStats - Mock fs.Stats for shell extensions
@@ -67,9 +68,19 @@ export class ShellManager {
   static async stat(path) {
     const ext = this.getExtensionForPath(path);
     if (ext) {
-      return ext.stat(path);
+      try {
+        return await ext.stat(path);
+      } catch (e) {
+        await DriveService.handleDriveError(path, e);
+        throw e;
+      }
     }
-    return fs.promises.stat(path);
+    try {
+      return await fs.promises.stat(path);
+    } catch (e) {
+      await DriveService.handleDriveError(path, e);
+      throw e;
+    }
   }
 
   /**
@@ -82,7 +93,8 @@ export class ShellManager {
     try {
       files = await fs.promises.readdir(path);
     } catch (e) {
-      // Path might be virtual only
+      // Path might be virtual only or an inaccessible drive
+      await DriveService.handleDriveError(path, e);
     }
 
     for (const ext of this.extensions) {

--- a/src/system/drive-service.js
+++ b/src/system/drive-service.js
@@ -1,0 +1,109 @@
+import { fs, umount, mounts } from "@zenfs/core";
+import { RemovableDiskManager } from "../shell/explorer/drives/removable-disk-manager.js";
+import { FloppyManager } from "../shell/explorer/drives/floppy-manager.js";
+import { CDManager } from "../shell/explorer/drives/cd-manager.js";
+import { removeDiskHandle } from "./removable-disk-persistence.js";
+import { ShowDialogWindow } from "../shared/components/dialog-window.js";
+
+/**
+ * DriveService - Centralized service for drive management and error handling
+ */
+export const DriveService = {
+  /**
+   * Ejects a drive by letter
+   * @param {string} letter
+   */
+  async ejectDrive(letter) {
+    const upperLetter = letter.toUpperCase();
+    const mountPoint = `/${upperLetter}:`;
+
+    if (mounts.has(mountPoint)) {
+      try {
+        umount(mountPoint);
+      } catch (e) {
+        console.warn(`Failed to unmount ${mountPoint}:`, e);
+      }
+    }
+
+    // Clear managers
+    if (upperLetter === "A") {
+      FloppyManager.clear();
+      document.dispatchEvent(new CustomEvent("floppy-change"));
+    } else if (upperLetter === "E") {
+      CDManager.clear();
+      document.dispatchEvent(new CustomEvent("cd-change"));
+    } else {
+      RemovableDiskManager.unmount(upperLetter);
+      await removeDiskHandle(upperLetter);
+      document.dispatchEvent(new CustomEvent("removable-disk-change"));
+    }
+
+    // Remove mount point directory from root FS
+    try {
+      if (fs.existsSync(mountPoint)) {
+        await fs.promises.rmdir(mountPoint);
+      }
+    } catch (err) {
+      console.warn(`Failed to remove mount point ${mountPoint}:`, err);
+    }
+  },
+
+  /**
+   * Checks if a drive is still accessible
+   * @param {string} letter
+   * @returns {Promise<boolean>}
+   */
+  async isDriveAccessible(letter) {
+    const mountPoint = `/${letter.toUpperCase()}:`;
+    try {
+      // Attempt to read the root of the drive
+      await fs.promises.readdir(mountPoint);
+      return true;
+    } catch (e) {
+      return false;
+    }
+  },
+
+  /**
+   * Notifies the user and ejects the drive
+   * @param {string} letter
+   */
+  async notifyAndEject(letter) {
+    const upperLetter = letter.toUpperCase();
+
+    ShowDialogWindow({
+      title: `Drive ${upperLetter}:`,
+      text: `The drive ${upperLetter}: is no longer accessible and has been automatically ejected.`,
+      buttons: [{ label: "OK", isDefault: true }],
+      soundEvent: "SystemHand",
+    });
+
+    await this.ejectDrive(upperLetter);
+  },
+
+  /**
+   * Handles a filesystem error, checking if it was caused by an inaccessible drive
+   * @param {string} path
+   * @param {Error} error
+   */
+  async handleDriveError(path, error) {
+    const driveMatch = path.match(/^\/([A-Z]):/i);
+    if (!driveMatch) return;
+
+    const letter = driveMatch[1].toUpperCase();
+
+    // We only auto-eject removable drives (A:, E:, and others except C:)
+    if (letter === "C") return;
+
+    // Check if it's currently mounted according to our managers
+    const isMounted = letter === "A" || letter === "E" || RemovableDiskManager.isMounted(letter);
+    if (!isMounted) return;
+
+    // Verify accessibility
+    const accessible = await this.isDriveAccessible(letter);
+    if (!accessible) {
+      console.warn(`Drive ${letter}: is inaccessible. Triggering auto-eject.`);
+      await this.notifyAndEject(letter);
+    }
+  }
+};

--- a/src/system/zenfs-init.js
+++ b/src/system/zenfs-init.js
@@ -13,8 +13,9 @@ import { getStartupApps } from "./startup-manager.js";
 import { apps } from "../config/apps.js";
 import { existsAsync } from "./zenfs-utils.js";
 import { wallpapers } from "../config/wallpapers.js";
-import { getAllDiskHandles } from "./removable-disk-persistence.js";
+import { getAllDiskHandles, removeDiskHandle } from "./removable-disk-persistence.js";
 import { RemovableDiskManager } from "../shell/explorer/drives/removable-disk-manager.js";
+import { DriveService } from "./drive-service.js";
 
 let isInitialized = false;
 
@@ -312,17 +313,36 @@ export async function initFileSystem(onProgress) {
     try {
       const savedHandles = await getAllDiskHandles();
       for (const [letter, handle] of Object.entries(savedHandles)) {
+        const mountPoint = `/${letter}:`;
         try {
-          const mountPoint = `/${letter}:`;
           if (!(await existsAsync(mountPoint))) {
             await fs.promises.mkdir(mountPoint);
           }
           const diskFs = await WebAccess.create({ handle });
           fs.mount(mountPoint, diskFs);
+
+          // Accessibility check
+          await fs.promises.readdir(mountPoint);
+
           RemovableDiskManager.mount(letter, handle.name);
           console.log(`Restored removable disk ${letter}: (${handle.name})`);
         } catch (e) {
           console.warn(`Failed to restore removable disk ${letter}:`, e);
+          // Clean up if it failed to mount or is inaccessible
+          try {
+            if (mounts.has(mountPoint)) {
+              fs.umount(mountPoint);
+            }
+          } catch (umountErr) {}
+
+          try {
+            if (await existsAsync(mountPoint)) {
+              await fs.promises.rmdir(mountPoint);
+            }
+          } catch (rmdirErr) {}
+
+          await removeDiskHandle(letter);
+          RemovableDiskManager.unmount(letter);
         }
       }
     } catch (e) {


### PR DESCRIPTION
Automatically eject removable drives (including Floppy and CD-ROM) if they become inaccessible during runtime or are missing at boot. Provides a centralized `DriveService` and integrates it with `ShellManager` for automatic error detection and UI notification.

---
*PR created automatically by Jules for task [1035492006930146784](https://jules.google.com/task/1035492006930146784) started by @azayrahmad*