### PR TITLE
Add GSC verification and GA4 tracking

### DIFF
--- a/index.html
+++ b/index.html
@@ -15,10 +15,21 @@
         />
         <meta
             name="keywords"
-            content="Windows 98, Web OS, Simulation, Retro Gaming, Doom, Pinball, SimCity 2000, Clippy, Retro Tech, Nostalgia"
+            content="Windows 98, Web OS, Simulation, Retro Gaming, Doom, Pinball, SimCity 2000, Clippy, Retro Tech, Nostalgia, Windows 98 Simulator, Classic Windows Online, Retro Browser Games"
         />
         <meta name="author" content="azayrahmad" />
         <link rel="canonical" href="https://azayrahmad.github.io/win98-web/" />
+        <meta name="google-site-verification" content="5Lv76sxt6l0zQB0e4glOTLLt3BjWArL8r4HVuc0J8xI" />
+
+        <!-- Google tag (gtag.js) -->
+        <script async src="https://www.googletagmanager.com/gtag/js?id=G-MEASUREMENT_ID"></script>
+        <script>
+            window.dataLayer = window.dataLayer || [];
+            function gtag(){dataLayer.push(arguments);}
+            gtag('js', new Date());
+
+            gtag('config', 'G-MEASUREMENT_ID');
+        </script>
 
         <!-- Open Graph / Facebook -->
         <meta property="og:type" content="website" />

--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -2,7 +2,7 @@
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
    <url>
       <loc>https://azayrahmad.github.io/win98-web/</loc>
-      <lastmod>2025-02-12</lastmod>
+      <lastmod>2026-02-14</lastmod>
       <changefreq>monthly</changefreq>
       <priority>1.0</priority>
    </url>


### PR DESCRIPTION
I have addressed the issue where Google Search Console was not detecting usage by adding the necessary verification tag and integrating Google Analytics 4. I also performed some SEO enhancements.

Key changes:
1. Added `<meta name="google-site-verification" content="5Lv76sxt6l0zQB0e4glOTLLt3BjWArL8r4HVuc0J8xI" />` to `index.html`.
2. Added Google Analytics 4 tracking script to `index.html` (currently using `G-MEASUREMENT_ID` as a placeholder).
3. Expanded the `keywords` meta tag in `index.html` to include more relevant terms like "Windows 98 Simulator" and "Classic Windows Online".
4. Updated the `lastmod` date in `public/sitemap.xml` to the current date (2026-02-14).
5. Verified that `robots.txt` correctly points to the sitemap.

The user will need to replace `G-MEASUREMENT_ID` in `index.html` with their actual GA4 Measurement ID once they have it.

---
*PR created automatically by Jules for task [9428896726874242563](https://jules.google.com/task/9428896726874242563) started by @azayrahmad*