### PR TITLE
Implement Default 2x Zoom with Cross-Browser Support

### DIFF
--- a/check_body_zoom.py
+++ b/check_body_zoom.py
@@ -1,0 +1,31 @@
+import asyncio
+from playwright.async_api import async_playwright
+
+async def main():
+    async with async_playwright() as p:
+        browser = await p.chromium.launch()
+        page = await browser.new_page()
+        await page.set_content("""
+            <body style="zoom: 2; margin: 0; padding: 0;">
+                <div id="target" style="width: 100px; height: 100px; background: red;"></div>
+            </body>
+        """)
+
+        await page.evaluate('''() => {
+            window.clickData = null;
+            document.onclick = (e) => {
+                window.clickData = {
+                    clientX: e.clientX,
+                    clientY: e.clientY
+                };
+            };
+        }''')
+
+        await page.mouse.click(100, 100)
+
+        pos = await page.evaluate('window.clickData')
+        print(f"Click at physical 100, 100 results in: {pos}")
+
+        await browser.close()
+
+asyncio.run(main())

--- a/check_zoom_offsets.py
+++ b/check_zoom_offsets.py
@@ -1,0 +1,42 @@
+import asyncio
+from playwright.async_api import async_playwright
+
+async def main():
+    async with async_playwright() as p:
+        browser = await p.chromium.launch()
+        page = await browser.new_page()
+        await page.set_content("""
+            <div id="container" style="zoom: 2; width: 400px; height: 300px; border: 1px solid black;">
+                <div id="child" style="width: 100px; height: 100px; background: red;"></div>
+            </div>
+        """)
+
+        # Check container
+        container = await page.evaluate('''() => {
+            const el = document.getElementById("container");
+            const rect = el.getBoundingClientRect();
+            return {
+                offsetWidth: el.offsetWidth,
+                offsetHeight: el.offsetHeight,
+                rectWidth: rect.width,
+                rectHeight: rect.height
+            };
+        }''')
+        print(f"Container: {container}")
+
+        # Check child
+        child = await page.evaluate('''() => {
+            const el = document.getElementById("child");
+            const rect = el.getBoundingClientRect();
+            return {
+                offsetWidth: el.offsetWidth,
+                offsetHeight: el.offsetHeight,
+                rectWidth: rect.width,
+                rectHeight: rect.height
+            };
+        }''')
+        print(f"Child: {child}")
+
+        await browser.close()
+
+asyncio.run(main())

--- a/index.html
+++ b/index.html
@@ -208,8 +208,9 @@
         </style>
     </head>
 
-    <body class="scanlines">
-        <div id="screen">
+    <body>
+        <div id="os-scale-wrapper">
+            <div id="screen" class="scanlines">
             <section
                 id="boot-screen"
                 aria-live="polite"
@@ -279,7 +280,8 @@
                     </filter>
                 </defs>
             </svg>
-            <script type="module" src="/src/main.js"></script>
+                <script type="module" src="/src/main.js"></script>
+            </div>
         </div>
     </body>
 </html>

--- a/public/os-gui/$Window.js
+++ b/public/os-gui/$Window.js
@@ -3,6 +3,8 @@
 
   const E = document.createElement.bind(document);
 
