### PR TITLE
Auto-close DOSBox games on exit

### DIFF
--- a/public/games/doom/index.html
+++ b/public/games/doom/index.html
@@ -21,6 +21,9 @@
                 onRuntimeInitialized: function() {
                     console.log("Doom runtime initialized in iframe");
                     window.parent.postMessage({ type: 'DOOM_READY' }, '*');
+                },
+                onExit: function() {
+                    window.parent.postMessage({ type: 'DOOM_EXIT' }, '*');
                 }
             };
         </script>

--- a/public/games/dos/doswasmx/host.html
+++ b/public/games/dos/doswasmx/host.html
@@ -69,11 +69,19 @@
                 window.parent.postMessage({ type: "DOSBOX_READY" }, "*");
             };
             window.myApp.initModule = newInit;
-            if (window.Module) window.Module.onRuntimeInitialized = newInit;
+            if (window.Module) {
+                window.Module.onRuntimeInitialized = newInit;
+                window.Module.onExit = function() {
+                    window.parent.postMessage({ type: "DOSBOX_EXIT" }, "*");
+                };
+            }
 
             const originalPrint = window.myApp.processPrintStatement;
             window.myApp.processPrintStatement = function(text) {
                 if (originalPrint) originalPrint.apply(window.myApp, arguments);
+                if (text && text.indexOf("QUIT_DOSBOX") !== -1) {
+                    window.parent.postMessage({ type: "DOSBOX_EXIT" }, "*");
+                }
                 if (text.startsWith("DEBUG_ShowMsg:")) {
                     const msg = text.substring(15).trim();
                     if (msg && msg.length > 1) showStatus(msg);

--- a/public/games/keen/index.html
+++ b/public/games/keen/index.html
@@ -40,6 +40,9 @@
             var Module = {
                 preRun: [],
                 postRun: [],
+                onExit: () => {
+                    window.parent.postMessage({ type: 'KEEN_EXIT' }, '*');
+                },
                 onRuntimeInitialized: () => {
                     // Load all save games from localStorage
                     for (let i = 0; i < localStorage.length; i++) {

--- a/src/apps/doom/doom-app.js
+++ b/src/apps/doom/doom-app.js
@@ -80,6 +80,10 @@ export class DoomApp extends Application {
       } else {
         this._startGame(this.availableWads[0] || "doom1.wad");
       }
+    } else if (event.data && event.data.type === "DOOM_EXIT") {
+      if (this.win) {
+        this.win.close();
+      }
     }
   }
 

--- a/src/apps/dos-box/dos-box-app.js
+++ b/src/apps/dos-box/dos-box-app.js
@@ -74,6 +74,10 @@ export class DosBoxApp extends Application {
     if (event.data && event.data.type === "DOSBOX_READY") {
       await this._setupFileSystem();
       this._startEmulator();
+    } else if (event.data && event.data.type === "DOSBOX_EXIT") {
+      if (this.win) {
+        this.win.close();
+      }
     }
   }
 
@@ -175,7 +179,7 @@ export class DosBoxApp extends Application {
           ? parts.slice(1)
           : parts;
       const dir = dirParts.join("\\");
-      dosCommands = `C:\ncd \\${dir}\n${exe} ${this.args.join(" ")}\n`;
+      dosCommands = `C:\r\ncd \\${dir}\r\n${exe} ${this.args.join(" ")}\r\necho QUIT_DOSBOX\r\nexit\r\n`;
     }
 
     if (guestWindow.startWithCommands) {

--- a/src/apps/keen/keen-app.js
+++ b/src/apps/keen/keen-app.js
@@ -15,6 +15,7 @@ export class KeenApp extends IFrameApplication {
 
   constructor(config) {
     super(config);
+    this._boundHandleMessage = this._handleMessage.bind(this);
   }
 
   _createWindow() {
@@ -50,6 +51,19 @@ export class KeenApp extends IFrameApplication {
   }
 
   _onLaunch() {
+    window.addEventListener("message", this._boundHandleMessage);
     this.win.focus();
+  }
+
+  _handleMessage(event) {
+    if (event.data && event.data.type === "KEEN_EXIT") {
+      if (this.win) {
+        this.win.close();
+      }
+    }
+  }
+
+  _onClose() {
+    window.removeEventListener("message", this._boundHandleMessage);
   }
 }


### PR DESCRIPTION
Automatically close and dispose the DOSBox window when a DOS game (launched via a shortcut or direct path) exits. This is achieved by appending termination commands to the emulator's execution sequence and setting up a communication bridge between the DOSBox iframe and the host application. Direct launches to the DOS prompt are unaffected and stay open.

---
*PR created automatically by Jules for task [9002835575924817878](https://jules.google.com/task/9002835575924817878) started by @azayrahmad*