### PR TITLE
Implement modal progress dialog for DOS Games Downloader

### DIFF
--- a/src/apps/dos-games-downloader/dos-games-downloader-app.js
+++ b/src/apps/dos-games-downloader/dos-games-downloader-app.js
@@ -4,6 +4,7 @@ import { fs, mount, umount } from "@zenfs/core";
 import { Zip } from "@zenfs/archives";
 import { existsAsync } from "../../system/zenfs-utils.js";
 import { ShowDialogWindow } from '../../shared/components/dialog-window.js';
+import { DosGamesDownloaderProgressDialog } from './dos-games-downloader-progress-dialog.js';
 import { getIcon } from '../../shared/utils/icon-resolver.js';
 import "./dos-games-downloader.css";
 
@@ -71,12 +72,6 @@ export class DosGamesDownloaderApp extends Application {
         </div>
         <div class="results-container inset-deep">
           <div class="results-list"></div>
-          <div class="status-overlay hidden">
-             <div class="status-message">Downloading...</div>
-             <div class="progress-bar-container">
-                <div class="progress-bar"></div>
-             </div>
-          </div>
         </div>
       </div>
     `);
@@ -152,26 +147,27 @@ export class DosGamesDownloaderApp extends Application {
     }
   }
 
-  async _fetchWithProxy(url, title, statusMsg) {
+  async _fetchWithProxy(url, title, dialog, signal) {
     const proxies = [
+      (u) => `https://api.codetabs.com/v1/proxy?quest=${encodeURIComponent(u)}`,
       (u) => `https://corsproxy.io/?${encodeURIComponent(u)}`,
       (u) => `https://api.allorigins.win/raw?url=${encodeURIComponent(u)}`,
-      (u) => `https://api.codetabs.com/v1/proxy?quest=${encodeURIComponent(u)}`,
     ];
 
     for (let i = 0; i < proxies.length; i++) {
       const proxiedUrl = proxies[i](url);
       try {
         console.log(`Attempting download with proxy ${i + 1}: ${proxiedUrl}`);
-        const response = await fetch(proxiedUrl);
+        const response = await fetch(proxiedUrl, { signal });
         if (response.ok) return response;
         console.warn(`Proxy ${i + 1} failed with status ${response.status}`);
       } catch (e) {
+        if (e.name === 'AbortError') throw e;
         console.warn(`Proxy ${i + 1} failed with error:`, e);
       }
 
       if (i < proxies.length - 1) {
-        statusMsg.text(`Download failed with proxy ${i+1}, retrying with fallback...`);
+        if (dialog) dialog.update(`Proxy ${i+1} failed, retrying with fallback...`);
         await new Promise(r => setTimeout(r, 1000));
       }
     }
