### PR TITLE
Improve Diablo app: close window on exit and sync saves with ZenFS

### DIFF
--- a/public/games/diablo/bootloader.js
+++ b/public/games/diablo/bootloader.js
@@ -3,6 +3,14 @@
 
     let autoStartFile = null;
 
+    // Detect reload/exit to signal parent OS to close the window
+    window.addEventListener('beforeunload', () => {
+        // When the game reloads (Quit Game), signal the parent to close the window
+        if (window.parent && window.parent !== window) {
+            window.parent.postMessage({ type: "DIABLO_EXIT" }, window.location.origin);
+        }
+    });
+
     // Signal readiness to parent
     window.parent.postMessage({ type: "DIABLO_READY" }, "*");
 

--- a/src/apps/diablo/diablo-app.js
+++ b/src/apps/diablo/diablo-app.js
@@ -5,6 +5,7 @@ import { fs } from "@zenfs/core";
 import { ShowDialogWindow } from '../../shared/components/dialog-window.js';
 import { DiabloProgressDialog } from './diablo-progress-dialog.js';
 import { existsAsync } from '../../system/zenfs-utils.js';
+import { DiabloStorage } from './diablo-storage.js';
 
 export class DiabloApp extends Application {
     static config = {
@@ -29,17 +30,21 @@ export class DiabloApp extends Application {
         this.selectedMPQ = null;
         this.isReady = false;
         this.isDownloading = false;
+        this._isClosing = false;
         this._boundHandleMessage = this._handleMessage.bind(this);
     }
 
     async _onLaunch() {
         window.addEventListener("message", this._boundHandleMessage);
         await this._ensureFileSystem();
+        await this._setupFileSystemSync();
         await this._scanAndLaunch();
     }
 
     async _onClose() {
+        this._isClosing = true;
         window.removeEventListener("message", this._boundHandleMessage);
+        await this._persistFilesToZenFS();
     }
 
     async _ensureFileSystem() {
@@ -226,7 +231,7 @@ export class DiabloApp extends Application {
                 type: 'START_WITH_FILE',
                 name: this.selectedMPQ,
                 data: data
-            }, '*', [data.buffer || data]);
+            }, window.location.origin, [data.buffer || data]);
         } catch (e) {
             console.error("Failed to send start message:", e);
         }
@@ -241,6 +246,11 @@ export class DiabloApp extends Application {
             this.isReady = true;
             if (this.selectedMPQ) {
                 this._sendStartMessage();
+            }
+        } else if (type === "DIABLO_EXIT") {
+            if (this.win && !this._isClosing) {
+                await this._persistFilesToZenFS();
+                this.win.close();
             }
         } else if (type === "GET_MPQ") {
             const { url } = event.data;
@@ -262,6 +272,42 @@ export class DiabloApp extends Application {
                 console.error("Error providing MPQ", e);
                 port.postMessage({ error: e.message });
             }
+        }
+    }
+
+    async _setupFileSystemSync() {
+        try {
+            const entries = await fs.promises.readdir(this.baseLocalPath);
+            const storage = new DiabloStorage();
+            const filesToSync = new Map();
+            for (const entry of entries) {
+                if (entry.toLowerCase().endsWith('.mpq')) continue;
+                const path = `${this.baseLocalPath}/${entry}`;
+                const stat = await fs.promises.stat(path);
+                if (stat.isDirectory()) continue;
+
+                const data = await fs.promises.readFile(path);
+                filesToSync.set(entry, data);
+            }
+            if (filesToSync.size > 0) {
+                await storage.setFiles(filesToSync);
+            }
+        } catch (e) {
+            console.error("Failed to sync files to Diablo storage", e);
+        }
+    }
+
+    async _persistFilesToZenFS() {
+        try {
+            const storage = new DiabloStorage();
+            const files = await storage.getFiles();
+            for (const [name, data] of files) {
+                if (name.toLowerCase().endsWith('.mpq')) continue;
+                await fs.promises.writeFile(`${this.baseLocalPath}/${name}`, data);
+            }
+            document.dispatchEvent(new CustomEvent("zen-fs-change", { detail: { path: this.baseLocalPath } }));
+        } catch (e) {
+            console.error("Failed to persist Diablo files to ZenFS", e);
         }
     }
 

