### PR TITLE
Implement local version check for updates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ node_modules
 dist
 dist-ssr
 *.local
+public/version.json
 
 # Editor directories and files
 .vscode/*

--- a/bun.lock
+++ b/bun.lock
@@ -13,6 +13,7 @@
         "@zenfs/emscripten": "^1.0.5",
         "ani-cursor": "^0.0.5",
         "html2canvas": "^1.4.1",
+        "music-metadata-browser": "^2.5.11",
         "os-gui": "^0.7.3",
       },
       "devDependencies": {
@@ -339,6 +340,8 @@
 
     "@surma/rollup-plugin-off-main-thread": ["@surma/rollup-plugin-off-main-thread@2.2.3", "", { "dependencies": { "ejs": "^3.1.6", "json5": "^2.2.0", "magic-string": "^0.25.0", "string.prototype.matchall": "^4.0.6" } }, "sha512-lR8q/9W7hZpMWweNiAKU7NQerBnzQQLvi8qnTDU/fxItPhtZVMbPV3lbCwjhIlNBe9Bbr5V+KHshvWmVSG9cxQ=="],
 
+    "@tokenizer/token": ["@tokenizer/token@0.3.0", "", {}, "sha512-OvjF+z51L3ov0OyAU0duzsYuvO01PH7x4t6DJx+guahgTnBHkhJdG7soQeTSFLWN3efnHyibZ4Z8l2EuWwJN3A=="],
+
     "@types/estree": ["@types/estree@1.0.8", "", {}, "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w=="],
 
     "@types/jquery": ["@types/jquery@3.5.33", "", { "dependencies": { "@types/sizzle": "*" } }, "sha512-SeyVJXlCZpEki5F0ghuYe+L+PprQta6nRZqhONt9F13dWBtR/ftoaIbdRQ7cis7womE+X2LKhsDdDtkkDhJS6g=="],
@@ -429,6 +432,8 @@
 
     "common-tags": ["common-tags@1.8.2", "", {}, "sha512-gk/Z852D2Wtb//0I+kRFNKKE9dIIVirjoqPoA1wJU+XePVXZfGeBpk45+A1rKO4Q43prqWBNY/MiIeRLbPWUaA=="],
 
+    "content-type": ["content-type@1.0.5", "", {}, "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA=="],
+
     "convert-source-map": ["convert-source-map@2.0.0", "", {}, "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg=="],
 
     "core-js-compat": ["core-js-compat@3.48.0", "", { "dependencies": { "browserslist": "^4.28.1" } }, "sha512-OM4cAF3D6VtH/WkLtWvyNC56EZVXsZdU3iqaMG2B4WvYrlqU831pc4UtG5yp0sE9z8Y02wVN7PjW5Zf9Gt0f1Q=="],
@@ -500,6 +505,8 @@
     "fdir": ["fdir@6.5.0", "", { "peerDependencies": { "picomatch": "^3 || ^4" } }, "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg=="],
 
     "fflate": ["fflate@0.8.2", "", {}, "sha512-cPJU47OaAoCbg0pBvzsgpTPhmhqI5eJjh/JIu8tPj5q+T7iLvW/JAYUqmE7KOB4R1ZyEhzBaIQpQpardBF5z8A=="],
+
+    "file-type": ["file-type@16.5.4", "", { "dependencies": { "readable-web-to-node-stream": "^3.0.0", "strtok3": "^6.2.4", "token-types": "^4.1.1" } }, "sha512-/yFHK0aGjFEgDJjEKP0pWCplsPFPhwyfwevf/pVxiN0tmE4L9LmwWxWukdJSHdoCli4VgQLehjJtwQBnqmsKcw=="],
 
     "filelist": ["filelist@1.0.4", "", { "dependencies": { "minimatch": "^5.0.1" } }, "sha512-w1cEuf3S+DrLCQL7ET6kz+gmlJdbq9J7yXCSjK/OZCPA+qEN1WyF4ZAf0YYJa4/shHJra2t/d/r8SV4Ji+x+8Q=="],
 
@@ -651,6 +658,8 @@
 
     "math-intrinsics": ["math-intrinsics@1.1.0", "", {}, "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g=="],
 
+    "media-typer": ["media-typer@1.1.0", "", {}, "sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw=="],
+
     "memium": ["memium@0.3.11", "", { "dependencies": { "kerium": "^1.3.2", "utilium": "^2.0.0" } }, "sha512-CwmIpLVSG7UToDj2sYAZFDkpco30OPsXpaCnt+7Z7JQaulCjH5UvwJIctTIHmgQdFqk8pliBsPLnH5OZcDLZyQ=="],
 
     "minimatch": ["minimatch@10.1.1", "", { "dependencies": { "@isaacs/brace-expansion": "^5.0.0" } }, "sha512-enIvLvRAFZYXJzkCYG5RKmPfrFArdLv+R+lbQ53BmIMLIry74bjKzX6iHAm8WYamJkhSSEabrWN5D97XnKObjQ=="],
@@ -658,6 +667,10 @@
     "minipass": ["minipass@7.1.2", "", {}, "sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw=="],
 
     "ms": ["ms@2.1.3", "", {}, "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="],
+
+    "music-metadata": ["music-metadata@7.14.0", "", { "dependencies": { "@tokenizer/token": "^0.3.0", "content-type": "^1.0.5", "debug": "^4.3.4", "file-type": "^16.5.4", "media-typer": "^1.1.0", "strtok3": "^6.3.0", "token-types": "^4.2.1" } }, "sha512-xrm3w7SV0Wk+OythZcSbaI8mcr/KHd0knJieu8bVpaPfMv/Agz5EooCAPz3OR5hbYMiUG6dgAPKZKnMzV+3amA=="],
+
+    "music-metadata-browser": ["music-metadata-browser@2.5.11", "", { "dependencies": { "buffer": "^6.0.3", "debug": "^4.3.4", "music-metadata": "^7.13.3", "readable-stream": "^4.3.0", "readable-web-to-node-stream": "^3.0.2" } }, "sha512-Khq5nYapffIet0PUVb5J69pZPgqgn+/yoEr0jkO/OjH5xwfdz6rdwj0zsWPaqo3ylv+OthXoGjT6EegVHbMkJQ=="],
 
     "nanoid": ["nanoid@3.3.11", "", { "bin": "bin/nanoid.cjs" }, "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w=="],
 
@@ -681,6 +694,8 @@
 
     "path-scurry": ["path-scurry@2.0.1", "", { "dependencies": { "lru-cache": "^11.0.0", "minipass": "^7.1.2" } }, "sha512-oWyT4gICAu+kaA7QWk/jvCHWarMKNs6pXOGWKDTr7cw4IGcUbW+PeTfbaQiLGheFRpjo6O9J0PmyMfQPjH71oA=="],
 
+    "peek-readable": ["peek-readable@4.1.0", "", {}, "sha512-ZI3LnwUv5nOGbQzD9c2iDG6toheuXSZP5esSHBjopsXH4dg19soufvpUGA3uohi5anFtGb2lhAVdHzH6R/Evvg=="],
+
     "picocolors": ["picocolors@1.1.1", "", {}, "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA=="],
 
     "picomatch": ["picomatch@4.0.3", "", {}, "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q=="],
@@ -702,6 +717,8 @@
     "randombytes": ["randombytes@2.1.0", "", { "dependencies": { "safe-buffer": "^5.1.0" } }, "sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ=="],
 
     "readable-stream": ["readable-stream@4.7.0", "", { "dependencies": { "abort-controller": "^3.0.0", "buffer": "^6.0.3", "events": "^3.3.0", "process": "^0.11.10", "string_decoder": "^1.3.0" } }, "sha512-oIGGmcpTLwPga8Bn6/Z75SVaH1z5dUut2ibSyAMVhmUggWpmDn2dapB0n7f8nwaSiRtepAsfJyfXIO5DCVAODg=="],
+
+    "readable-web-to-node-stream": ["readable-web-to-node-stream@3.0.4", "", { "dependencies": { "readable-stream": "^4.7.0" } }, "sha512-9nX56alTf5bwXQ3ZDipHJhusu9NTQJ/CVPtb/XHAJCXihZeitfJvIRS4GqQ/mfIoOE3IelHMrpayVrosdHBuLw=="],
 
     "reflect.getprototypeof": ["reflect.getprototypeof@1.0.10", "", { "dependencies": { "call-bind": "^1.0.8", "define-properties": "^1.2.1", "es-abstract": "^1.23.9", "es-errors": "^1.3.0", "es-object-atoms": "^1.0.0", "get-intrinsic": "^1.2.7", "get-proto": "^1.0.1", "which-builtin-type": "^1.2.1" } }, "sha512-00o4I+DVrefhv+nX0ulyi3biSHCPDe+yLv5o/p6d/UVlirijB8E16FtfwSAi4g3tcqrQ4lRAqQSoFEZJehYEcw=="],
 
@@ -791,6 +808,8 @@
 
     "strip-comments": ["strip-comments@2.0.1", "", {}, "sha512-ZprKx+bBLXv067WTCALv8SSz5l2+XhpYCsVtSqlMnkAXMWDq+/ekVbl1ghqP9rUHTzv6sm/DwCOiYutU/yp1fw=="],
 
+    "strtok3": ["strtok3@6.3.0", "", { "dependencies": { "@tokenizer/token": "^0.3.0", "peek-readable": "^4.1.0" } }, "sha512-fZtbhtvI9I48xDSywd/somNqgUHl2L2cstmXCCif0itOf96jeW18MBSyrLuNicYQVkvpOxkZtkzujiTJ9LW5Jw=="],
+
     "supports-preserve-symlinks-flag": ["supports-preserve-symlinks-flag@1.0.0", "", {}, "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w=="],
 
     "temp-dir": ["temp-dir@2.0.0", "", {}, "sha512-aoBAniQmmwtcKp/7BzsH8Cxzv8OL736p7v1ihGb5e9DJ9kTwGWHrQrVB5+lfVDzfGrdRzXch+ig7LHaY1JTOrg=="],
@@ -802,6 +821,8 @@
     "text-segmentation": ["text-segmentation@1.0.3", "", { "dependencies": { "utrie": "^1.0.2" } }, "sha512-iOiPUo/BGnZ6+54OsWxZidGCsdU8YbE4PSpdPinp7DeMtUJNJBoJ/ouUSTJjHkh1KntHaltHl/gDs2FC4i5+Nw=="],
 
     "tinyglobby": ["tinyglobby@0.2.15", "", { "dependencies": { "fdir": "^6.5.0", "picomatch": "^4.0.3" } }, "sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ=="],
+
+    "token-types": ["token-types@4.2.1", "", { "dependencies": { "@tokenizer/token": "^0.3.0", "ieee754": "^1.2.1" } }, "sha512-6udB24Q737UD/SDsKAHI9FCRP7Bqc9D/MQUV02ORQg5iskjtLJlZJNdN4kKtcdtwCeWIwIHDGaUsTsCCAa8sFQ=="],
 
     "tr46": ["tr46@1.0.1", "", { "dependencies": { "punycode": "^2.1.0" } }, "sha512-dTpowEjclQ7Kgx5SdBkqRzVhERQXov8/l9Ft9dVM9fmg0W0KQSVaXX9T4i6twCPNtYiZM53lpSSUAwJbFPOHxA=="],
 

--- a/package.json
+++ b/package.json
@@ -4,9 +4,10 @@
   "version": "0.8.0",
   "type": "module",
   "scripts": {
-    "dev": "bun --bun vite",
-    "build": "bun run build:registry && bun --bun vite build",
+    "dev": "bun run build:version && bun --bun vite",
+    "build": "bun run build:registry && bun run build:version && bun --bun vite build",
     "build:registry": "bun scripts/generate_registry.js",
+    "build:version": "bun scripts/generate_version.js",
     "preview": "bun --bun vite preview",
     "test": "bun x playwright test"
   },

--- a/public/version.json
+++ b/public/version.json
@@ -1,0 +1,1 @@
+{"version": "0.8.0", "timestamp": "now"}

--- a/scripts/generate_version.js
+++ b/scripts/generate_version.js
@@ -1,0 +1,21 @@
+import fs from 'fs';
+import path from 'path';
+
+const packageJsonPath = path.join(process.cwd(), 'package.json');
+const packageJson = JSON.parse(fs.readFileSync(packageJsonPath, 'utf-8'));
+const version = packageJson.version;
+
+const versionData = {
+  version: version,
+  timestamp: new Date().toISOString()
+};
+
+const publicDir = path.join(process.cwd(), 'public');
+if (!fs.existsSync(publicDir)) {
+  fs.mkdirSync(publicDir);
+}
+
+const versionJsonPath = path.join(publicDir, 'version.json');
+fs.writeFileSync(versionJsonPath, JSON.stringify(versionData, null, 2));
+
+console.log(`Generated version.json with version ${version} at ${versionJsonPath}`);

--- a/src/config/app-registry.js
+++ b/src/config/app-registry.js
@@ -540,7 +540,8 @@ export const appRegistry = {
     id: "webamp",
     title: "Winamp",
     description: "A classic music player.",
-    icon: ICONS.webamp, category: "",
+    icon: ICONS.webamp,
+    category: "",
     hasTaskbarButton: true,
     isSingleton: true,
     tray: {

--- a/src/shell/about/about-app.js
+++ b/src/shell/about/about-app.js
@@ -125,23 +125,20 @@ export class AboutApp extends Application {
 
   async checkVersion($status) {
     try {
-      const response = await fetch(
-        "https://api.github.com/repos/azayrahmad/win98-web/releases/latest",
+      const { getLatestVersion } = await import(
+        "../../system/version-utils.js"
       );
-      if (!response.ok) throw new Error("Failed to fetch version info");
-      const data = await response.json();
-
-      // Extract version number (e.g., "0.5.0" from "v0.5.0" or "win98-web-v0.5.0")
-      const versionMatch = data.tag_name.match(/(\d+\.\d+\.\d+)/);
-      const latestVersion = versionMatch
-        ? versionMatch[1]
-        : data.tag_name.replace(/^v/, "");
+      const latestVersion = await getLatestVersion();
       const currentVersion = import.meta.env.APP_VERSION;
 
       if (latestVersion === currentVersion) {
         $status.text("You are using the latest version.");
+      } else if (latestVersion) {
+        $status.html(
+          `A new version is available: <b>${latestVersion}</b><br>Please use Windows Update to install it.`,
+        );
       } else {
-        $status.html(`A new version is available: <b>${latestVersion}</b>`);
+        $status.text("Could not check for updates.");
       }
     } catch (error) {
       console.error("Version check failed:", error);

--- a/src/system/boot-screen.js
+++ b/src/system/boot-screen.js
@@ -284,6 +284,15 @@ export function writeBootError(message) {
     }
 }
 
+/**
+ * Writes a message to the boot screen.
+ */
+export function writeBootMessage(message) {
+    if (terminal) {
+        terminal.write(`\r\n${message}\r\n`);
+    }
+}
+
 export {
     hideBootScreen,
     startBootProcessStep,

--- a/src/system/os-init.js
+++ b/src/system/os-init.js
@@ -16,6 +16,7 @@ import {
   prepareBootScreen,
   getTerminal,
   writeBootError,
+  writeBootMessage,
 } from "./boot-screen.js";
 import { preloadThemeAssets } from "./asset-preloader.js";
 import { launchApp } from "./app-manager.js";
@@ -151,6 +152,34 @@ export async function initializeOS() {
       document.getElementById("boot-screen-content").style.display = "flex";
 
       await prepareBootScreen();
+    });
+
+    await executeBootStep(async () => {
+      const currentVersion = import.meta.env.APP_VERSION;
+      const term = getTerminal();
+      if (term) {
+        term.write(`Windows 98 Web Edition v${currentVersion}\r\n`);
+      }
+
+      let logElement = startBootProcessStep("Checking for updates...");
+      try {
+        const { getLatestVersion } = await import("./version-utils.js");
+        const latestVersion = await getLatestVersion();
+
+        if (latestVersion && latestVersion !== currentVersion) {
+          finalizeBootProcessStep(logElement, "UPDATE AVAILABLE");
+          writeBootMessage(`A new version (${latestVersion}) is available.`);
+          writeBootMessage(
+            `Please use 'Windows Update' from the Start menu to update.`,
+          );
+          // Give user a moment to read it
+          await new Promise((resolve) => setTimeout(resolve, 2000));
+        } else {
+          finalizeBootProcessStep(logElement, "OK");
+        }
+      } catch (e) {
+        finalizeBootProcessStep(logElement, "FAILED", e);
+      }
     });
 
     function loadCustomApps() {

--- a/src/system/version-utils.js
+++ b/src/system/version-utils.js
@@ -1,0 +1,23 @@
+/**
+ * Fetches the latest version from the server.
+ * Uses cache-busting to ensure we always get the freshest version.
+ */
+export async function getLatestVersion() {
+  try {
+    const baseUrl = import.meta.env.BASE_URL || "/";
+    // Normalize base URL to ensure it ends with / if it's not empty
+    const normalizedBaseUrl = baseUrl.endsWith("/") ? baseUrl : `${baseUrl}/`;
+
+    const response = await fetch(`${normalizedBaseUrl}version.json?t=${Date.now()}`, {
+      cache: 'no-store'
+    });
+
+    if (!response.ok) throw new Error(`Failed to fetch version info: ${response.status}`);
+
+    const data = await response.json();
+    return data.version;
+  } catch (error) {
+    console.error("Failed to check for updates:", error);
+    return null;
+  }
+}


### PR DESCRIPTION
This PR implements a local versioning system to reliably detect new deployments without hitting GitHub API rate limits. 

Key changes:
1. **Automated version generation**: A new script `scripts/generate_version.js` extracts the version from `package.json` and creates `public/version.json` during the build process.
2. **Reliable fetching**: `src/system/version-utils.js` implements `getLatestVersion` with `cache: 'no-store'` and timestamp query parameters to bypass any caching layers (browser, CDN, or Service Worker).
3. **Boot-time notification**: The system now displays the current version and checks for updates during the boot sequence (before mouse detection). If a new version is found, it notifies the user to use the "Windows Update" tool.
4. **Improved About dialog**: The About application now uses the same local version check, providing a consistent and rate-limit-free experience.
5. **CI/CD alignment**: The `version.json` is generated during the build, ensuring it always reflects the version from `package.json` in the deployed environment.

---
*PR created automatically by Jules for task [10048426452564394857](https://jules.google.com/task/10048426452564394857) started by @azayrahmad*