+  const { get_os_scale, is_os_zoom, get_mouse_pos } = window.os_gui_utils;
+
   /**
    * @param {Element | object | null | undefined} element
    * @returns {string}
@@ -1694,9 +1696,10 @@ You can also disable this warning by passing {iframes: {ignoreCrossOrigin: true}
       const screenRect = document
         .getElementById("screen")
         .getBoundingClientRect();
+      const scale = is_os_zoom() ? 1 : get_os_scale();
       $w.css({
-        left: drag_pointer_x - screenRect.left - drag_offset_x,
-        top: drag_pointer_y - screenRect.top - drag_offset_y,
+        left: (drag_pointer_x - screenRect.left) / scale - drag_offset_x,
+        top: (drag_pointer_y - screenRect.top) / scale - drag_offset_y,
       });
     };
     $w.$titlebar.css("touch-action", "none");
@@ -1755,8 +1758,9 @@ You can also disable this warning by passing {iframes: {ignoreCrossOrigin: true}
       const screenRect = document
         .getElementById("screen")
         .getBoundingClientRect();
-      drag_offset_x = e.clientX - screenRect.left - $w.position().left;
-      drag_offset_y = e.clientY - screenRect.top - $w.position().top;
+      const scale = is_os_zoom() ? 1 : get_os_scale();
+      drag_offset_x = (e.clientX - screenRect.left) / scale - $w.position().left;
+      drag_offset_y = (e.clientY - screenRect.top) / scale - $w.position().top;
       drag_pointer_x = e.clientX;
       drag_pointer_y = e.clientY;
       drag_pointer_id = e.pointerId ?? e.originalEvent?.pointerId; // originalEvent doesn't exist for triggerHandler()
@@ -1900,14 +1904,13 @@ You can also disable this warning by passing {iframes: {ignoreCrossOrigin: true}
             height: $w.outerHeight(),
           };
 
+          const scale = is_os_zoom() ? 1 : get_os_scale();
           resize_offset_x =
-            e.clientX +
-            scrollX -
+            (e.clientX + scrollX) / scale -
             rect.x -
             (x_axis === HANDLE_RIGHT ? rect.width : 0);
           resize_offset_y =
-            e.clientY +
-            scrollY -
+            (e.clientY + scrollY) / scale -
             rect.y -
             (y_axis === HANDLE_BOTTOM ? rect.height : 0);
           resize_pointer_x = e.clientX;
@@ -1947,8 +1950,11 @@ You can also disable this warning by passing {iframes: {ignoreCrossOrigin: true}
           $w.bringTitleBarInBounds();
         }
         function update_resize() {
-          const mouse_x = resize_pointer_x + scrollX - resize_offset_x;
-          const mouse_y = resize_pointer_y + scrollY - resize_offset_y;
+          const scale = is_os_zoom() ? 1 : get_os_scale();
+          const mouse_x =
+            (resize_pointer_x + scrollX) / scale - resize_offset_x;
+          const mouse_y =
+            (resize_pointer_y + scrollY) / scale - resize_offset_y;
           let delta_x = 0;
           let delta_y = 0;
           let width, height;

--- a/public/os-gui/$Window.js
+++ b/public/os-gui/$Window.js
@@ -833,8 +833,9 @@
         $w.trigger("minimize");
         if (minimize_target_el && !$w.hasClass("minimized-without-taskbar")) {
           window.playSound?.("Minimize");
-          const before_rect = $w.$titlebar[0].getBoundingClientRect();
-          const after_rect = minimize_target_el.getBoundingClientRect();
+          const { get_rect } = window.os_gui_utils;
+          const before_rect = get_rect($w.$titlebar[0]);
+          const after_rect = get_rect(minimize_target_el);
           $w.animateTitlebar(before_rect, after_rect, () => {
             $w.hide();
             $w.blur();
@@ -933,16 +934,17 @@
             }
           };
 
-          const before_rect = $w.$titlebar[0].getBoundingClientRect();
+          const { get_rect } = window.os_gui_utils;
+          const before_rect = get_rect($w.$titlebar[0]);
           let after_rect;
           $w.css("transform", "");
           if ($w.hasClass("minimized-without-taskbar")) {
             instantly_unminimize();
-            after_rect = $w.$titlebar[0].getBoundingClientRect();
+            after_rect = get_rect($w.$titlebar[0]);
             instantly_minimize();
           } else {
             instantly_minimize();
-            after_rect = $w.$titlebar[0].getBoundingClientRect();
+            after_rect = get_rect($w.$titlebar[0]);
             instantly_unminimize();
           }
           $w.animateTitlebar(before_rect, after_rect, () => {
@@ -968,9 +970,10 @@
       if ($w.is(":hidden")) {
         $w.trigger("restore");
         window.playSound?.("RestoreUp");
-        const before_rect = minimize_target_el.getBoundingClientRect();
+        const { get_rect } = window.os_gui_utils;
+        const before_rect = get_rect(minimize_target_el);
         $w.show();
-        const after_rect = $w.$titlebar[0].getBoundingClientRect();
+        const after_rect = get_rect($w.$titlebar[0]);
         $w.hide();
         $w.animateTitlebar(before_rect, after_rect, () => {
           $w.show();
@@ -1012,7 +1015,7 @@
 
         $w.addClass("maximized");
         const screen = document.getElementById("desktop-area");
-        const screenRect = screen.getBoundingClientRect();
+        const screenRect = window.os_gui_utils.get_rect(screen);
 
         $w.css({
           position: "absolute", // Changed from fixed
@@ -1036,17 +1039,18 @@
         }
       };
 
-      const before_rect = $w.$titlebar[0].getBoundingClientRect();
+      const { get_rect } = window.os_gui_utils;
+      const before_rect = get_rect($w.$titlebar[0]);
       let after_rect;
       $w.css("transform", "");
       const restoring = $w.hasClass("maximized");
       if (restoring) {
         instantly_unmaximize();
-        after_rect = $w.$titlebar[0].getBoundingClientRect();
+        after_rect = get_rect($w.$titlebar[0]);
         instantly_maximize();
       } else {
         instantly_maximize();
-        after_rect = $w.$titlebar[0].getBoundingClientRect();
+        after_rect = get_rect($w.$titlebar[0]);
         instantly_unmaximize();
       }
       $w.animateTitlebar(before_rect, after_rect, () => {
@@ -1603,7 +1607,7 @@ You can also disable this warning by passing {iframes: {ignoreCrossOrigin: true}
 
     $w.applyBounds = () => {
       const screen = document.getElementById("screen");
-      const rect = screen.getBoundingClientRect();
+      const rect = window.os_gui_utils.get_rect(screen);
       $w.css({
         left: Math.max(
           0,
@@ -1619,7 +1623,7 @@ You can also disable this warning by passing {iframes: {ignoreCrossOrigin: true}
     $w.bringTitleBarInBounds = () => {
       // Try to make the titlebar always accessible
       const screen = document.getElementById("screen");
-      const rect = screen.getBoundingClientRect();
+      const rect = window.os_gui_utils.get_rect(screen);
       const min_horizontal_pixels_on_screen = 40; // enough for space past a close button
       $w.css({
         left: Math.max(
@@ -1641,7 +1645,7 @@ You can also disable this warning by passing {iframes: {ignoreCrossOrigin: true}
 
     $w.center = () => {
       const screen = document.getElementById("screen");
-      const rect = screen.getBoundingClientRect();
+      const rect = window.os_gui_utils.get_rect(screen);
       $w.css({
         left: (rect.width - $w.width()) / 2,
         top: (rect.height - $w.height()) / 2,
@@ -1654,7 +1658,7 @@ You can also disable this warning by passing {iframes: {ignoreCrossOrigin: true}
       if ($w.hasClass("maximized")) {
         const screen = document.getElementById("desktop-area");
         if (screen) {
-          const screenRect = screen.getBoundingClientRect();
+          const screenRect = window.os_gui_utils.get_rect(screen);
           $w.css({
             width: screenRect.width,
             height: screenRect.height,
@@ -1690,16 +1694,16 @@ You can also disable this warning by passing {iframes: {ignoreCrossOrigin: true}
         drag_pointer_id === 1234567890 // allowing real events to affect a drag started with a synthetic event with this fake pointerId, for jspaint's Eye Gaze Mode!!
         // @TODO: find a better way to support synthetic events (could make the fake pointerId a formal part of the API contract at least...)
       ) {
-        drag_pointer_x = e.clientX ?? drag_pointer_x;
-        drag_pointer_y = e.clientY ?? drag_pointer_y;
+        const mousePos = get_mouse_pos(e);
+        drag_pointer_x = mousePos.x;
+        drag_pointer_y = mousePos.y;
       }
-      const screenRect = document
-        .getElementById("screen")
-        .getBoundingClientRect();
-      const scale = is_os_zoom() ? 1 : get_os_scale();
+      const screenRect = window.os_gui_utils.get_rect(
+        document.getElementById("screen"),
+      );
       $w.css({
-        left: (drag_pointer_x - screenRect.left) / scale - drag_offset_x,
-        top: (drag_pointer_y - screenRect.top) / scale - drag_offset_y,
+        left: drag_pointer_x - screenRect.left - drag_offset_x,
+        top: drag_pointer_y - screenRect.top - drag_offset_y,
       });
     };
     $w.$titlebar.css("touch-action", "none");
@@ -1755,12 +1759,12 @@ You can also disable this warning by passing {iframes: {ignoreCrossOrigin: true}
       if (customEvent.isDefaultPrevented()) {
         return; // allow custom drag behavior of component windows in jspaint (Tools / Colors)
       }
-      const screenRect = document
-        .getElementById("screen")
-        .getBoundingClientRect();
-      const scale = is_os_zoom() ? 1 : get_os_scale();
-      drag_offset_x = (e.clientX - screenRect.left) / scale - $w.position().left;
-      drag_offset_y = (e.clientY - screenRect.top) / scale - $w.position().top;
+      const screenRect = window.os_gui_utils.get_rect(
+        document.getElementById("screen"),
+      );
+      const mousePos = get_mouse_pos(e);
+      drag_offset_x = mousePos.x - screenRect.left - $w.position().left;
+      drag_offset_y = mousePos.y - screenRect.top - $w.position().top;
       drag_pointer_x = e.clientX;
       drag_pointer_y = e.clientY;
       drag_pointer_id = e.pointerId ?? e.originalEvent?.pointerId; // originalEvent doesn't exist for triggerHandler()
@@ -1904,13 +1908,15 @@ You can also disable this warning by passing {iframes: {ignoreCrossOrigin: true}
             height: $w.outerHeight(),
           };
 
-          const scale = is_os_zoom() ? 1 : get_os_scale();
+          const mousePos = get_mouse_pos(e);
           resize_offset_x =
-            (e.clientX + scrollX) / scale -
+            mousePos.x +
+            scrollX / get_os_scale() -
             rect.x -
             (x_axis === HANDLE_RIGHT ? rect.width : 0);
           resize_offset_y =
-            (e.clientY + scrollY) / scale -
+            mousePos.y +
+            scrollY / get_os_scale() -
             rect.y -
             (y_axis === HANDLE_BOTTOM ? rect.height : 0);
           resize_pointer_x = e.clientX;
@@ -1950,11 +1956,10 @@ You can also disable this warning by passing {iframes: {ignoreCrossOrigin: true}
           $w.bringTitleBarInBounds();
         }
         function update_resize() {
-          const scale = is_os_zoom() ? 1 : get_os_scale();
           const mouse_x =
-            (resize_pointer_x + scrollX) / scale - resize_offset_x;
+            resize_pointer_x + scrollX / get_os_scale() - resize_offset_x;
           const mouse_y =
-            (resize_pointer_y + scrollY) / scale - resize_offset_y;
+            resize_pointer_y + scrollY / get_os_scale() - resize_offset_y;
           let delta_x = 0;
           let delta_y = 0;
           let width, height;
@@ -2082,23 +2087,28 @@ You can also disable this warning by passing {iframes: {ignoreCrossOrigin: true}
       animating_titlebar = true;
       const $eye_leader = $w.$titlebar.clone(true);
       $eye_leader.find("button").remove();
-      $eye_leader.appendTo("body");
+
+      const screen = document.getElementById("screen");
+      const { get_rect } = window.os_gui_utils;
+      const screenRect = get_rect(screen);
+
+      $eye_leader.appendTo(screen);
       const duration_ms = $Window.OVERRIDE_TRANSITION_DURATION ?? 200; // TODO: how long?
       const duration_str = `${duration_ms}ms`;
       $eye_leader.css({
         transition: `left ${duration_str} linear, top ${duration_str} linear, width ${duration_str} linear, height ${duration_str} linear`,
-        position: "fixed",
+        position: "absolute",
         zIndex: 10000000,
         pointerEvents: "none",
-        left: from.left,
-        top: from.top,
+        left: from.left - screenRect.left,
+        top: from.top - screenRect.top,
         width: from.width,
         height: from.height,
       });
       setTimeout(() => {
         $eye_leader.css({
-          left: to.left,
-          top: to.top,
+          left: to.left - screenRect.left,
+          top: to.top - screenRect.top,
           width: to.width,
           height: to.height,
         });

--- a/public/os-gui/ContextMenu.js
+++ b/public/os-gui/ContextMenu.js
@@ -69,17 +69,16 @@
       wrap.style.zIndex = window.os_gui_utils.get_new_menu_z_index();
       wrap.style.position = "absolute";
 
+      const { get_rect } = window.os_gui_utils;
+      const screenRect = get_rect(screen);
+
       // Measure without showing
       wrap.classList.add("measuring");
-      const menuRect = menuPopup.element.getBoundingClientRect();
+      const menuRect = get_rect(menuPopup.element);
       wrap.classList.remove("measuring");
 
-      const { get_rect, get_os_scale, is_os_zoom } = window.os_gui_utils;
-      const screenRect = get_rect(screen);
-      const scale = is_os_zoom() ? 1 : get_os_scale();
-
-      const relX = x / scale - screenRect.left;
-      const relY = y / scale - screenRect.top;
+      const relX = x - screenRect.left;
+      const relY = y - screenRect.top;
 
       let finalX = relX;
       let finalY = relY;
@@ -119,7 +118,8 @@
     };
 
     // Position at pointer
-    positionAt(event.pageX, event.pageY);
+    const mousePos = window.os_gui_utils.get_mouse_pos(event);
+    positionAt(mousePos.x, mousePos.y);
 
     // After positioning, dispatch an update event to set initial checkbox states
     menuPopup.element.dispatchEvent(new CustomEvent("update", {}));

--- a/public/os-gui/ContextMenu.js
+++ b/public/os-gui/ContextMenu.js
@@ -74,9 +74,12 @@
       const menuRect = menuPopup.element.getBoundingClientRect();
       wrap.classList.remove("measuring");
 
-      const screenRect = screen.getBoundingClientRect();
-      const relX = x - screenRect.left;
-      const relY = y - screenRect.top;
+      const { get_rect, get_os_scale, is_os_zoom } = window.os_gui_utils;
+      const screenRect = get_rect(screen);
+      const scale = is_os_zoom() ? 1 : get_os_scale();
+
+      const relX = x / scale - screenRect.left;
+      const relY = y / scale - screenRect.top;
 
       let finalX = relX;
       let finalY = relY;

--- a/public/os-gui/MenuBar.js
+++ b/public/os-gui/MenuBar.js
@@ -348,7 +348,7 @@
       menus_el.appendChild(menu_button_el);
 
       const menu_popup_el = E("div", { class: "menu-popup-wrapper to-down" });
-      document.body?.appendChild(menu_popup_el);
+      document.getElementById("screen")?.appendChild(menu_popup_el);
       const menu_popup = new MenuPopup(menu_items, {
         handleKeyDown,
         closeMenus: close_menus,
@@ -370,24 +370,33 @@
       );
 
       const update_position = () => {
-        const rect = menu_button_el.getBoundingClientRect();
+        const { get_rect } = window.os_gui_utils;
+        const rect = get_rect(menu_button_el);
 
         // Measure without showing
         menu_popup_el.classList.add("measuring");
-        const popup_rect = menu_popup_el.getBoundingClientRect();
+        const popup_rect = get_rect(menu_popup_el);
         menu_popup_el.classList.remove("measuring");
 
-        menu_popup_el.style.position = "absolute";
-        menu_popup_el.style.left = `${(get_direction() === "rtl" ? rect.right - popup_rect.width : rect.left) + window.scrollX}px`;
-        menu_popup_el.style.top = `${rect.bottom + window.scrollY}px`;
+        const screen = document.getElementById("screen");
+        const screenRect = get_rect(screen);
 
-        const final_left = parseFloat(menu_popup_el.style.left);
-        if (final_left + popup_rect.width > innerWidth + window.scrollX) {
-          menu_popup_el.style.left = `${innerWidth + window.scrollX - popup_rect.width}px`;
+        menu_popup_el.style.position = "absolute";
+        let final_left = (get_direction() === "rtl" ? rect.right - popup_rect.width : rect.left);
+        let final_top = rect.bottom;
+
+        if (final_left + popup_rect.width > screenRect.right) {
+          final_left = screenRect.right - popup_rect.width;
         }
-        if (final_left < window.scrollX) {
-          menu_popup_el.style.left = `${window.scrollX}px`;
+        if (final_left < screenRect.left) {
+          final_left = screenRect.left;
         }
+
+        final_left -= screenRect.left;
+        final_top -= screenRect.top;
+
+        menu_popup_el.style.left = `${final_left}px`;
+        menu_popup_el.style.top = `${final_top}px`;
       };
       window.addEventListener("resize", update_position);
       menu_popup_el.addEventListener("update", update_position);
@@ -435,7 +444,7 @@
         menu_popup_el.setAttribute("dir", get_direction());
         if (window.inheritTheme) window.inheritTheme(menu_popup_el, menus_el);
         if (!menu_popup_el.parentElement)
-          document.body.appendChild(menu_popup_el);
+          document.getElementById("screen")?.appendChild(menu_popup_el);
         top_level_highlight(menus_key);
         menu_popup_el.dispatchEvent(new CustomEvent("update", {}));
         selecting_menus = true;

--- a/public/os-gui/MenuPopup.js
+++ b/public/os-gui/MenuPopup.js
@@ -252,7 +252,7 @@
           const submenu_popup_el_actual = submenu_popup.element;
           submenu_popup_el.appendChild(submenu_popup_el_actual);
 
-          document.body?.appendChild(submenu_popup_el);
+          document.getElementById("screen")?.appendChild(submenu_popup_el);
           // submenu_popup_el.style.display = "none"; // Managed by .open class
           item_el.setAttribute("aria-haspopup", "true");
           item_el.setAttribute("aria-expanded", "false");
@@ -284,38 +284,45 @@
               window.inheritTheme(submenu_popup_el, menu_popup_el);
             }
             if (!submenu_popup_el.parentElement) {
-              document.body.appendChild(submenu_popup_el);
+              document.getElementById("screen")?.appendChild(submenu_popup_el);
             }
             submenu_popup_el.dispatchEvent(new CustomEvent("update", {}));
 
-            const rect = item_el.getBoundingClientRect();
+            const { get_rect } = window.os_gui_utils;
+            const rect = get_rect(item_el);
 
             // Measure without showing
             submenu_popup_el.classList.add("measuring");
-            const submenu_popup_rect = submenu_popup_el.getBoundingClientRect();
+            const submenu_popup_rect = get_rect(submenu_popup_el);
             submenu_popup_el.classList.remove("measuring");
+
+            const screen = document.getElementById("screen");
+            const screenRect = get_rect(screen);
 
             let final_x =
               (get_direction() === "rtl"
                 ? rect.left - submenu_popup_rect.width
-                : rect.right) + window.scrollX;
-            let final_y = rect.top + window.scrollY;
+                : rect.right);
+            let final_y = rect.top;
             let from_left = false;
 
             if (get_direction() === "rtl") {
-              if (final_x < 0) {
+              if (final_x < screenRect.left) {
                 final_x = rect.right;
                 from_left = true;
               }
             } else {
-              if (final_x + submenu_popup_rect.width > innerWidth) {
+              if (final_x + submenu_popup_rect.width > screenRect.right) {
                 final_x = rect.left - submenu_popup_rect.width;
                 from_left = true;
               }
             }
-            if (final_y + submenu_popup_rect.height > innerHeight) {
-              final_y = Math.max(0, innerHeight - submenu_popup_rect.height);
+            if (final_y + submenu_popup_rect.height > screenRect.bottom) {
+              final_y = Math.max(screenRect.top, screenRect.bottom - submenu_popup_rect.height);
             }
+
+            final_x -= screenRect.left;
+            final_y -= screenRect.top;
 
             submenu_popup_el.style.left = `${final_x}px`;
             submenu_popup_el.style.top = `${final_y}px`;

--- a/public/os-gui/Toolbar.js
+++ b/public/os-gui/Toolbar.js
@@ -211,8 +211,14 @@
       const submenuItems =
         typeof item.submenu === "function" ? item.submenu() : item.submenu;
 
-      const parentRect = parentEl.getBoundingClientRect();
-      const event = { pageX: parentRect.left, pageY: parentRect.bottom };
+      const { get_rect, is_os_zoom, get_os_scale } = window.os_gui_utils;
+      const parentRect = get_rect(parentEl);
+      const scale = is_os_zoom() ? 1 : get_os_scale();
+
+      const event = {
+        clientX: parentRect.left * scale,
+        clientY: parentRect.bottom * scale,
+      };
       this.activeMenu = new window.ContextMenu(submenuItems, event);
     }
 
@@ -341,11 +347,14 @@
         );
       }
 
-      document.body.appendChild(this.overflowMenu);
+      const { get_rect } = window.os_gui_utils;
+      const screen = document.getElementById("screen");
+      const screenRect = get_rect(screen);
+      screen.appendChild(this.overflowMenu);
 
-      const parentRect = parentEl.getBoundingClientRect();
-      this.overflowMenu.style.left = `${parentRect.left}px`;
-      this.overflowMenu.style.top = `${parentRect.bottom}px`;
+      const parentRect = get_rect(parentEl);
+      this.overflowMenu.style.left = `${parentRect.left - screenRect.left}px`;
+      this.overflowMenu.style.top = `${parentRect.bottom - screenRect.top}px`;
 
       this.closeMenuOnClickOutside = (e) => {
         if (!this.overflowMenu.contains(e.target) && e.target !== parentEl) {

--- a/public/os-gui/utils.js
+++ b/public/os-gui/utils.js
@@ -70,15 +70,19 @@
     }
 
     /**
-     * @param {MouseEvent | Touch | PointerEvent} e
+     * @param {MouseEvent | Touch | PointerEvent | {clientX?: number, clientY?: number, pageX?: number, pageY?: number}} e
      * @returns {{x: number, y: number}}
      */
     function get_mouse_pos(e) {
-        if (is_os_zoom()) {
-            return { x: e.clientX, y: e.clientY };
-        }
+        const clientX = e.clientX ?? e.pageX ?? 0;
+        const clientY = e.clientY ?? e.pageY ?? 0;
         const scale = get_os_scale();
-        return { x: e.clientX / scale, y: e.clientY / scale };
+        const screen_el = document.getElementById("screen") || document.body;
+        const screen_rect = screen_el.getBoundingClientRect();
+        return {
+            x: (clientX - screen_rect.left) / scale,
+            y: (clientY - screen_rect.top) / scale,
+        };
     }
 
     /**
@@ -87,15 +91,14 @@
      */
     function get_rect(el) {
         const rect = el.getBoundingClientRect();
-        if (is_os_zoom()) {
-            return rect;
-        }
         const scale = get_os_scale();
+        const screen_el = document.getElementById("screen") || document.body;
+        const screen_rect = screen_el.getBoundingClientRect();
         return {
-            left: rect.left / scale,
-            top: rect.top / scale,
-            right: rect.right / scale,
-            bottom: rect.bottom / scale,
+            left: (rect.left - screen_rect.left) / scale,
+            top: (rect.top - screen_rect.top) / scale,
+            right: (rect.right - screen_rect.left) / scale,
+            bottom: (rect.bottom - screen_rect.top) / scale,
             width: rect.width / scale,
             height: rect.height / scale,
         };

--- a/public/os-gui/utils.js
+++ b/public/os-gui/utils.js
@@ -51,9 +51,63 @@
         }
     }
 
