### PR TITLE
Add Mouse and Touch Hardware Detection to Boot Sequence

### DIFF
--- a/src/system/os-init.js
+++ b/src/system/os-init.js
@@ -136,9 +136,19 @@ export async function initializeOS() {
     }
 
     await executeBootStep(async () => {
-      let logElement = startBootProcessStep("Detecting keyboard...");
-      await new Promise((resolve) => setTimeout(resolve, 500));
-      finalizeBootProcessStep(logElement, "OK");
+      let logElement = startBootProcessStep("Detecting mouse...");
+      await new Promise((resolve) => setTimeout(resolve, 300));
+      const hasMouse = window.matchMedia("(any-pointer: fine)").matches;
+      finalizeBootProcessStep(logElement, hasMouse ? "OK" : "FAILED");
+    });
+
+    await executeBootStep(async () => {
+      let logElement = startBootProcessStep("Detecting touch support...");
+      await new Promise((resolve) => setTimeout(resolve, 300));
+      const hasTouch =
+        window.matchMedia("(any-pointer: coarse)").matches ||
+        navigator.maxTouchPoints > 0;
+      finalizeBootProcessStep(logElement, hasTouch ? "OK" : "FAILED");
     });
 
     await executeBootStep(async () => {


### PR DESCRIPTION
I have updated the OS boot sequence to include actual hardware detection for mouse and touch devices. 

Previously, there was only a simulated keyboard check. Per your requirements, I have:
1. Removed the simulated keyboard detection.
2. Added a "Detecting mouse..." step that uses the `any-pointer: fine` media query.
3. Added a "Detecting touch support..." step that uses `any-pointer: coarse` and `navigator.maxTouchPoints`.
4. Ensured each check appears on its own line and reports "OK" or "FAILED" based on the detection result.
5. Added a small delay (300ms) for each step to provide visual feedback during boot.

I verified these changes by running the system in both mobile (touch-enabled) and desktop (mouse-enabled) browser contexts via Playwright, confirming that the detection correctly identifies the available input devices in the terminal.

---
*PR created automatically by Jules for task [9569684519629114554](https://jules.google.com/task/9569684519629114554) started by @azayrahmad*