--- a/src/apps/diablo/diablo-storage.js
+++ b/src/apps/diablo/diablo-storage.js
@@ -1,0 +1,157 @@
+/**
+ * Utility to interface with Diablo's IndexedDB storage (diablo_fs).
+ * This allows syncing save games and configuration between ZenFS and the game's internal storage.
+ */
+export class DiabloStorage {
+    constructor(dbName = 'diablo_fs') {
+        this.dbName = dbName;
+        this.storeName = null;
+    }
+
+    async _getDb() {
+        return new Promise((resolve, reject) => {
+            const request = indexedDB.open(this.dbName);
+            request.onsuccess = () => resolve(request.result);
+            request.onerror = () => reject(request.error);
+            request.onupgradeneeded = (event) => {
+                const db = event.target.result;
+                // If the DB doesn't exist, create the default store used by idb-keyval/localForage
+                if (!db.objectStoreNames.contains('keyvaluepairs')) {
+                    db.createObjectStore('keyvaluepairs');
+                }
+            };
+        });
+    }
+
+    async _getStoreName() {
+        if (this.storeName) return this.storeName;
+        const db = await this._getDb();
+
+        // Try to find the store name. Most common for these ports is 'keyvaluepairs'.
+        if (db.objectStoreNames.contains('keyvaluepairs')) {
+            this.storeName = 'keyvaluepairs';
+        } else if (db.objectStoreNames.length > 0) {
+            this.storeName = db.objectStoreNames[0];
+        } else {
+            this.storeName = 'keyvaluepairs';
+        }
+
+        db.close();
+        return this.storeName;
+    }
+
+    /**
+     * Retrieves all files from Diablo's IndexedDB storage.
+     * @returns {Promise<Map<string, Uint8Array>>} A map of filenames to their data.
+     */
+    async getFiles() {
+        const storeName = await this._getStoreName();
+        const db = await this._getDb();
+
+        return new Promise((resolve, reject) => {
+            try {
+                const transaction = db.transaction(storeName, 'readonly');
+                const store = transaction.objectStore(storeName);
+                const request = store.getAll();
+                const keysRequest = store.getAllKeys();
+
+                transaction.oncomplete = () => {
+                    const files = new Map();
+                    for (let i = 0; i < keysRequest.result.length; i++) {
+                        const key = keysRequest.result[i];
+                        let value = request.result[i];
+
+                        // Handle standard emscripten IDBFS metadata wrapper if present
+                        if (value && typeof value === 'object' && value.contents && value.timestamp) {
+                            value = value.contents;
+                        }
+
+                        // Ensure we only treat strings as keys and handle the data
+                        if (typeof key === 'string') {
+                            files.set(key, value);
+                        }
+                    }
+                    db.close();
+                    resolve(files);
+                };
+                transaction.onerror = () => {
+                    db.close();
+                    reject(transaction.error);
+                };
+            } catch (e) {
+                db.close();
+                reject(e);
+            }
+        });
+    }
+
+    /**
+     * Writes multiple files to Diablo's IndexedDB storage in a single transaction.
+     * @param {Map<string, Uint8Array>} filesMap Map of filenames to their data.
+     */
+    async setFiles(filesMap) {
+        if (filesMap.size === 0) return;
+        const storeName = await this._getStoreName();
+        const db = await this._getDb();
+
+        return new Promise((resolve, reject) => {
+            try {
+                const transaction = db.transaction(storeName, 'readwrite');
+                const store = transaction.objectStore(storeName);
+                for (const [name, data] of filesMap) {
+                    // The game uses lower-case keys for filenames
+                    store.put(data, name.toLowerCase());
+                }
+                transaction.oncomplete = () => {
+                    db.close();
+                    resolve();
+                };
+                transaction.onerror = () => {
+                    db.close();
+                    reject(transaction.error);
+                };
+            } catch (e) {
+                db.close();
+                reject(e);
+            }
+        });
+    }
+
+    /**
+     * Writes a single file to Diablo's IndexedDB storage.
+     * @param {string} name Filename.
+     * @param {Uint8Array} data File data.
+     */
+    async setFile(name, data) {
+        const map = new Map();
+        map.set(name, data);
+        return this.setFiles(map);
+    }
+
+    /**
+     * Clears all files from the storage.
+     */
+    async clear() {
+        const storeName = await this._getStoreName();
+        const db = await this._getDb();
+
+        return new Promise((resolve, reject) => {
+            try {
+                const transaction = db.transaction(storeName, 'readwrite');
+                const store = transaction.objectStore(storeName);
+                store.clear();
+                transaction.oncomplete = () => {
+                    db.close();
+                    resolve();
+                };
+                transaction.onerror = () => {
+                    db.close();
+                    reject(transaction.error);
+                };
+            } catch (e) {
+                db.close();
+                reject(e);
+            }
+        });
+    }
+}


### PR DESCRIPTION
Improved the Diablo application by implementing two major features:
1. **Window Closure on Exit**: The game now correctly signals the OS to close the application window when "Quit Game" is selected from the menu, instead of just reloading within the iframe. This is achieved by catching the `beforeunload` event in a custom bootloader and sending a `DIABLO_EXIT` message to the parent.
2. **Save Game Persistence**: Added a synchronization mechanism that copies save games and configuration files between ZenFS (`/C:/Program Files/Diablo`) and the game's internal IndexedDB storage.
   - Files are synced to the game at launch.
   - Files are persisted back to ZenFS when the game exits or the window is closed.
   - Large `.mpq` files are automatically skipped to ensure efficiency.
   - Synchronization is optimized using bulk IndexedDB transactions.

Also improved overall security and robustness of the application's message passing and filesystem operations.

---
*PR created automatically by Jules for task [14816955874684998650](https://jules.google.com/task/14816955874684998650) started by @azayrahmad*