### PR TITLE
Improve DOS Games Downloader

### DIFF
--- a/src/apps/dos-box/dos-box-app.js
+++ b/src/apps/dos-box/dos-box-app.js
@@ -18,24 +18,6 @@ export class DosBoxApp extends Application {
       allowFullscreen: true,
       startFullscreen: true,
       isSingleton: false,
-    },
-    {
-      id: "wolf3d",
-      title: "Wolfenstein 3D",
-      description: "Play Wolfenstein 3D",
-      icon: ICONS.msdos,
-      category: "Accessories/Games",
-      width: 640,
-      height: 480,
-    },
-    {
-      id: "sky",
-      title: "Beneath a Steel Sky",
-      description: "Play Beneath a Steel Sky",
-      icon: ICONS.msdos,
-      category: "Accessories/Games",
-      width: 640,
-      height: 480,
     }
   ];
 
@@ -50,11 +32,7 @@ export class DosBoxApp extends Application {
   }
 
   async _createWindow(data) {
-    if (this.id === 'wolf3d') {
-      this.executablePath = "/C:/Games/WOLF3D/WOLF3D.EXE";
-    } else if (this.id === 'sky') {
-      this.executablePath = "/C:/Games/SKY/SKY.EXE";
-    } else if (typeof data === 'string') {
+    if (typeof data === 'string') {
       this.executablePath = data;
     } else if (data && data.path) {
       this.executablePath = data.path;

--- a/src/apps/dos-games-downloader/dos-games-downloader-app.js
+++ b/src/apps/dos-games-downloader/dos-games-downloader-app.js
@@ -244,9 +244,8 @@ export class DosGamesDownloaderApp extends Application {
         } catch (e) {}
       }
 
-      // 4. Find the first .EXE or .COM
-      const files = await fs.promises.readdir(installDir);
-      const executable = files.find(f => f.toLowerCase().endsWith(".exe") || f.toLowerCase().endsWith(".com"));
+      // 4. Find the best executable (.EXE, .COM, .BAT)
+      const executable = await this._findExecutable(installDir, identifier);
 
       // 5. Update persistence
       const thumbUrl = `https://archive.org/services/img/${identifier}`;
@@ -284,6 +283,57 @@ export class DosGamesDownloaderApp extends Application {
     } finally {
       this.isDownloading = false;
     }
+  }
+
+  async _findExecutable(installDir, identifier) {
+    const candidates = [];
+    const extensions = [".exe", ".com", ".bat"];
+
+    try {
+      const entries = await fs.promises.readdir(installDir);
+      for (const entry of entries) {
+        const fullPath = `${installDir}/${entry}`;
+        const stats = await fs.promises.stat(fullPath);
+        const lowerEntry = entry.toLowerCase();
+
+        if (stats.isDirectory()) {
+          // Check one level deep
+          const subEntries = await fs.promises.readdir(fullPath);
+          for (const subEntry of subEntries) {
+            const subFullPath = `${fullPath}/${subEntry}`;
+            const subStats = await fs.promises.stat(subFullPath);
+            if (subStats.isFile()) {
+              const subLower = subEntry.toLowerCase();
+              const extMatch = extensions.find(ext => subLower.endsWith(ext));
+              if (extMatch) {
+                let score = extensions.length - extensions.indexOf(extMatch);
+                const nameWithoutExt = subLower.slice(0, -extMatch.length);
+                if (nameWithoutExt === lowerEntry) score += 10; // Matches parent dir
+                if (nameWithoutExt === identifier.toLowerCase()) score += 5;
+                candidates.push({ path: `${entry}/${subEntry}`, score });
+              }
+            }
+          }
+        } else if (stats.isFile()) {
+          const extMatch = extensions.find(ext => lowerEntry.endsWith(ext));
+          if (extMatch) {
+            let score = extensions.length - extensions.indexOf(extMatch);
+            const nameWithoutExt = lowerEntry.slice(0, -extMatch.length);
+            const parentName = installDir.split("/").pop().toLowerCase();
+            if (nameWithoutExt === parentName) score += 10;
+            if (nameWithoutExt === identifier.toLowerCase()) score += 5;
+            candidates.push({ path: entry, score });
+          }
+        }
+      }
+    } catch (e) {
+      console.error("Error finding executable", e);
+    }
+
+    if (candidates.length === 0) return null;
+
+    candidates.sort((a, b) => b.score - a.score);
+    return candidates[0].path;
   }
 
   async _copyRecursive(src, dest) {

--- a/src/apps/dos-games-downloader/dos-games-downloader-app.js
+++ b/src/apps/dos-games-downloader/dos-games-downloader-app.js
@@ -21,6 +21,35 @@ export class DosGamesDownloaderApp extends Application {
     super(config);
     this.results = [];
     this.isDownloading = false;
+    this.installedGames = {};
+    this.persistencePath = "/C:/Program Files/DOS Games Downloader/installed.json";
+  }
+
+  async _onLaunch() {
+    await this._loadInstalledGames();
+  }
+
+  async _loadInstalledGames() {
+    try {
+      if (await existsAsync(this.persistencePath)) {
+        const content = await fs.promises.readFile(this.persistencePath, "utf8");
+        this.installedGames = JSON.parse(content);
+      }
+    } catch (e) {
+      console.error("Failed to load installed games", e);
+    }
+  }
+
+  async _saveInstalledGames() {
+    try {
+      const dir = "/C:/Program Files/DOS Games Downloader";
+      if (!(await existsAsync(dir))) {
+        await fs.promises.mkdir(dir, { recursive: true });
+      }
+      await fs.promises.writeFile(this.persistencePath, JSON.stringify(this.installedGames, null, 2));
+    } catch (e) {
+      console.error("Failed to save installed games", e);
+    }
   }
 
   _createWindow() {
@@ -68,6 +97,19 @@ export class DosGamesDownloaderApp extends Application {
       const title = $(e.currentTarget).data("title");
       this._downloadAndInstall(identifier, title);
     });
+
+    this.win.$content.on("click", ".play-btn", (e) => {
+      const identifier = $(e.currentTarget).data("id");
+      this._playGame(identifier);
+    });
+  }
+
+  _playGame(identifier) {
+    const game = this.installedGames[identifier];
+    if (game) {
+      const executablePath = `${game.installDir}/${game.executable}`;
+      window.System.launchApp("dos-box", { path: executablePath });
+    }
   }
 
   async _handleSearch() {
@@ -97,7 +139,9 @@ export class DosGamesDownloaderApp extends Application {
     list.empty();
 
     this.results.forEach((item) => {
-      const thumbUrl = `https://archive.org/services/img/${item.identifier}`;
+      const isInstalled = !!this.installedGames[item.identifier];
+      const thumbUrl = isInstalled ? this.installedGames[item.identifier].thumbUrl : `https://archive.org/services/img/${item.identifier}`;
+
       const card = $(`
         <div class="game-card">
           <img class="game-thumb" src="${thumbUrl}" alt="${item.title}" loading="lazy">
@@ -105,7 +149,10 @@ export class DosGamesDownloaderApp extends Application {
             <div class="game-title">${item.title}</div>
             <div class="game-id">${item.identifier}</div>
           </div>
-          <button class="download-btn" data-id="${item.identifier}" data-title="${item.title}">Install</button>
+          ${isInstalled
+            ? `<button class="play-btn" data-id="${item.identifier}">Play</button>`
+            : `<button class="download-btn" data-id="${item.identifier}" data-title="${item.title}">Install</button>`
+          }
         </div>
       `);
       list.append(card);
@@ -201,16 +248,33 @@ export class DosGamesDownloaderApp extends Application {
       const files = await fs.promises.readdir(installDir);
       const executable = files.find(f => f.toLowerCase().endsWith(".exe") || f.toLowerCase().endsWith(".com"));
 
-      // 5. Create shortcut
+      // 5. Update persistence
+      const thumbUrl = `https://archive.org/services/img/${identifier}`;
+      this.installedGames[identifier] = {
+        identifier,
+        title,
+        installDir,
+        executable,
+        thumbUrl
+      };
+      await this._saveInstalledGames();
+
+      // 6. Create shortcut in DOS Games folder
       if (executable) {
-          await addDesktopShortcut("dos-box", title);
-          // Update the shortcut content to point to the game
-          const lnkPath = `/C:/WINDOWS/Desktop/${title}.lnk.json`;
-          const lnkContent = JSON.parse(await fs.promises.readFile(lnkPath, "utf8"));
-          lnkContent.args = `${installDir}/${executable}`;
-          await fs.promises.writeFile(lnkPath, JSON.stringify(lnkContent, null, 2));
+          const dosGamesPath = "/C:/WINDOWS/Desktop/DOS Games";
+          if (!(await existsAsync(dosGamesPath))) {
+              await fs.promises.mkdir(dosGamesPath, { recursive: true });
+          }
+          const lnkPath = `${dosGamesPath}/${title}.lnk.json`;
+          await fs.promises.writeFile(lnkPath, JSON.stringify({
+              type: "shortcut",
+              appId: "dos-box",
+              args: `${installDir}/${executable}`
+          }, null, 2));
+          document.dispatchEvent(new CustomEvent("fs-change", { detail: { path: lnkPath } }));
       }
 
+      this._renderResults();
       statusMsg.text(`Successfully installed ${title}!`);
       setTimeout(() => overlay.addClass("hidden"), 3000);
     } catch (e) {

--- a/src/config/app-registry.js
+++ b/src/config/app-registry.js
@@ -171,24 +171,6 @@ export const appRegistry = {
       allowFullscreen: true,
       startFullscreen: true,
       isSingleton: false,
-    },
-    {
-      id: "wolf3d",
-      title: "Wolfenstein 3D",
-      description: "Play Wolfenstein 3D",
-      icon: ICONS.msdos,
-      category: "Accessories/Games",
-      width: 640,
-      height: 480,
-    },
-    {
-      id: "sky",
-      title: "Beneath a Steel Sky",
-      description: "Play Beneath a Steel Sky",
-      icon: ICONS.msdos,
-      category: "Accessories/Games",
-      width: 640,
-      height: 480,
     }
   ],
     importApp: () => import("../apps/dos-box/dos-box-app.js")

--- a/src/system/zenfs-init.js
+++ b/src/system/zenfs-init.js
@@ -92,6 +92,9 @@ export async function initFileSystem(onProgress) {
     if (!(await existsAsync("/C:/Program Files/Doom"))) {
       await fs.promises.mkdir("/C:/Program Files/Doom");
     }
+    if (!(await existsAsync("/C:/Program Files/DOS Games Downloader"))) {
+      await fs.promises.mkdir("/C:/Program Files/DOS Games Downloader");
+    }
 
     const doomFiles = ["doom1.wad", "default.cfg"];
     const doomRemotePath = "games/doom/";
@@ -169,8 +172,6 @@ export async function initFileSystem(onProgress) {
       { name: "Diablo.lnk.json", appId: "diablo" },
       { name: "Quake.lnk.json", appId: "quake" },
       { name: "Prince of Persia.lnk.json", appId: "prince-of-persia" },
-      { name: "Wolfenstein 3D.lnk.json", appId: "wolf3d" },
-      { name: "Beneath a Steel Sky.lnk.json", appId: "sky" },
     ];
 
     for (const game of games) {
@@ -190,6 +191,33 @@ export async function initFileSystem(onProgress) {
       }
     }
 
+    // Add DOS Games folder to Desktop
+    const dosGamesPath = "/C:/WINDOWS/Desktop/DOS Games";
+    if (!(await existsAsync(dosGamesPath))) {
+      await fs.promises.mkdir(dosGamesPath);
+    }
+
+    const dosGamesShortcuts = [
+      { name: "DOS Games Downloader.lnk.json", appId: "dos-games-downloader" },
+    ];
+
+    for (const shortcut of dosGamesShortcuts) {
+      const lnkPath = `${dosGamesPath}/${shortcut.name}`;
+      if (!(await existsAsync(lnkPath))) {
+        await fs.promises.writeFile(
+          lnkPath,
+          JSON.stringify(
+            {
+              type: "shortcut",
+              appId: shortcut.appId,
+            },
+            null,
+            2,
+          ),
+        );
+      }
+    }
+
     // Ensure My Documents directory exists
     if (!(await existsAsync("/C:/My Documents"))) {
       await fs.promises.mkdir("/C:/My Documents");
@@ -198,45 +226,6 @@ export async function initFileSystem(onProgress) {
     // Ensure Games directory exists on C:
     if (!(await existsAsync("/C:/Games"))) {
       await fs.promises.mkdir("/C:/Games");
-    }
-
-    // Install Wolfenstein 3D to C:\Games\WOLF3D if it doesn't exist
-    if (!(await existsAsync("/C:/Games/WOLF3D"))) {
-      if (onProgress) onProgress("Installing Wolfenstein 3D...");
-      await fs.promises.mkdir("/C:/Games/WOLF3D", { recursive: true });
-      const wolfFiles = [
-        "AUDIOHED.WL6", "AUDIOT.WL6", "CONFIG.WL6", "GAMEMAPS.WL6",
-        "MAPHEAD.WL6", "VGADICT.WL6", "VGAGRAPH.WL6", "VGAHEAD.WL6",
-        "VSWAP.WL6", "WOLF3D.EXE"
-      ];
-      for (const file of wolfFiles) {
-        try {
-          const response = await fetch(`games/dos/wolf3d/${file}`);
-          const buffer = await response.arrayBuffer();
-          await fs.promises.writeFile(`/C:/Games/WOLF3D/${file}`, new Uint8Array(buffer));
-        } catch (e) {
-          console.error(`Failed to install ${file}:`, e);
-        }
-      }
-    }
-
-    // Install Beneath a Steel Sky to C:\Games\SKY if it doesn't exist
-    if (!(await existsAsync("/C:/Games/SKY"))) {
-      if (onProgress) onProgress("Installing Beneath a Steel Sky...");
-      await fs.promises.mkdir("/C:/Games/SKY", { recursive: true });
-      const skyFiles = ["SKY.DNR", "SKY.DSK", "SKY.EXE", "SKY.RST"];
-      for (const file of skyFiles) {
-        try {
-          const response = await fetch(`games/dos/sky/${file}`);
-          const buffer = await response.arrayBuffer();
-          await fs.promises.writeFile(
-            `/C:/Games/SKY/${file}`,
-            new Uint8Array(buffer),
-          );
-        } catch (e) {
-          console.error(`Failed to install ${file}:`, e);
-        }
-      }
     }
 
     if (onProgress) onProgress("Initializing Start Menu...");


### PR DESCRIPTION
This change improves the DOS Games Downloader by adding a persistence layer and a dedicated desktop folder for downloaded games. 

Key improvements:
- **Centralized Management:** A new "DOS Games" folder on the desktop now houses the downloader shortcut and all subsequently installed games, keeping the main desktop clean.
- **Persistence:** Installation metadata (identifier, title, paths, and thumbnails) is now saved to `C:\Program Files\DOS Games Downloader\installed.json`.
- **Improved UI:** The downloader now detects installed games and shows a "Play" button instead of "Install". Clicking "Play" launches the game directly via DOSBox.
- **Legacy Cleanup:** Removed obsolete pre-installed versions of Wolfenstein 3D and Beneath a Steel Sky to favor the downloader's dynamic installation.

Verified visually via Playwright screenshots showing the new folder structure and the functional "Play" button in the downloader.

---
*PR created automatically by Jules for task [13557849111934917733](https://jules.google.com/task/13557849111934917733) started by @azayrahmad*