### PR TITLE
Fix TypeError in $Window.js on iframe blur

### DIFF
--- a/public/os-gui/$Window.js
+++ b/public/os-gui/$Window.js
@@ -564,7 +564,7 @@
                   // This prevents the parent window from unfocusing when focus moves from the iframe to the window's titlebar, for example.
                   if (
                     !document.activeElement ||
-                    !$w.$window[0].contains(document.activeElement)
+                    !$w[0].contains(document.activeElement)
                   ) {
                     stopShowingAsFocused();
                   }


### PR DESCRIPTION
This PR fixes a `TypeError` in the `os-gui` library that occurred when interacting with or closing iframe-based applications. The error was caused by an incorrect property access in a focus-related event listener.

Changes:
- In `public/os-gui/$Window.js`, changed `$w.$window[0]` to `$w[0]` within the iframe blur handler.

Verification:
- Created a reproduction Playwright test that clicks the title bar of a DOS game and then closes it.
- Confirmed the error `Cannot read properties of undefined (reading '0')` was present before the fix.
- Confirmed the error is no longer present after the fix.
- Verified that existing DOSBox integration tests still pass.

---
*PR created automatically by Jules for task [12450131341397997874](https://jules.google.com/task/12450131341397997874) started by @azayrahmad*