### PR TITLE
Strip decorative styling from about page and use semantic HTML

### DIFF
--- a/about.html
+++ b/about.html
@@ -26,43 +26,21 @@
 
     <style>
         body {
-            background-color: #000080; /* Classic Navy */
-            background-image: url('img/about/carbon-fibre.png'); /* Subtle texture */
-            color: #ffffff;
-            font-family: "Comic Sans MS", "Comic Sans", cursive;
             margin: 0;
             padding: 20px;
             text-align: center;
         }
-        .geocities-container {
-            background-color: #c0c0c0; /* Silver */
-            color: #000000;
-            border: 4px outset #ffffff;
+        main {
             max-width: 800px;
             margin: 0 auto;
             padding: 20px;
-            box-shadow: 10px 10px 0px rgba(0,0,0,0.5);
         }
         h1 {
-            color: #ff0000;
-            text-shadow: 2px 2px #ffff00;
-            font-family: Impact, Charcoal, sans-serif;
-            font-size: 3em;
             margin-bottom: 10px;
         }
         .marquee-container {
-            background: #000;
-            color: #0f0;
             padding: 5px;
-            border: 2px inset #808080;
             margin-bottom: 20px;
-            font-family: "Courier New", Courier, monospace;
-        }
-        .tagline {
-            font-size: 1.5em;
-            font-weight: bold;
-            color: #0000ff;
-            text-decoration: underline;
         }
         .iframe-wrapper {
             margin: 30px 0;
@@ -72,122 +50,88 @@
             gap: 10px;
         }
         .iframe-container {
-            border: 5px ridge #ffd700;
             padding: 10px;
-            background: #008080;
-            box-shadow: 5px 5px 15px rgba(0,0,0,0.8);
-            width: 320px;
-            height: 240px;
+            width: 640px;
+            height: 480px;
             overflow: hidden;
         }
         iframe {
             display: block;
-            border: 2px solid #000;
-            background: #000;
-            transform: scale(0.5);
-            transform-origin: 0 0;
-        }
-        .iframe-caption {
-            font-size: 0.9em;
-            color: #ff00ff;
-            font-weight: bold;
-            text-transform: uppercase;
         }
         h2 {
-            background: linear-gradient(to right, #000080, #0080ff);
-            color: white;
             padding: 5px 10px;
             text-align: left;
-            border-left: 10px solid #ff0000;
         }
         ul {
             text-align: left;
-            list-style-type: square;
         }
         li {
             margin-bottom: 10px;
-            font-size: 1.1em;
         }
         .links {
             margin-top: 40px;
-            border-top: 3px double #000;
             padding-top: 20px;
             display: flex;
             justify-content: center;
             gap: 30px;
         }
-        .links a {
-            color: #0000ee;
-            font-weight: bold;
-            font-size: 1.2em;
-        }
-        .links a:hover {
-            color: #ff0000;
-            background: #ffff00;
-        }
         .visitor-counter {
             margin-top: 30px;
-            font-family: "Courier New", Courier, monospace;
-            background: #000;
-            color: #f00;
             display: inline-block;
             padding: 5px 10px;
-            border: 2px solid #808080;
         }
         .construction {
             margin: 20px 0;
         }
-        blink {
-            animation: 1s blinker linear infinite;
-        }
-        @keyframes blinker {
-            50% { opacity: 0; }
-        }
     </style>
 </head>
 <body>
-    <div class="geocities-container">
-        <div class="construction">
-            <img src="img/about/consbar2.gif" alt="Under Construction">
-        </div>
+    <main>
+        <header>
+            <div class="construction">
+                <img src="img/about/consbar2.gif" alt="Under Construction">
+            </div>
 
-        <h1>Welcome to Windows 98 Web!</h1>
+            <h1>Welcome to Windows 98 Web!</h1>
 
-        <div class="marquee-container">
-            <marquee scrollamount="5">*** THE BEST WINDOWS 98 SIMULATOR ON THE WORLD WIDE WEB! *** CHECK IT OUT NOW! ***</marquee>
-        </div>
+            <div class="marquee-container">
+                *** THE BEST WINDOWS 98 SIMULATOR ON THE WORLD WIDE WEB! *** CHECK IT OUT NOW! ***
+            </div>
 
-        <p class="tagline">The Ultimate Pixel-Perfect Browser Recreation!</p>
+            <p>The Ultimate Pixel-Perfect Browser Recreation!</p>
 
-        <p>This is my cool website where I show off my Windows 98 project. It's built with <b>VANILLA JAVASCRIPT</b> and <b>HTML/CSS</b>. No fancy frameworks here, just like the good old days!</p>
+            <p>This is my cool website where I show off my Windows 98 project. It's built with VANILLA JAVASCRIPT and HTML/CSS. No fancy frameworks here, just like the good old days!</p>
+        </header>
 
-        <div class="iframe-wrapper">
+        <section class="iframe-wrapper">
             <div class="iframe-container">
                 <iframe src="./" width="640" height="480" title="Windows 98 Web Edition Live Preview"></iframe>
             </div>
-            <p class="iframe-caption"><blink>LIVE PREVIEW! CLICK TO PLAY!</blink></p>
-        </div>
+            <p class="iframe-caption">LIVE PREVIEW! CLICK TO PLAY!</p>
+        </section>
 
-        <h2>Awesome Features:</h2>
-        <ul>
-            <li>Real <b>Start Menu</b> and <b>Taskbar</b> action!</li>
-            <li>Play <b>Solitaire</b> and <b>Minesweeper</b> until your boss catches you!</li>
-            <li>Use <b>Paint</b> and <b>WordPad</b> for all your creative needs!</li>
-            <li>AI powered <b>Clippy</b> is here to "help" you!</li>
-            <li>Change <b>Desktop Themes</b> just like a pro!</li>
-        </ul>
+        <section>
+            <h2>Awesome Features:</h2>
+            <ul>
+                <li>Real Start Menu and Taskbar action!</li>
+                <li>Play Solitaire and Minesweeper until your boss catches you!</li>
+                <li>Use Paint and WordPad for all your creative needs!</li>
+                <li>AI powered Clippy is here to "help" you!</li>
+                <li>Change Desktop Themes just like a pro!</li>
+            </ul>
 
-        <h2>Cool Tech I Used:</h2>
-        <ul>
-            <li><b>ZenFS</b> for that sweet virtual hard drive!</li>
-            <li><b>98.css</b> for the authentic look and feel!</li>
-            <li><b>Vite</b> because even retro sites need a fast build!</li>
-        </ul>
+            <h2>Cool Tech I Used:</h2>
+            <ul>
+                <li>ZenFS for that sweet virtual hard drive!</li>
+                <li>98.css for the authentic look and feel!</li>
+                <li>Vite because even retro sites need a fast build!</li>
+            </ul>
+        </section>
 
-        <div class="links">
+        <nav class="links">
             <a href="./">[ ENTER FULL SITE ]</a>
             <a href="https://github.com/azayrahmad/win98-web" target="_blank" rel="noopener noreferrer">[ GITHUB REPO ]</a>
-        </div>
+        </nav>
 
         <div class="visitor-counter">
             YOU ARE VISITOR NUMBER:
@@ -197,15 +141,17 @@
             ></script>
         </div>
 
-        <p style="margin-top: 20px;">
-            Best viewed in <br>
-            <img src="img/about/netscani.gif" alt="Netscape">
-            <img src="img/about/ie_anima.gif" alt="IE">
-        </p>
+        <footer>
+            <p style="margin-top: 20px;">
+                Best viewed in <br>
+                <img src="img/about/netscani.gif" alt="Netscape">
+                <img src="img/about/ie_anima.gif" alt="IE">
+            </p>
 
-        <p style="font-size: 0.8em;">Copyright &copy; 1998-2025 azOS Productions</p>
-    </div>
+            <p><small>Copyright &copy; 1998-2025 azOS Productions</small></p>
+        </footer>
+    </main>
 
-    <p><a href="mailto:azayrahmad@gmail.com" style="color: #fff;">Email Me!</a></p>
+    <p><a href="mailto:azayrahmad@gmail.com">Email Me!</a></p>
 </body>
 </html>


### PR DESCRIPTION
The `about.html` page has been overhauled to meet the request for a "stripped down" version. All decorative CSS was removed while maintaining the core layout. The live preview iframe no longer uses scaling and is displayed at its full 640x480 size. The HTML has been refactored for better semantics, replacing non-standard tags with standard ones and removing unnecessary bolding and uppercase transformations.

---
*PR created automatically by Jules for task [18347459418779380461](https://jules.google.com/task/18347459418779380461) started by @azayrahmad*