### PR TITLE
Fix menu brightness in CRT mode

### DIFF
--- a/public/os-gui/$Window.js
+++ b/public/os-gui/$Window.js
@@ -2076,23 +2076,25 @@ You can also disable this warning by passing {iframes: {ignoreCrossOrigin: true}
       animating_titlebar = true;
       const $eye_leader = $w.$titlebar.clone(true);
       $eye_leader.find("button").remove();
-      $eye_leader.appendTo("body");
+      const $screen = $("#screen");
+      $eye_leader.appendTo($screen.length ? $screen : "body");
       const duration_ms = $Window.OVERRIDE_TRANSITION_DURATION ?? 200; // TODO: how long?
       const duration_str = `${duration_ms}ms`;
+      const screen_rect = ($screen[0] || document.body).getBoundingClientRect();
       $eye_leader.css({
         transition: `left ${duration_str} linear, top ${duration_str} linear, width ${duration_str} linear, height ${duration_str} linear`,
-        position: "fixed",
+        position: "absolute",
         zIndex: 10000000,
         pointerEvents: "none",
-        left: from.left,
-        top: from.top,
+        left: from.left - screen_rect.left,
+        top: from.top - screen_rect.top,
         width: from.width,
         height: from.height,
       });
       setTimeout(() => {
         $eye_leader.css({
-          left: to.left,
-          top: to.top,
+          left: to.left - screen_rect.left,
+          top: to.top - screen_rect.top,
           width: to.width,
           height: to.height,
         });

--- a/public/os-gui/MenuBar.js
+++ b/public/os-gui/MenuBar.js
@@ -348,7 +348,8 @@
       menus_el.appendChild(menu_button_el);
 
       const menu_popup_el = E("div", { class: "menu-popup-wrapper to-down" });
-      document.body?.appendChild(menu_popup_el);
+      const screen = document.getElementById("screen");
+      (screen || document.body)?.appendChild(menu_popup_el);
       const menu_popup = new MenuPopup(menu_items, {
         handleKeyDown,
         closeMenus: close_menus,
@@ -370,6 +371,8 @@
       );
 
       const update_position = () => {
+        const screen = document.getElementById("screen") || document.body;
+        const screen_rect = screen.getBoundingClientRect();
         const rect = menu_button_el.getBoundingClientRect();
 
         // Measure without showing
@@ -378,15 +381,15 @@
         menu_popup_el.classList.remove("measuring");
 
         menu_popup_el.style.position = "absolute";
-        menu_popup_el.style.left = `${(get_direction() === "rtl" ? rect.right - popup_rect.width : rect.left) + window.scrollX}px`;
-        menu_popup_el.style.top = `${rect.bottom + window.scrollY}px`;
+        menu_popup_el.style.left = `${(get_direction() === "rtl" ? rect.right - popup_rect.width : rect.left) - screen_rect.left}px`;
+        menu_popup_el.style.top = `${rect.bottom - screen_rect.top}px`;
 
         const final_left = parseFloat(menu_popup_el.style.left);
-        if (final_left + popup_rect.width > innerWidth + window.scrollX) {
-          menu_popup_el.style.left = `${innerWidth + window.scrollX - popup_rect.width}px`;
+        if (final_left + popup_rect.width > screen_rect.width) {
+          menu_popup_el.style.left = `${screen_rect.width - popup_rect.width}px`;
         }
-        if (final_left < window.scrollX) {
-          menu_popup_el.style.left = `${window.scrollX}px`;
+        if (final_left < 0) {
+          menu_popup_el.style.left = `0px`;
         }
       };
       window.addEventListener("resize", update_position);
@@ -434,8 +437,10 @@
 
         menu_popup_el.setAttribute("dir", get_direction());
         if (window.inheritTheme) window.inheritTheme(menu_popup_el, menus_el);
-        if (!menu_popup_el.parentElement)
-          document.body.appendChild(menu_popup_el);
+        if (!menu_popup_el.parentElement) {
+          const screen = document.getElementById("screen");
+          (screen || document.body).appendChild(menu_popup_el);
+        }
         top_level_highlight(menus_key);
         menu_popup_el.dispatchEvent(new CustomEvent("update", {}));
         selecting_menus = true;

--- a/public/os-gui/MenuPopup.js
+++ b/public/os-gui/MenuPopup.js
@@ -252,7 +252,8 @@
           const submenu_popup_el_actual = submenu_popup.element;
           submenu_popup_el.appendChild(submenu_popup_el_actual);
 
-          document.body?.appendChild(submenu_popup_el);
+          const screen = document.getElementById("screen");
+          (screen || document.body)?.appendChild(submenu_popup_el);
           // submenu_popup_el.style.display = "none"; // Managed by .open class
           item_el.setAttribute("aria-haspopup", "true");
           item_el.setAttribute("aria-expanded", "false");
@@ -284,10 +285,13 @@
               window.inheritTheme(submenu_popup_el, menu_popup_el);
             }
             if (!submenu_popup_el.parentElement) {
-              document.body.appendChild(submenu_popup_el);
+              const screen = document.getElementById("screen");
+              (screen || document.body).appendChild(submenu_popup_el);
             }
             submenu_popup_el.dispatchEvent(new CustomEvent("update", {}));
 
+            const screen = document.getElementById("screen") || document.body;
+            const screen_rect = screen.getBoundingClientRect();
             const rect = item_el.getBoundingClientRect();
 
             // Measure without showing
@@ -298,23 +302,23 @@
             let final_x =
               (get_direction() === "rtl"
                 ? rect.left - submenu_popup_rect.width
-                : rect.right) + window.scrollX;
-            let final_y = rect.top + window.scrollY;
+                : rect.right) - screen_rect.left;
+            let final_y = rect.top - screen_rect.top;
             let from_left = false;
 
             if (get_direction() === "rtl") {
               if (final_x < 0) {
-                final_x = rect.right;
+                final_x = rect.right - screen_rect.left;
                 from_left = true;
               }
             } else {
-              if (final_x + submenu_popup_rect.width > innerWidth) {
-                final_x = rect.left - submenu_popup_rect.width;
+              if (final_x + submenu_popup_rect.width > screen_rect.width) {
+                final_x = rect.left - submenu_popup_rect.width - screen_rect.left;
                 from_left = true;
               }
             }
-            if (final_y + submenu_popup_rect.height > innerHeight) {
-              final_y = Math.max(0, innerHeight - submenu_popup_rect.height);
+            if (final_y + submenu_popup_rect.height > screen_rect.height) {
+              final_y = Math.max(0, screen_rect.height - submenu_popup_rect.height);
             }
 
             submenu_popup_el.style.left = `${final_x}px`;

--- a/src/apps/webamp/webamp-app.js
+++ b/src/apps/webamp/webamp-app.js
@@ -236,7 +236,8 @@ export class WebampApp extends Application {
       webampContainer.style.zIndex = $Window.Z_INDEX++;
       webampContainer.style.left = "50px";
       webampContainer.style.top = "50px";
-      document.body.appendChild(webampContainer);
+      const screen = document.getElementById("screen");
+      (screen || document.body).appendChild(webampContainer);
 
       webampContainer.addEventListener(
         "mousedown",

--- a/src/shared/components/tooltip.js
+++ b/src/shared/components/tooltip.js
@@ -13,7 +13,8 @@ export class Tooltip {
     if (this.text) {
         this.element.innerHTML = marked.parseInline(this.text, { breaks: true });
     }
-    document.body.appendChild(this.element);
+    const screen = document.getElementById('screen');
+    (screen || document.body).appendChild(this.element);
 
     this._position();
 
@@ -26,18 +27,20 @@ export class Tooltip {
   }
 
   _position() {
+    const screen = document.getElementById('screen') || document.body;
+    const screenRect = screen.getBoundingClientRect();
     const targetRect = this.targetElement.getBoundingClientRect();
     const tooltipRect = this.element.getBoundingClientRect();
 
-    let top = targetRect.bottom + 5;
-    let left = targetRect.left + (targetRect.width / 2) - (tooltipRect.width / 2);
+    let top = targetRect.bottom - screenRect.top + 5;
+    let left = targetRect.left - screenRect.left + (targetRect.width / 2) - (tooltipRect.width / 2);
 
     // Adjust if it goes off-screen
     if (left < 0) {
       left = 5;
     }
-    if (top + tooltipRect.height > window.innerHeight) {
-      top = targetRect.top - tooltipRect.height - 5;
+    if (top + tooltipRect.height > screenRect.height) {
+      top = targetRect.top - screenRect.top - tooltipRect.height - 5;
     }
 
     this.element.style.left = `${left}px`;

--- a/src/shared/utils/drag-drop-manager.js
+++ b/src/shared/utils/drag-drop-manager.js
@@ -71,7 +71,8 @@ export function createDragGhost(icon, e) {
     dragImage.style.position = "absolute";
     dragImage.style.top = "-1000px";
     dragImage.style.opacity = "0.5";
-    document.body.appendChild(dragImage);
+    const screen = document.getElementById("screen");
+    (screen || document.body).appendChild(dragImage);
     e.dataTransfer.setDragImage(dragImage, 0, 0);
     return dragImage;
 }

--- a/src/shell/explorer/components/address-bar.js
+++ b/src/shell/explorer/components/address-bar.js
@@ -44,7 +44,8 @@ export class AddressBar {
     // Dropdown Menu
     this.dropdownMenu = document.createElement("div");
     this.dropdownMenu.className = "address-bar-dropdown";
-    document.body.appendChild(this.dropdownMenu);
+    const screen = document.getElementById("screen");
+    (screen || document.body).appendChild(this.dropdownMenu);
 
     if (this.options.onEnter) {
       this.input.addEventListener("keydown", (e) => {
@@ -101,9 +102,11 @@ export class AddressBar {
 
   async openDropdown() {
     // Positioning
+    const screen = document.getElementById("screen") || document.body;
+    const screenRect = screen.getBoundingClientRect();
     const rect = this.combo.getBoundingClientRect();
-    this.dropdownMenu.style.top = `${rect.bottom}px`;
-    this.dropdownMenu.style.left = `${rect.left}px`;
+    this.dropdownMenu.style.top = `${rect.bottom - screenRect.top}px`;
+    this.dropdownMenu.style.left = `${rect.left - screenRect.left}px`;
     this.dropdownMenu.style.width = `${rect.width}px`;
 
     await this.renderTree();

--- a/src/shell/explorer/file-operations/drag-drop-manager.js
+++ b/src/shell/explorer/file-operations/drag-drop-manager.js
@@ -54,11 +54,13 @@ export class DragDropManager {
     }
 
     _createGhost(iconElements, x, y) {
+        const screen = document.getElementById('screen') || document.body;
+        const screenRect = screen.getBoundingClientRect();
         const ghost = document.createElement('div');
         ghost.className = 'drag-ghost';
-        ghost.style.position = 'fixed';
-        ghost.style.left = `${x - this.offsetX}px`;
-        ghost.style.top = `${y - this.offsetY}px`;
+        ghost.style.position = 'absolute';
+        ghost.style.left = `${x - this.offsetX - screenRect.left}px`;
+        ghost.style.top = `${y - this.offsetY - screenRect.top}px`;
         ghost.style.pointerEvents = 'none';
         ghost.style.zIndex = '99999';
         ghost.style.opacity = '0.6';
@@ -73,7 +75,8 @@ export class DragDropManager {
             clone.style.margin = '0';
             ghost.appendChild(clone);
         });
-        document.body.appendChild(ghost);
+        const screenElement = document.getElementById('screen');
+        (screenElement || document.body).appendChild(ghost);
         this.ghostElement = ghost;
     }
 
@@ -87,8 +90,10 @@ export class DragDropManager {
         }
 
         if (this.ghostElement) {
-            this.ghostElement.style.left = `${x - this.offsetX}px`;
-            this.ghostElement.style.top = `${y - this.offsetY}px`;
+            const screen = document.getElementById('screen') || document.body;
+            const screenRect = screen.getBoundingClientRect();
+            this.ghostElement.style.left = `${x - this.offsetX - screenRect.left}px`;
+            this.ghostElement.style.top = `${y - this.offsetY - screenRect.top}px`;
         }
         this._updateDropTarget(x, y);
     }

--- a/src/shell/taskbar/volume-control.js
+++ b/src/shell/taskbar/volume-control.js
@@ -28,13 +28,13 @@ class VolumeControl {
     // Position the element
     // "at the bottom of the screen, to the left of the pointer"
     // We need to wait for it to be in the DOM to get its size
+    const screen = document.getElementById("screen") || document.body;
+    const screenRect = screen.getBoundingClientRect();
     const rect = this.element.getBoundingClientRect();
-    const screenWidth = window.innerWidth;
-    const screenHeight = window.innerHeight;
     const taskbarHeight = 28; // Approximate taskbar height
 
-    let left = x - rect.width;
-    let top = screenHeight - taskbarHeight - rect.height - 2;
+    let left = x - rect.width - screenRect.left;
+    let top = screenRect.height - taskbarHeight - rect.height - 2;
 
     // Ensure it's within screen bounds
     if (left < 0) left = 0;
@@ -113,7 +113,7 @@ class VolumeControl {
   render() {
     const container = document.createElement("div");
     container.className = "volume-control-popup outset-deep";
-    container.style.position = "fixed";
+    container.style.position = "absolute";
     container.style.padding = "5px 5px";
     container.style.zIndex = "9999";
     container.style.width = "70px";
@@ -139,7 +139,8 @@ class VolumeControl {
       </div>
     `;
 
-    document.body.appendChild(container);
+    const screen = document.getElementById("screen");
+    (screen || document.body).appendChild(container);
     this.element = container;
 
     const slider = container.querySelector("#volume-slider");

--- a/src/system/screensaver-utils.js
+++ b/src/system/screensaver-utils.js
@@ -27,7 +27,7 @@ class Screensaver {
     if (!this.element) {
       this.element = document.createElement("iframe");
       this.element.src = `${import.meta.env.BASE_URL}${screensaver.path}`;
-      this.element.style.position = "fixed";
+      this.element.style.position = "absolute";
       this.element.style.top = "0";
       this.element.style.left = "0";
       this.element.style.width = "100%";
@@ -48,7 +48,8 @@ class Screensaver {
         );
       };
 
-      document.body.appendChild(this.element);
+      const screen = document.getElementById("screen");
+      (screen || document.body).appendChild(this.element);
     }
     this.element.style.display = "block";
     this.active = true;
@@ -72,7 +73,7 @@ class Screensaver {
 
     this.previewElement = document.createElement("iframe");
     this.previewElement.src = `${import.meta.env.BASE_URL}${screensaver.path}`;
-    this.previewElement.style.position = "fixed";
+    this.previewElement.style.position = "absolute";
     this.previewElement.style.top = "0";
     this.previewElement.style.left = "0";
     this.previewElement.style.width = "100%";
@@ -88,7 +89,8 @@ class Screensaver {
       iframeDoc.addEventListener("keydown", hidePreviewCallback);
     };
 
-    document.body.appendChild(this.previewElement);
+    const screen = document.getElementById("screen");
+    (screen || document.body).appendChild(this.previewElement);
   }
 
   hidePreview() {


### PR DESCRIPTION
This change fixes the issue where menus and other floating UI elements appeared darker than the rest of the application when the CRT monitor effect was enabled. The fix involves moving these elements into the `#screen` container, which has a brightness compensation filter, and updating their positioning logic to account for the new parent element.

---
*PR created automatically by Jules for task [3642578921813378943](https://jules.google.com/task/3642578921813378943) started by @azayrahmad*