+    function get_os_scale() {
+        return (
+            parseFloat(
+                getComputedStyle(document.documentElement).getPropertyValue(
+                    "--os-scale",
+                ),
+            ) || 1
+        );
+    }
+
+    function is_os_zoom() {
+        return (
+            getComputedStyle(document.documentElement)
+                .getPropertyValue("--os-is-zoom")
+                .trim() === "1"
+        );
+    }
+
+    /**
+     * @param {MouseEvent | Touch | PointerEvent} e
+     * @returns {{x: number, y: number}}
+     */
+    function get_mouse_pos(e) {
+        if (is_os_zoom()) {
+            return { x: e.clientX, y: e.clientY };
+        }
+        const scale = get_os_scale();
+        return { x: e.clientX / scale, y: e.clientY / scale };
+    }
+
+    /**
+     * @param {Element} el
+     * @returns {{left: number, top: number, right: number, bottom: number, width: number, height: number}}
+     */
+    function get_rect(el) {
+        const rect = el.getBoundingClientRect();
+        if (is_os_zoom()) {
+            return rect;
+        }
+        const scale = get_os_scale();
+        return {
+            left: rect.left / scale,
+            top: rect.top / scale,
+            right: rect.right / scale,
+            bottom: rect.bottom / scale,
+            width: rect.width / scale,
+            height: rect.height / scale,
+        };
+    }
+
     exports.E = E;
     exports.uid = uid;
     exports.get_new_menu_z_index = get_new_menu_z_index;
     exports.get_direction = get_direction;
     exports.is_disabled = is_disabled;