@@ -183,15 +179,22 @@ export class DosGamesDownloaderApp extends Application {
     if (this.isDownloading) return;
     this.isDownloading = true;
 
-    const overlay = this.win.$content.find(".status-overlay");
-    const statusMsg = this.win.$content.find(".status-message");
-    overlay.removeClass("hidden");
-    statusMsg.text(`Downloading ${title}...`);
+    const abortController = new AbortController();
+    const installDir = `/C:/Games/${identifier}`;
+
+    const dialog = new DosGamesDownloaderProgressDialog({
+      title: "Installing Game",
+      parentWindow: this.win,
+      onCancel: () => {
+        abortController.abort();
+      }
+    });
 
     try {
       // 1. Get metadata to find the zip file
+      dialog.update(`Fetching metadata for ${title}...`, "Archive.org", installDir);
       const metaUrl = `https://archive.org/metadata/${identifier}`;
-      const metaResponse = await fetch(metaUrl);
+      const metaResponse = await fetch(metaUrl, { signal: abortController.signal });
       const metaData = await metaResponse.json();
 
       const zipFile = metaData.files.find(f => f.name.toLowerCase().endsWith(".zip"));
@@ -199,20 +202,40 @@ export class DosGamesDownloaderApp extends Application {
 
       const downloadUrl = `https://archive.org/download/${identifier}/${zipFile.name}`;
 
-      // 2. Download the ZIP
-      const zipResponse = await this._fetchWithProxy(downloadUrl, title, statusMsg);
-      statusMsg.text(`Downloading ${title}...`); // Restore message after fallback notification
+      // 2. Download the ZIP with progress
+      const zipResponse = await this._fetchWithProxy(downloadUrl, title, dialog, abortController.signal);
 
-      const buffer = await zipResponse.arrayBuffer();
+      const contentLength = zipResponse.headers.get('content-length');
+      const totalDownloadSize = contentLength ? parseInt(contentLength, 10) : 0;
+      dialog.setTotalSize(totalDownloadSize);
+      dialog.update(`Downloading ${title}...`, downloadUrl, installDir);
+
+      const reader = zipResponse.body.getReader();
+      let downloadedSize = 0;
+      const chunks = [];
+
+      while(true) {
+        const {done, value} = await reader.read();
+        if (done) break;
+        chunks.push(value);
+        downloadedSize += value.length;
+        dialog.update(null, null, null, downloadedSize);
+      }
+
+      const buffer = new Uint8Array(downloadedSize);
+      let offset = 0;
+      for (const chunk of chunks) {
+        buffer.set(chunk, offset);
+        offset += chunk.length;
+      }
 
       // 3. Extract to /C:/Games/[identifier]
-      statusMsg.text(`Extracting ${title}...`);
-      const installDir = `/C:/Games/${identifier}`;
+      dialog.update(`Preparing extraction...`, null, null, 0);
       if (!(await existsAsync(installDir))) {
         await fs.promises.mkdir(installDir, { recursive: true });
       }
 
-      const zipFs = await Zip.create({ data: new Uint8Array(buffer) });
+      const zipFs = await Zip.create({ data: buffer });
       await zipFs.ready();
 
       const mountPoint = `/mnt/zip-${identifier}`;
@@ -222,7 +245,9 @@ export class DosGamesDownloaderApp extends Application {
       mount(mountPoint, zipFs);
 
       try {
-        await this._copyRecursive(mountPoint, installDir);
+        const totalExtractSize = await this._getRecursiveSize(mountPoint);
+        dialog.setTotalSize(totalExtractSize);
+        await this._copyRecursive(mountPoint, installDir, dialog, 0);
       } finally {
         umount(mountPoint);
         try {
@@ -245,8 +270,7 @@ export class DosGamesDownloaderApp extends Application {
       await this._saveInstalledGames();
 
       this._renderResults();
-      statusMsg.text(`Successfully installed ${title}!`);
-      setTimeout(() => overlay.addClass("hidden"), 3000);
+      dialog.close();
 
       ShowDialogWindow({
         title: "Installation Successful",
@@ -264,9 +288,26 @@ export class DosGamesDownloaderApp extends Application {
         modal: true,
       });
     } catch (e) {
-      console.error("Installation failed", e);
-      statusMsg.text(`Error: ${e.message}`);
-      setTimeout(() => overlay.addClass("hidden"), 5000);
+      if (e.name === 'AbortError' || dialog.cancelled) {
+         console.log("Installation cancelled");
+         // Cleanup
+         try {
+           if (await existsAsync(installDir)) {
+             await fs.promises.rm(installDir, { recursive: true });
+           }
+         } catch (err) {
+           console.error("Cleanup failed", err);
+         }
+      } else {
+        console.error("Installation failed", e);
+        ShowDialogWindow({
+          title: "Installation Failed",
+          text: `Error: ${e.message}`,
+          buttons: [{ label: "OK", isDefault: true }],
+          modal: true,
+        });
+      }
+      dialog.close();
     } finally {
       this.isDownloading = false;
     }
@@ -323,9 +364,25 @@ export class DosGamesDownloaderApp extends Application {
     return candidates[0].path;
   }
 
-  async _copyRecursive(src, dest) {
+  async _getRecursiveSize(path) {
+    let size = 0;
+    const entries = await fs.promises.readdir(path);
+    for (const entry of entries) {
+      const fullPath = `${path}/${entry}`;
+      const stats = await fs.promises.stat(fullPath);
+      if (stats.isDirectory()) {
+        size += await this._getRecursiveSize(fullPath);
+      } else {
+        size += stats.size;
+      }
+    }
+    return size;
+  }
+
+  async _copyRecursive(src, dest, dialog, currentProgress) {
     const entries = await fs.promises.readdir(src);
     for (const entry of entries) {
+      if (dialog && dialog.cancelled) throw new Error("Cancelled");
       const srcPath = `${src}/${entry}`;
       const destPath = `${dest}/${entry}`;
       const stats = await fs.promises.stat(srcPath);
@@ -334,11 +391,14 @@ export class DosGamesDownloaderApp extends Application {
         if (!(await existsAsync(destPath))) {
           await fs.promises.mkdir(destPath);
         }
-        await this._copyRecursive(srcPath, destPath);
+        currentProgress = await this._copyRecursive(srcPath, destPath, dialog, currentProgress);
       } else {
         const data = await fs.promises.readFile(srcPath);
         await fs.promises.writeFile(destPath, data);
+        currentProgress += stats.size;
+        if (dialog) dialog.update(`Extracting ${entry}...`, null, null, currentProgress);
       }
     }
+    return currentProgress;
   }
 }

--- a/src/apps/dos-games-downloader/dos-games-downloader-progress-dialog.js
+++ b/src/apps/dos-games-downloader/dos-games-downloader-progress-dialog.js
@@ -1,0 +1,164 @@
+import { ShowDialogWindow } from '../../shared/components/dialog-window.js';
+
+export class DosGamesDownloaderProgressDialog {
+  constructor(options) {
+    this.title = options.title || "Downloading...";
+    this.parentWindow = options.parentWindow;
+    this.onCancel = options.onCancel;
+    this.totalSize = options.totalSize || 0;
+    this.processedSize = 0;
+    this.startTime = Date.now();
+    this.cancelled = false;
+
+    this._createUI();
+  }
+
+  _createUI() {
+    const gifUrl = new URL("../../shell/explorer/assets/copying.gif", import.meta.url).href;
+
+    const content = document.createElement("div");
+    content.className = "progress-dialog-content";
+    content.style.width = "400px";
+
+    // GIF container
+    const gifContainer = document.createElement("div");
+    gifContainer.style.height = "60px";
+    gifContainer.style.marginBottom = "10px";
+    gifContainer.style.display = "flex";
+    gifContainer.style.alignItems = "left";
+    gifContainer.style.justifyContent = "left";
+    gifContainer.style.overflow = "hidden";
+
+    const gifEl = document.createElement("img");
+    gifEl.src = gifUrl;
+    gifEl.style.maxWidth = "100%";
+    gifEl.style.maxHeight = "100%";
+    gifContainer.appendChild(gifEl);
+    content.appendChild(gifContainer);
+
+    // Current action/file
+    this.statusTextEl = document.createElement("div");
+    this.statusTextEl.style.whiteSpace = "nowrap";
+    this.statusTextEl.style.overflow = "hidden";
+    this.statusTextEl.style.textOverflow = "ellipsis";
+    this.statusTextEl.textContent = "Preparing...";
+    content.appendChild(this.statusTextEl);
+
+    // From/To info
+    this.fromEl = document.createElement("div");
+    this.fromEl.style.fontSize = "11px";
+    this.fromEl.style.minHeight = "1.2em";
+    this.fromEl.style.whiteSpace = "nowrap";
+    this.fromEl.style.overflow = "hidden";
+    this.fromEl.style.textOverflow = "ellipsis";
+    this.fromEl.textContent = " ";
+    content.appendChild(this.fromEl);
+
+    this.toEl = document.createElement("div");
+    this.toEl.style.marginBottom = "10px";
+    this.toEl.style.fontSize = "11px";
+    this.toEl.style.minHeight = "1.2em";
+    this.toEl.style.whiteSpace = "nowrap";
+    this.toEl.style.overflow = "hidden";
+    this.toEl.style.textOverflow = "ellipsis";
+    this.toEl.textContent = " ";
+    content.appendChild(this.toEl);
+
+    // Progress bar section
+    const progressSection = document.createElement("div");
+    progressSection.style.display = "flex";
+    progressSection.style.alignItems = "flex-end";
+    progressSection.style.gap = "10px";
+
+    const progressInfo = document.createElement("div");
+    progressInfo.style.flexGrow = "1";
+
+    this.progressBarContainer = document.createElement("div");
+    this.progressBarContainer.className = "progress-indicator segmented";
+    this.progressBarContainer.style.height = "15px";
+    this.progressBarContainer.style.padding = "3px";
+
+    this.progressBar = document.createElement("span");
+    this.progressBar.className = "progress-indicator-bar";
+    this.progressBar.style.width = "0%";
+    this.progressBar.style.backgroundImage = "linear-gradient(90deg,var(--ActiveTitle) 6px,transparent 0 2px)";
+    this.progressBar.style.backgroundSize = "8px 100%";
+    this.progressBarContainer.appendChild(this.progressBar);
+
+    progressInfo.appendChild(this.progressBarContainer);
+
+    this.timeRemainingEl = document.createElement("div");
+    this.timeRemainingEl.style.marginTop = "5px";
+    this.timeRemainingEl.style.fontSize = "11px";
+    this.timeRemainingEl.style.minHeight = "1.2em";
+    this.timeRemainingEl.textContent = "";
+    progressInfo.appendChild(this.timeRemainingEl);
+
+    progressSection.appendChild(progressInfo);
+
+    const cancelBtn = document.createElement("button");
+    cancelBtn.textContent = "Cancel";
+    cancelBtn.style.minWidth = "50px";
+    cancelBtn.onclick = () => {
+      this.cancelled = true;
+      if (this.onCancel) this.onCancel();
+      this.close();
+    };
+    progressSection.appendChild(cancelBtn);
+
+    content.appendChild(progressSection);
+
+    this.win = ShowDialogWindow({
+      title: this.title,
+      content: content,
+      modal: true,
+      parentWindow: this.parentWindow,
+      buttons: [],
+    });
+  }
+
+  update(status, from, to, currentProcessed) {
+    if (this.cancelled) return;
+
+    if (status) this.statusTextEl.textContent = status;
+    if (from) this.fromEl.textContent = `From '${from}'`;
+    if (to) this.toEl.textContent = `To '${to}'`;
+
+    if (currentProcessed !== undefined) {
+      this.processedSize = currentProcessed;
+    }
+
+    const percent = this.totalSize > 0 ? (this.processedSize / this.totalSize) * 100 : 0;
+    if (this.progressBar) {
+        this.progressBar.style.width = `${Math.min(100, percent)}%`;
+    }
+
+    // Time remaining
+    const now = Date.now();
+    const elapsed = (now - this.startTime) / 1000;
+    if (elapsed > 1 && this.processedSize > 0 && this.totalSize > 0) {
+      const speed = this.processedSize / elapsed;
+      const remaining = (this.totalSize - this.processedSize) / speed;
+      this.timeRemainingEl.textContent = this._formatTime(remaining);
+    }
+  }
+
+  setTotalSize(size) {
+    this.totalSize = size;
+  }
+
+  _formatTime(seconds) {
+    if (seconds < 1) return "0 Seconds Remaining";
+    if (seconds > 3600 * 24 * 7) return "Calculating...";
+    const minutes = Math.floor(seconds / 60);
+    const secs = Math.floor(seconds % 60);
+    if (minutes > 0) return `${minutes} Minutes Remaining`;
+    return `${secs} Seconds Remaining`;
+  }
+
+  close() {
+    if (this.win && !this.win.closed) {
+      this.win.close();
+    }
+  }
+}

--- a/src/apps/dos-games-downloader/dos-games-downloader.css
+++ b/src/apps/dos-games-downloader/dos-games-downloader.css
@@ -70,44 +70,6 @@
     color: #666;
 }
 
-.status-overlay {
-    position: absolute;
-    top: 0;
-    left: 0;
-    right: 0;
-    bottom: 0;
-    background: rgba(255, 255, 255, 0.8);
-    display: flex;
-    flex-direction: column;
-    justify-content: center;
-    align-items: center;
-    z-index: 10;
-}
-
 .hidden {
     display: none;
-}
-
-.status-message {
-    margin-bottom: 10px;
-    font-weight: bold;
-}
-
-.progress-bar-container {
-    width: 200px;
-    height: 20px;
-    border: 2px inset #dfdfdf;
-    background: #c0c0c0;
-}
-
-.progress-bar {
-    width: 100%; /* We don't have real progress yet, so just full or animated */
-    height: 100%;
-    background: navy;
-    animation: progress-indet 2s infinite linear;
-}
-
-@keyframes progress-indet {
-    0% { transform: translateX(-100%); }
-    100% { transform: translateX(100%); }
 }


### PR DESCRIPTION
This change enhances the DOS Games Downloader by moving the installation progress into a modal dialog that matches the Windows 98 Explorer file operation style. Key improvements include:

1. **Proxy Priority**: Switched the primary proxy to `api.codetabs.com` as requested.
2. **Visual Feedback**: The new dialog features the classic `copying.gif` animation and clearly shows the source URL and destination path.
3. **Real Progress Tracking**: Uses `ReadableStream` and recursive size calculation to provide byte-accurate progress updates and time remaining estimates.
4. **Cancellation**: Users can now cancel the installation at any time, which aborts the download and cleans up any partially extracted files.
5. **UI Polish**: Removed the embedded progress bar from the downloader's main view to focus on the search results.

---
*PR created automatically by Jules for task [6378535757513441567](https://jules.google.com/task/6378535757513441567) started by @azayrahmad*