+    exports.get_os_scale = get_os_scale;
+    exports.is_os_zoom = is_os_zoom;
+    exports.get_mouse_pos = get_mouse_pos;
+    exports.get_rect = get_rect;
 })(typeof module !== "undefined" ? module.exports : (window.os_gui_utils = {}));

--- a/src/apps/help/help-app.js
+++ b/src/apps/help/help-app.js
@@ -442,10 +442,7 @@ class HelpApp extends Application {
                 action: () => forwardButton.click()
             }
         ];
-        window.ContextMenu(menu, {
-            left: e.clientX,
-            top: e.clientY
-        });
+        window.ContextMenu(menu, e);
     });
 
     webHelpButton.addEventListener("click", () => {
@@ -475,8 +472,10 @@ class HelpApp extends Application {
 
     window.addEventListener("mousemove", (e) => {
       if (!isDragging) return;
-      const rect = win.$content[0].getBoundingClientRect();
-      const x = e.clientX - rect.left;
+      const { get_rect, get_mouse_pos } = window.os_gui_utils;
+      const rect = get_rect(win.$content[0]);
+      const pos = get_mouse_pos(e);
+      const x = pos.x - rect.left;
       const sidebarWidth = Math.max(50, Math.min(x, rect.width - 50));
       sidebar.style.flexBasis = `${sidebarWidth}px`;
       sidebar.style.width = `${sidebarWidth}px`; // Ensure it stays this width

--- a/src/apps/solitaire/solitaire-app.js
+++ b/src/apps/solitaire/solitaire-app.js
@@ -587,6 +587,8 @@ export class SolitaireApp extends Application {
     const cardDiv = target.closest(".card");
     if (!cardDiv) return;
 
+    const { get_rect } = window.os_gui_utils;
+
     const pileType = cardDiv.dataset.pileType;
     const pileIndex = parseInt(cardDiv.dataset.pileIndex, 10);
     const cardIndex = parseInt(cardDiv.dataset.cardIndex, 10);
@@ -632,8 +634,8 @@ export class SolitaireApp extends Application {
     else return;
 
     const cardsToDrag = fromPile.cards.slice(cardIndex);
-    const containerRect = this.container.getBoundingClientRect();
-    const cardRect = cardDiv.getBoundingClientRect();
+    const containerRect = get_rect(this.container);
+    const cardRect = get_rect(cardDiv);
     this.dragOffsetX = clientX - cardRect.left;
     this.dragOffsetY = clientY - cardRect.top;
 
@@ -699,7 +701,9 @@ export class SolitaireApp extends Application {
     if (!this.isDragging) return;
     this.wasDragged = true;
 
-    const containerRect = this.container.getBoundingClientRect();
+    const { get_rect } = window.os_gui_utils;
+
+    const containerRect = get_rect(this.container);
     const x = clientX - containerRect.left - this.dragOffsetX;
     const y = clientY - containerRect.top - this.dragOffsetY;
     this.draggedElement.style.left = `${x}px`;
@@ -834,11 +838,13 @@ export class SolitaireApp extends Application {
     if (event.button !== 0) return; // Only main button
     this.wasDragged = false;
     this.doubleTapHandled = false;
-    this.handleStart(event.clientX, event.clientY, event.target, false);
+    const pos = window.os_gui_utils.get_mouse_pos(event);
+    this.handleStart(pos.x, pos.y, event.target, false);
   }
 
   onMouseMove(event) {
-    this.handleMove(event.clientX, event.clientY);
+    const pos = window.os_gui_utils.get_mouse_pos(event);
+    this.handleMove(pos.x, pos.y);
   }
 
   onMouseUp(event) {
@@ -855,13 +861,15 @@ export class SolitaireApp extends Application {
     window.addEventListener("touchmove", this.boundOnTouchMove, { passive: false });
     window.addEventListener("touchend", this.boundOnTouchEnd);
 
-    this.handleStart(touch.clientX, touch.clientY, touch.target, true);
+    const pos = window.os_gui_utils.get_mouse_pos(touch);
+    this.handleStart(pos.x, pos.y, touch.target, true);
     event.preventDefault();
   }
 
   onTouchMove(event) {
     const touch = event.touches[0];
-    this.handleMove(touch.clientX, touch.clientY);
+    const pos = window.os_gui_utils.get_mouse_pos(touch);
+    this.handleMove(pos.x, pos.y);
     if (this.isDragging) {
       event.preventDefault();
     }
@@ -904,8 +912,9 @@ export class SolitaireApp extends Application {
 
     const canvas = this.win.element.querySelector(".win-animation-canvas");
     const gameBoard = this.win.element.querySelector(".game-board");
-    const boardRect = gameBoard.getBoundingClientRect();
-    const containerRect = this.container.getBoundingClientRect();
+    const { get_rect } = window.os_gui_utils;
+    const boardRect = get_rect(gameBoard);
+    const containerRect = get_rect(this.container);
 
     canvas.width = boardRect.width;
     canvas.height = boardRect.height;

--- a/src/apps/spider-solitaire/spider-solitaire-app.js
+++ b/src/apps/spider-solitaire/spider-solitaire-app.js
@@ -525,6 +525,8 @@ export class SpiderSolitaireApp extends Application {
     const cardDiv = target.closest(".card");
     if (!cardDiv) return;
 
+    const { get_rect } = window.os_gui_utils;
+
     const pileIndex = parseInt(cardDiv.dataset.pileIndex, 10);
     const cardIndex = parseInt(cardDiv.dataset.cardIndex, 10);
 
@@ -535,8 +537,8 @@ export class SpiderSolitaireApp extends Application {
       const fromPile = this.game.tableauPiles[pileIndex];
       const cardsToDrag = fromPile.cards.slice(cardIndex);
 
-      const containerRect = this.container.getBoundingClientRect();
-      const cardRect = cardDiv.getBoundingClientRect();
+      const containerRect = get_rect(this.container);
+      const cardRect = get_rect(cardDiv);
       this.dragOffsetX = clientX - cardRect.left;
       this.dragOffsetY = clientY - cardRect.top;
 
@@ -580,11 +582,12 @@ export class SpiderSolitaireApp extends Application {
   handleMove(clientX, clientY) {
     if (!this.isDragging) return;
     this.wasDragged = true;
-    const containerRect = this.container.getBoundingClientRect();
+    const { get_rect } = window.os_gui_utils;
+    const containerRect = get_rect(this.container);
     this.draggedElement.style.left = `${clientX - containerRect.left - this.dragOffsetX}px`;
     this.draggedElement.style.top = `${clientY - containerRect.top - this.dragOffsetY}px`;
 
-    const draggedRect = this.draggedElement.getBoundingClientRect();
+    const draggedRect = get_rect(this.draggedElement);
     const potentialTargets = this.container.querySelectorAll(
       ".tableau-pile, .tableau-placeholder",
     );
@@ -658,11 +661,13 @@ export class SpiderSolitaireApp extends Application {
   onMouseDown(event) {
     if (event.button !== 0) return; // Only main button
     this.wasDragged = false;
-    this.handleStart(event.clientX, event.clientY, event.target, false);
+    const pos = window.os_gui_utils.get_mouse_pos(event);
+    this.handleStart(pos.x, pos.y, event.target, false);
   }
 
   onMouseMove(event) {
-    this.handleMove(event.clientX, event.clientY);
+    const pos = window.os_gui_utils.get_mouse_pos(event);
+    this.handleMove(pos.x, pos.y);
   }
 
   async onMouseUp(event) {
@@ -678,13 +683,15 @@ export class SpiderSolitaireApp extends Application {
     window.addEventListener("touchmove", this.boundOnTouchMove, { passive: false });
     window.addEventListener("touchend", this.boundOnTouchEnd);
 
-    this.handleStart(touch.clientX, touch.clientY, touch.target, true);
+    const pos = window.os_gui_utils.get_mouse_pos(touch);
+    this.handleStart(pos.x, pos.y, touch.target, true);
     event.preventDefault();
   }
 
   onTouchMove(event) {
     const touch = event.touches[0];
-    this.handleMove(touch.clientX, touch.clientY);
+    const pos = window.os_gui_utils.get_mouse_pos(touch);
+    this.handleMove(pos.x, pos.y);
     if (this.isDragging) {
       event.preventDefault();
     }
@@ -748,7 +755,8 @@ export class SpiderSolitaireApp extends Application {
     return new Promise((resolve) => {
       let startRect;
       if (this.use98Style) {
-        const containerRect = this.container.getBoundingClientRect();
+        const { get_rect } = window.os_gui_utils;
+        const containerRect = get_rect(this.container);
         startRect = {
           left: containerRect.left,
           top: containerRect.bottom,
@@ -766,10 +774,11 @@ export class SpiderSolitaireApp extends Application {
           this.container.querySelector(".stock-pile").getBoundingClientRect();
       }
 
+      const { get_rect } = window.os_gui_utils;
       const tableauPileRects = Array.from(
         this.container.querySelectorAll(".tableau-pile"),
-      ).map((pile) => pile.getBoundingClientRect());
-      const containerRect = this.container.getBoundingClientRect();
+      ).map((pile) => get_rect(pile));
+      const containerRect = get_rect(this.container);
 
       const animationLayer = document.createElement("div");
       animationLayer.className = "animation-layer";
@@ -833,7 +842,8 @@ export class SpiderSolitaireApp extends Application {
 
     return new Promise((resolve) => {
       let targetRect;
-      const containerRect = this.container.getBoundingClientRect();
+      const { get_rect } = window.os_gui_utils;
+      const containerRect = get_rect(this.container);
 
       if (this.use98Style) {
         targetRect = {
@@ -850,7 +860,7 @@ export class SpiderSolitaireApp extends Application {
           this.container.querySelectorAll(".foundation-pile")[
             foundationPileIndex
           ];
-        targetRect = foundationPileEl.getBoundingClientRect();
+        targetRect = get_rect(foundationPileEl);
       }
       const animationLayer = document.createElement("div");
       animationLayer.className = "animation-layer";
@@ -875,7 +885,7 @@ export class SpiderSolitaireApp extends Application {
         );
         if (!originalCardEl) return;
 
-        const startRect = originalCardEl.getBoundingClientRect();
+        const startRect = get_rect(originalCardEl);
 
         const cardDiv = card.element.cloneNode(true);
         cardDiv.style.position = "absolute";

--- a/src/shared/styles/main.css
+++ b/src/shared/styles/main.css
@@ -85,6 +85,11 @@ html {
     cursor: var(--cursor-default);
 }
 
+#os-scale-wrapper {
+    width: 100%;
+    height: 100%;
+}
+
 #screen {
     position: relative;
     overflow: hidden;

--- a/src/shared/styles/scanlines-css.css
+++ b/src/shared/styles/scanlines-css.css
@@ -14,7 +14,7 @@
     display: block;
     pointer-events: none;
     content: "";
-    position: fixed;
+    position: absolute;
     top: 0;
     left: 0;
     bottom: 0;
@@ -52,7 +52,7 @@
         filter 0.5s ease;
 }
 
-.scanlines #screen {
+#screen.scanlines {
     animation:
         crt-flicker 0.15s infinite,
         crt-power-on 0.8s ease-out forwards;

--- a/src/shell/desktop/desktop.js
+++ b/src/shell/desktop/desktop.js
@@ -581,11 +581,12 @@ export async function initDesktop(profile = null) {
   desktopController.iconManager = new IconManager(desktop, {
     iconSelector: ".explorer-icon",
     onDragStart: (e, icon, selectedIcons, x, y, isTouch) => {
+      const pos = window.os_gui_utils.get_mouse_pos(e);
       DragDropManager.startDrag(
         selectedIcons,
         desktopController,
-        x !== undefined ? x : e.clientX,
-        y !== undefined ? y : e.clientY,
+        x !== undefined ? x : pos.x,
+        y !== undefined ? y : pos.y,
         isTouch
       );
     },

--- a/src/shell/desktop/icon-manager.js
+++ b/src/shell/desktop/icon-manager.js
@@ -116,11 +116,10 @@ export class IconManager {
     if (e.button !== 0) return; // Only for left click
 
     this.isLassoing = true;
-    const containerRect = this.container.getBoundingClientRect();
-    const isZoom = window.os_gui_utils.is_os_zoom();
-    const scale = window.os_gui_utils.get_os_scale();
-    const rectLeft = isZoom ? containerRect.left : containerRect.left / scale;
-    const rectTop = isZoom ? containerRect.top : containerRect.top / scale;
+    const { get_rect } = window.os_gui_utils;
+    const containerRect = get_rect(this.container);
+    const rectLeft = containerRect.left;
+    const rectTop = containerRect.top;
     const pos = window.os_gui_utils.get_mouse_pos(e);
 
     const lassoStartX = pos.x - rectLeft + this.container.scrollLeft;

--- a/src/shell/desktop/icon-manager.js
+++ b/src/shell/desktop/icon-manager.js
@@ -117,8 +117,14 @@ export class IconManager {
 
     this.isLassoing = true;
     const containerRect = this.container.getBoundingClientRect();
-    const lassoStartX = e.clientX - containerRect.left + this.container.scrollLeft;
-    const lassoStartY = e.clientY - containerRect.top + this.container.scrollTop;
+    const isZoom = window.os_gui_utils.is_os_zoom();
+    const scale = window.os_gui_utils.get_os_scale();
+    const rectLeft = isZoom ? containerRect.left : containerRect.left / scale;
+    const rectTop = isZoom ? containerRect.top : containerRect.top / scale;
+    const pos = window.os_gui_utils.get_mouse_pos(e);
+
+    const lassoStartX = pos.x - rectLeft + this.container.scrollLeft;
+    const lassoStartY = pos.y - rectTop + this.container.scrollTop;
 
 
     this.lasso = document.createElement("div");
@@ -133,8 +139,9 @@ export class IconManager {
       if (!this.isLassoing) return;
       this.wasLassoing = true;
 
-      const currentX = moveEvent.clientX - containerRect.left + this.container.scrollLeft;
-      const currentY = moveEvent.clientY - containerRect.top + this.container.scrollTop;
+      const movePos = window.os_gui_utils.get_mouse_pos(moveEvent);
+      const currentX = movePos.x - rectLeft + this.container.scrollLeft;
+      const currentY = movePos.y - rectTop + this.container.scrollTop;
 
       const width = Math.abs(currentX - lassoStartX);
       const height = Math.abs(currentY - lassoStartY);
@@ -224,8 +231,9 @@ export class IconManager {
 
   handleTouchStart(e, icon) {
     if (e.touches.length !== 1) return;
-    this.touchStartX = e.touches[0].clientX;
-    this.touchStartY = e.touches[0].clientY;
+    const pos = window.os_gui_utils.get_mouse_pos(e.touches[0]);
+    this.touchStartX = pos.x;
+    this.touchStartY = pos.y;
     this.touchIcon = icon;
     this.isTouchDragging = false;
 
@@ -239,8 +247,9 @@ export class IconManager {
     if (this.isTouchDragging) return;
     if (e.touches.length !== 1) return;
 
-    const touchX = e.touches[0].clientX;
-    const touchY = e.touches[0].clientY;
+    const pos = window.os_gui_utils.get_mouse_pos(e.touches[0]);
+    const touchX = pos.x;
+    const touchY = pos.y;
     const dist = Math.sqrt(
       Math.pow(touchX - this.touchStartX, 2) +
         Math.pow(touchY - this.touchStartY, 2),
@@ -274,13 +283,15 @@ export class IconManager {
       this.setSelection(new Set([icon]));
     }
 
-    const startX = e.clientX;
-    const startY = e.clientY;
+    const pos = window.os_gui_utils.get_mouse_pos(e);
+    const startX = pos.x;
+    const startY = pos.y;
 
     const onMouseMove = (moveEvent) => {
+      const movePos = window.os_gui_utils.get_mouse_pos(moveEvent);
       const dist = Math.sqrt(
-        Math.pow(moveEvent.clientX - startX, 2) +
-          Math.pow(moveEvent.clientY - startY, 2),
+        Math.pow(movePos.x - startX, 2) +
+          Math.pow(movePos.y - startY, 2),
       );
       if (dist > 5) {
         document.removeEventListener("mousemove", onMouseMove);

--- a/src/shell/display-properties/displayproperties.css
+++ b/src/shell/display-properties/displayproperties.css
@@ -169,6 +169,18 @@
     margin-top: 10px;
 }
 
+.scaling-slider-container {
+    display: flex;
+    align-items: center;
+    gap: 5px;
+    margin-top: 5px;
+}
+
+.current-scaling {
+    text-align: center;
+    margin-top: 10px;
+}
+
 .advanced-container {
     display: flex;
     gap: 5px;

--- a/src/shell/display-properties/settings/settings.html
+++ b/src/shell/display-properties/settings/settings.html
@@ -21,6 +21,15 @@
         <div class="current-resolution">800 by 600 pixels</div>
     </fieldset>
 </div>
+<fieldset class="scaling-fieldset">
+    <legend>Scaling</legend>
+    <div class="scaling-slider-container">
+        <span>1x</span>
+        <input id="scaling-slider" type="range" min="1" max="3" step="0.5" value="2" />
+        <span>3x</span>
+    </div>
+    <div class="current-scaling">2.0x</div>
+</fieldset>
 <div class="advanced-container">
   <div class="field-row">
       <input type="checkbox" id="extend-checkbox" disabled checked/>

--- a/src/shell/display-properties/settings/settings.js
+++ b/src/shell/display-properties/settings/settings.js
@@ -7,6 +7,8 @@ import {
   getAvailableResolutions,
   setResolution,
   getCurrentResolutionId,
+  getScale,
+  setScale,
 } from '../../../system/screen-manager.js';
 
 const PALETTES = {
@@ -64,6 +66,8 @@ export const settingsTab = {
     const $colorModeSelect = win.$content.find("#color-mode-select");
     const $resolutionSlider = win.$content.find("#resolution-slider");
     const $currentResolution = win.$content.find(".current-resolution");
+    const $scalingSlider = win.$content.find("#scaling-slider");
+    const $currentScaling = win.$content.find(".current-scaling");
     const $browserInfo = win.$content.find(".browser-info");
 
     const colorModes = getColorModes();
@@ -88,6 +92,11 @@ export const settingsTab = {
     );
     app.selectedResolution = currentResolutionId;
 
+    const currentScale = getScale();
+    $scalingSlider.val(currentScale);
+    $currentScaling.text(`${currentScale.toFixed(1)}x`);
+    app.selectedScale = currentScale;
+
     $browserInfo.text(navigator.userAgent);
 
     $colorModeSelect.on("change", (e) => {
@@ -105,6 +114,13 @@ export const settingsTab = {
       );
       app._enableApplyButton(win);
     });
+
+    $scalingSlider.on("input", (e) => {
+      const scale = parseFloat($(e.target).val());
+      app.selectedScale = scale;
+      $currentScaling.text(`${scale.toFixed(1)}x`);
+      app._enableApplyButton(win);
+    });
   },
   applyChanges(app) {
     if (app.selectedColorMode) {
@@ -112,6 +128,9 @@ export const settingsTab = {
     }
     if (app.selectedResolution) {
       setResolution(app.selectedResolution);
+    }
+    if (app.selectedScale) {
+      setScale(app.selectedScale);
     }
   },
 };

--- a/src/shell/explorer/file-operations/drag-drop-manager.js
+++ b/src/shell/explorer/file-operations/drag-drop-manager.js
@@ -22,13 +22,12 @@ export class DragDropManager {
         this.isDragging = true;
         this.isTouchDrag = isTouch;
 
-        const isZoom = window.os_gui_utils.is_os_zoom();
-        const scale = window.os_gui_utils.get_os_scale();
+        const { get_rect } = window.os_gui_utils;
 
         this.draggedItems = iconElements.map(el => {
-            const rect = el.getBoundingClientRect();
-            const rectLeft = isZoom ? rect.left : rect.left / scale;
-            const rectTop = isZoom ? rect.top : rect.top / scale;
+            const rect = get_rect(el);
+            const rectLeft = rect.left;
+            const rectTop = rect.top;
             return {
                 element: el,
                 path: el.getAttribute('data-path'),
@@ -167,14 +166,12 @@ export class DragDropManager {
         }
 
         if (container) {
-            const rect = container.getBoundingClientRect();
-            const isZoom = window.os_gui_utils.is_os_zoom();
-            const scale = window.os_gui_utils.get_os_scale();
-            const rectLeft = isZoom ? rect.left : rect.left / scale;
-            const rectTop = isZoom ? rect.top : rect.top / scale;
+            const rect = window.os_gui_utils.get_rect(container);
+            const rectLeft = rect.left;
+            const rectTop = rect.top;
 
-            dropX = x - rectLeft + (container.scrollLeft || 0) - offsetX;
-            dropY = y - rectTop + (container.scrollTop || 0) - offsetY;
+            dropX = x - rectLeft + (container.scrollLeft / window.os_gui_utils.get_os_scale() || 0) - offsetX;
+            dropY = y - rectTop + (container.scrollTop / window.os_gui_utils.get_os_scale() || 0) - offsetY;
         }
         const sourceDir = sourcePaths[0].substring(0, sourcePaths[0].lastIndexOf('/')) || '/';
         if (!isCopy && destinationPath === sourceDir) {

--- a/src/shell/explorer/file-operations/drag-drop-manager.js
+++ b/src/shell/explorer/file-operations/drag-drop-manager.js
@@ -21,14 +21,20 @@ export class DragDropManager {
         if (this.isDragging) return;
         this.isDragging = true;
         this.isTouchDrag = isTouch;
+
+        const isZoom = window.os_gui_utils.is_os_zoom();
+        const scale = window.os_gui_utils.get_os_scale();
+
         this.draggedItems = iconElements.map(el => {
             const rect = el.getBoundingClientRect();
+            const rectLeft = isZoom ? rect.left : rect.left / scale;
+            const rectTop = isZoom ? rect.top : rect.top / scale;
             return {
                 element: el,
                 path: el.getAttribute('data-path'),
                 type: el.getAttribute('data-type'),
-                offsetX: x - rect.left,
-                offsetY: y - rect.top
+                offsetX: x - rectLeft,
+                offsetY: y - rectTop
             };
         });
         this.sourceApp = sourceApp;
@@ -79,8 +85,9 @@ export class DragDropManager {
 
     _handleMouseMove(e) {
         if (!this.isDragging) return;
-        const x = e.touches ? e.touches[0].clientX : e.clientX;
-        const y = e.touches ? e.touches[0].clientY : e.clientY;
+        const pos = window.os_gui_utils.get_mouse_pos(e.touches ? e.touches[0] : e);
+        const x = pos.x;
+        const y = pos.y;
 
         if (this.isTouchDrag && e.cancelable) {
             e.preventDefault();
@@ -133,8 +140,9 @@ export class DragDropManager {
         };
 
         const isCopy = e.ctrlKey;
-        const x = (e.changedTouches && e.changedTouches[0]) ? e.changedTouches[0].clientX : e.clientX;
-        const y = (e.changedTouches && e.changedTouches[0]) ? e.changedTouches[0].clientY : e.clientY;
+        const pos = window.os_gui_utils.get_mouse_pos((e.changedTouches && e.changedTouches[0]) ? e.changedTouches[0] : e);
+        const x = pos.x;
+        const y = pos.y;
 
         this._performDrop(x, y, isCopy, dragData);
         this._cleanup();
@@ -160,8 +168,13 @@ export class DragDropManager {
 
         if (container) {
             const rect = container.getBoundingClientRect();
-            dropX = x - rect.left + (container.scrollLeft || 0) - offsetX;
-            dropY = y - rect.top + (container.scrollTop || 0) - offsetY;
+            const isZoom = window.os_gui_utils.is_os_zoom();
+            const scale = window.os_gui_utils.get_os_scale();
+            const rectLeft = isZoom ? rect.left : rect.left / scale;
+            const rectTop = isZoom ? rect.top : rect.top / scale;
+
+            dropX = x - rectLeft + (container.scrollLeft || 0) - offsetX;
+            dropY = y - rectTop + (container.scrollTop || 0) - offsetY;
         }
         const sourceDir = sourcePaths[0].substring(0, sourcePaths[0].lastIndexOf('/')) || '/';
         if (!isCopy && destinationPath === sourceDir) {

--- a/src/system/local-storage.js
+++ b/src/system/local-storage.js
@@ -23,6 +23,7 @@ export const LOCAL_STORAGE_KEYS = {
   SOUND_SCHEME: 'soundScheme',
   COLOR_MODE: 'colorMode',
   SCREEN_RESOLUTION: 'screenResolution',
+  SCREEN_SCALE: 'screenScale',
   DROPPED_FILES: 'droppedFiles',
   SOLITAIRE_CARD_BACK: 'solitaire:cardBack',
   SOLITAIRE_DRAW_OPTION: 'solitaireDrawOption',

--- a/src/system/os-init.js
+++ b/src/system/os-init.js
@@ -32,6 +32,7 @@ import { appManager } from "./app-manager.js";
 import { WindowManager } from "./window-manager.js";
 
 export async function initializeOS() {
+  initScreenManager();
   const isMSDOSMode = window.location.hash === "#msdos";
 
   // Initialize Window Management System
@@ -394,7 +395,6 @@ export async function initializeOS() {
     window.addEventListener("keydown", resetInactivityTimer);
 
     resetInactivityTimer();
-    initScreenManager();
   } catch (error) {
     if (error.message !== "Setup interrupted") {
       console.error("An error occurred during boot:", error);

--- a/src/system/screen-manager.js
+++ b/src/system/screen-manager.js
@@ -8,11 +8,17 @@ const RESOLUTIONS = {
 };
 
 const DEFAULT_RESOLUTION = "fit";
+const DEFAULT_SCALE = 2;
 
 let currentResolutionId = DEFAULT_RESOLUTION;
+let currentScale = DEFAULT_SCALE;
 
 function getScreenElement() {
   return document.getElementById("screen");
+}
+
+function getScaleWrapper() {
+  return document.getElementById("os-scale-wrapper");
 }
 
 function getAvailableResolutions() {
@@ -21,6 +27,48 @@ function getAvailableResolutions() {
 
 function getCurrentResolutionId() {
   return currentResolutionId;
+}
+
+function getScale() {
+  return currentScale;
+}
+
+function setScale(scale) {
+  currentScale = scale;
+  setItem(LOCAL_STORAGE_KEYS.SCREEN_SCALE, scale);
+  applyScale();
+  // Trigger resize because scaling changes the available area
+  window.dispatchEvent(new Event("resize"));
+}
+
+function loadScale() {
+  const saved = getItem(LOCAL_STORAGE_KEYS.SCREEN_SCALE);
+  return saved !== null && saved !== undefined ? parseFloat(saved) : DEFAULT_SCALE;
+}
+
+function applyScale() {
+  const scale = currentScale;
+  const screen = getScreenElement();
+  const scaleWrapper = getScaleWrapper();
+  if (!screen || !scaleWrapper) return;
+
+  const isZoomSupported = 'zoom' in document.body.style;
+
+  // Set CSS variables for coordinate adjustment
+  document.documentElement.style.setProperty('--os-scale', scale);
+  document.documentElement.style.setProperty('--os-is-zoom', isZoomSupported ? '1' : '0');
+
+  if (isZoomSupported) {
+    document.body.style.zoom = scale;
+    scaleWrapper.style.transform = '';
+    scaleWrapper.style.transformOrigin = '';
+  } else {
+    document.body.style.zoom = '';
+    scaleWrapper.style.transform = `scale(${scale})`;
+    scaleWrapper.style.transformOrigin = 'top left';
+  }
+
+  setResolution(currentResolutionId);
 }
 
 function setResolution(resolutionId) {
@@ -35,16 +83,28 @@ function setResolution(resolutionId) {
     return;
   }
 
+  const scale = currentScale;
+  const isZoomSupported = 'zoom' in document.body.style;
+
   if (resolutionId === "fit") {
     // document.body.classList.add("fit-mode");
-    document.body.style.height = `${window.innerHeight}px`;
+    if (isZoomSupported) {
+      document.body.style.width = `${100 / scale}vw`;
+      document.body.style.height = `${100 / scale}vh`;
+      screen.style.width = "100%";
+      screen.style.height = "100%";
+    } else {
+      document.body.style.width = "100vw";
+      document.body.style.height = "100vh";
+      screen.style.width = `${100 / scale}vw`;
+      screen.style.height = `${100 / scale}vh`;
+    }
     document.body.style.minHeight = "0";
-    screen.style.width = "100%";
-    screen.style.height = "100%";
   } else {
     // document.body.classList.remove("fit-mode");
-    document.body.style.height = ""; // Revert to CSS default
-    document.body.style.minHeight = ""; // Revert to CSS default
+    document.body.style.width = "";
+    document.body.style.height = "";
+    document.body.style.minHeight = "";
     const newResolution = RESOLUTIONS[resolutionId];
     screen.style.width =
       typeof newResolution.width === "number"
@@ -70,12 +130,30 @@ function loadResolution() {
 }
 
 function initScreenManager() {
+  currentScale = loadScale();
   const savedResolution = loadResolution();
+
+  applyScale();
   setResolution(savedResolution);
 
   window.addEventListener("resize", () => {
     if (currentResolutionId === "fit") {
-      document.body.style.height = `${window.innerHeight}px`;
+      const scale = currentScale;
+      const isZoomSupported = 'zoom' in document.body.style;
+      const screen = getScreenElement();
+      if (isZoomSupported) {
+        document.body.style.width = `${100 / scale}vw`;
+        document.body.style.height = `${100 / scale}vh`;
+        if (screen) {
+          screen.style.width = "100%";
+          screen.style.height = "100%";
+        }
+      } else {
+        if (screen) {
+          screen.style.width = `${100 / scale}vw`;
+          screen.style.height = `${100 / scale}vh`;
+        }
+      }
       document.body.style.minHeight = "0";
     }
   });
@@ -86,4 +164,6 @@ export {
   getAvailableResolutions,
   setResolution,
   getCurrentResolutionId,
+  getScale,
+  setScale,
 };

--- a/verify_display_props.py
+++ b/verify_display_props.py
@@ -1,0 +1,37 @@
+import asyncio
+from playwright.async_api import async_playwright
+
+async def main():
+    async with async_playwright() as p:
+        browser = await p.chromium.launch()
+        page = await browser.new_page(viewport={'width': 1024, 'height': 768})
+        await page.goto('http://localhost:5173/win98-web/')
+
+        await page.wait_for_selector('.desktop', timeout=30000)
+        await asyncio.sleep(2)
+
+        # Open Display Properties (Settings tab)
+        # Right click desktop -> Properties
+        await page.locator('.desktop').click(button='right', position={'x': 100, 'y': 100})
+        await page.locator('text="Properties"').click()
+
+        # Wait for window
+        await page.wait_for_selector('.window-title:has-text("Display Properties")')
+
+        # Go to Settings tab
+        await page.locator('.tabs .tab:has-text("Settings")').click()
+
+        await asyncio.sleep(1)
+        await page.screenshot(path='/home/jules/verification/display_properties_settings.png')
+
+        # Check if slider exists
+        slider = page.locator('input[type="range"]')
+        if await slider.count() > 0:
+            val = await slider.get_attribute('value')
+            print(f"Scale slider value: {val}")
+        else:
+            print("Scale slider not found!")
+
+        await browser.close()
+
+asyncio.run(main())

--- a/verify_scaling_v2.py
+++ b/verify_scaling_v2.py
@@ -1,0 +1,42 @@
+import asyncio
+from playwright.async_api import async_playwright
+
+async def main():
+    async with async_playwright() as p:
+        browser = await p.chromium.launch()
+        page = await browser.new_page(viewport={'width': 800, 'height': 600})
+        await page.goto('http://localhost:5173/win98-web/')
+
+        # Wait for boot
+        print("Waiting for desktop...")
+        await page.wait_for_selector('.desktop', timeout=5173/win98-web0)
+        await asyncio.sleep(2) # Stabilize
+
+        # Check scale
+        scale = await page.evaluate('getComputedStyle(document.documentElement).getPropertyValue("--os-scale")')
+        print(f"OS Scale: {scale}")
+
+        # Check My Computer position
+        my_computer = page.locator('text="My Computer"').first
+        box = await my_computer.bounding_box()
+        print(f"My Computer bounding box: {box}")
+
+        # Right click to open context menu
+        print("Opening context menu...")
+        await page.mouse.click(400, 300, button="right")
+        await asyncio.sleep(1)
+        await page.screenshot(path='/home/jules/verification/context_menu_test.png')
+
+        # Check if context menu exists
+        menu = page.locator('.menu-popup-wrapper').last
+        if await menu.count() > 0:
+            menu_box = await menu.bounding_box()
+            print(f"Context menu box: {menu_box}")
+            # Mouse was at 400, 300. Menu should be near it.
+            # (Note: menu might be offset depending on its own size/animation)
+        else:
+            print("Context menu not found!")
+
+        await browser.close()
+
+asyncio.run(main())

--- a/verify_scaling_v3.py
+++ b/verify_scaling_v3.py
@@ -1,0 +1,42 @@
+import asyncio
+from playwright.async_api import async_playwright
+
+async def main():
+    async with async_playwright() as p:
+        browser = await p.chromium.launch()
+        page = await browser.new_page(viewport={'width': 800, 'height': 600})
+        await page.goto('http://localhost:5173/win98-web/')
+
+        # Wait for boot
+        print("Waiting for desktop...")
+        try:
+            await page.wait_for_selector('.desktop', timeout=30000)
+        except Exception as e:
+            print(f"Failed to find desktop: {e}")
+            await page.screenshot(path='/home/jules/verification/failed_boot.png')
+            await browser.close()
+            return
+
+        await asyncio.sleep(2) # Stabilize
+
+        # Check scale
+        scale = await page.evaluate('getComputedStyle(document.documentElement).getPropertyValue("--os-scale")')
+        print(f"OS Scale: {scale}")
+
+        # Right click to open context menu
+        print("Opening context menu...")
+        await page.mouse.click(400, 300, button="right")
+        await asyncio.sleep(2)
+        await page.screenshot(path='/home/jules/verification/context_menu_test.png')
+
+        # Check if context menu exists
+        menu = page.locator('.menu-popup-wrapper').last
+        if await menu.count() > 0:
+            menu_box = await menu.bounding_box()
+            print(f"Context menu box: {menu_box}")
+        else:
+            print("Context menu not found!")
+
+        await browser.close()
+
+asyncio.run(main())

--- a/verify_scaling_v4.py
+++ b/verify_scaling_v4.py
@@ -1,0 +1,56 @@
+import asyncio
+from playwright.async_api import async_playwright
+
+async def main():
+    async with async_playwright() as p:
+        browser = await p.chromium.launch()
+        # Use a larger viewport to avoid edge issues
+        page = await browser.new_page(viewport={'width': 1024, 'height': 768})
+        await page.goto('http://localhost:5173/win98-web/')
+
+        # Wait for boot
+        print("Waiting for desktop...")
+        try:
+            await page.wait_for_selector('.desktop', timeout=30000)
+        except Exception as e:
+            print(f"Failed to find desktop: {e}")
+            await browser.close()
+            return
+
+        await asyncio.sleep(2) # Stabilize
+
+        # Check scale
+        scale = await page.evaluate('getComputedStyle(document.documentElement).getPropertyValue("--os-scale")')
+        print(f"OS Scale: {scale}")
+
+        # Check Screen styles
+        styles = await page.evaluate('''() => {
+            const el = document.getElementById("screen");
+            return {
+                zoom: el.style.zoom,
+                transform: el.style.transform,
+                width: el.style.width,
+                height: el.style.height
+            };
+        }''')
+        print(f"Screen styles: {styles}")
+
+        # Click in the middle of the OS screen
+        # Viewport is 1024x768. OS at scale 2 is 512x384.
+        # Middle of OS is 256x192 OS pixels -> 512x384 physical pixels.
+        print("Opening context menu...")
+        await page.mouse.click(512, 384, button="right")
+        await asyncio.sleep(1)
+        await page.screenshot(path='/home/jules/verification/context_menu_test_v2.png')
+
+        # Check if context menu exists
+        menu = page.locator('.menu-popup-wrapper').last
+        if await menu.count() > 0:
+            menu_box = await menu.bounding_box()
+            print(f"Context menu box: {menu_box}")
+        else:
+            print("Context menu not found!")
+
+        await browser.close()
+
+asyncio.run(main())

--- a/verify_scaling_v5.py
+++ b/verify_scaling_v5.py
@@ -1,0 +1,65 @@
+import asyncio
+from playwright.async_api import async_playwright
+
+async def main():
+    async with async_playwright() as p:
+        browser = await p.chromium.launch()
+        page = await browser.new_page(viewport={'width': 1024, 'height': 768})
+        await page.goto('http://localhost:5173/win98-web/')
+
+        print("Waiting for desktop...")
+        await page.wait_for_selector('.desktop', timeout=30000)
+        await asyncio.sleep(5) # Wait for all boot processes
+
+        # Check scale
+        scale = await page.evaluate('getComputedStyle(document.documentElement).getPropertyValue("--os-scale")')
+        print(f"OS Scale: {scale}")
+
+        # Take a screenshot of the whole screen
+        await page.screenshot(path='/home/jules/verification/full_desktop.png')
+
+        # Try to right click on the desktop background
+        # Desktop should be visible. We click at a safe spot.
+        print("Right-clicking desktop background...")
+        await page.locator('.desktop').click(button='right', position={'x': 300, 'y': 200})
+        await asyncio.sleep(2)
+
+        # List all elements with menu-popup-wrapper
+        menus = await page.evaluate('''() => {
+            const els = Array.from(document.querySelectorAll('.menu-popup-wrapper'));
+            return els.map(el => ({
+                className: el.className,
+                isVisible: el.offsetWidth > 0,
+                rect: el.getBoundingClientRect(),
+                zIndex: el.style.zIndex,
+                parent: el.parentElement.id
+            }));
+        }''')
+        print(f"Menus found: {menus}")
+
+        await page.screenshot(path='/home/jules/verification/after_right_click.png')
+
+        # Double click My Computer to open a window
+        print("Opening My Computer...")
+        await page.locator('text="My Computer"').first.dblclick()
+        await asyncio.sleep(2)
+
+        # Check window position
+        windows = await page.evaluate('''() => {
+            const els = Array.from(document.querySelectorAll('.window'));
+            return els.map(el => ({
+                title: el.querySelector('.window-title')?.textContent,
+                rect: el.getBoundingClientRect(),
+                style: {
+                    left: el.style.left,
+                    top: el.style.top
+                }
+            }));
+        }''')
+        print(f"Windows found: {windows}")
+
+        await page.screenshot(path='/home/jules/verification/with_window.png')
+
+        await browser.close()
+
+asyncio.run(main())


### PR DESCRIPTION
I have implemented a default 2x zoom for the website as requested. 

Key changes include:
1.  **System-Wide Scaling**: The OS now starts with a 2x scale by default. This is handled by a new `ScreenManager` logic that uses the non-standard but highly effective CSS `zoom` property where supported (Chrome, Edge, Safari), and a robust `transform: scale()` fallback for Firefox.
2.  **Coordinate Accuracy**: To ensure "ctrl-scroll" like behavior, I've updated the window management system (`os-gui`), desktop icon management, and several core applications (Solitaire, Spider Solitaire, Help) to correctly translate mouse/touch coordinates into the scaled coordinate space. This ensures dragging and clicking remain precise regardless of the zoom level.
3.  **User Control**: A new "Scaling" slider has been added to the **Display Properties** application under the **Settings** tab, allowing users to adjust the zoom level between 1x and 3x. The setting is persisted in `localStorage`.
4.  **Visual Improvements**: The CRT scanlines effect has been moved to the main screen container so it scales naturally with the rest of the UI, maintaining the retro look at higher zoom levels.
5.  **Boot Integration**: The scaling is applied early in the boot process, ensuring the BIOS-style boot terminal is also correctly sized.

These changes make the interface much more accessible and user-friendly, especially on mobile and high-resolution displays.

---
*PR created automatically by Jules for task [5517616594155683235](https://jules.google.com/task/5517616594155683235) started by @azayrahmad*