### PR TITLE
Refactor Clippy into a reusable public library

### DIFF
--- a/public/clippy/clippy.css
+++ b/public/clippy/clippy.css
@@ -57,3 +57,50 @@
   margin-left: -50px;
   background-position: 0px -16px;
 }
+
+.clippy-input {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  padding: 5px;
+}
+
+.clippy-input b {
+  align-self: flex-start;
+  margin-bottom: 5px;
+}
+
+.clippy-input textarea {
+  width: 100%;
+  margin-bottom: 10px;
+  background-color: white;
+  border: 1px solid grey;
+  box-shadow: none;
+  resize: none;
+  font-family: inherit;
+  font-size: inherit;
+  box-sizing: border-box;
+}
+
+.clippy-input-buttons {
+  display: flex;
+  justify-content: space-between;
+  width: 100%;
+}
+
+.clippy-input-buttons button {
+  background-color: transparent;
+  border: 1px solid grey;
+  border-radius: 4px;
+  width: 70px;
+  padding: 2px;
+  cursor: pointer;
+}
+
+.clippy-input-buttons button:hover {
+  background-color: #eee;
+}
+
+.clippy-input-buttons .ask-button {
+  margin-right: 5px;
+}

--- a/public/clippy/clippy.js
+++ b/public/clippy/clippy.js
@@ -12,7 +12,11 @@ clippy.Agent = function (path, data, sounds) {
 
   this._el = $('<div class="clippy"></div>').hide();
 
-  $("#screen").append(this._el);
+  var container = $("#screen");
+  if (container.length === 0) {
+    container = $(document.body);
+  }
+  container.append(this._el);
 
   this._animator = new clippy.Animator(this._el, path, data, sounds);
 
@@ -176,10 +180,13 @@ clippy.Agent.prototype = {
       return;
     }
 
-    if (this._el.css("top") === "auto" || !this._el.css("left") === "auto") {
-      const screen = $("#screen");
-      var left = screen.width() * 0.8;
-      var top = screen.height() * 0.8;
+    if (this._el.css("top") === "auto" || this._el.css("left") === "auto") {
+      var container = $("#screen");
+      if (container.length === 0) {
+        container = $(window);
+      }
+      var left = container.width() * 0.8;
+      var top = container.height() * 0.8;
       this._el.css({ top: top, left: left });
     }
 
@@ -192,9 +199,10 @@ clippy.Agent.prototype = {
    *
    * @param {String} text
    * @param {Boolean} hold - Whether to hold the speech balloon
-   * @param {Boolean} useTTS - Whether to use text-to-speech
+   * @param {Boolean=} useTTS - Whether to use text-to-speech (defaults to this.isTTSEnabled())
    */
   speak: function (text, hold, useTTS) {
+    if (useTTS === undefined) useTTS = this.isTTSEnabled();
     this._addToQueue(function (complete) {
       this._balloon.speak(complete, text, hold, useTTS);
     }, this);
@@ -415,11 +423,20 @@ clippy.Agent.prototype = {
     var bH = this._el.outerHeight();
     var bW = this._el.outerWidth();
 
-    const screen = $("#screen");
-    var wW = screen.width();
-    var wH = screen.height();
-    var sT = screen.scrollTop();
-    var sL = screen.scrollLeft();
+    var container = $("#screen");
+    var wW, wH, sT, sL;
+    if (container.length > 0) {
+      wW = container.width();
+      wH = container.height();
+      sT = container.scrollTop();
+      sL = container.scrollLeft();
+    } else {
+      container = $(window);
+      wW = container.width();
+      wH = container.height();
+      sT = $(document).scrollTop();
+      sL = $(document).scrollLeft();
+    }
 
     var top = o.top - sT;
     var left = o.left - sL;

--- a/public/clippy/clippy_extensions_complete.js
+++ b/public/clippy/clippy_extensions_complete.js
@@ -68,7 +68,7 @@
          * @param {Object} options - Configuration options
          * @param {Number} options.animationTimeout - Timeout for animation (default: 5000ms)
          * @param {Boolean} options.hold - Whether to hold the speech balloon (default: false)
-         * @param {Boolean} options.useTTS - Whether to use text-to-speech (default: false)
+         * @param {Boolean=} options.useTTS - Whether to use text-to-speech (defaults to agent preference)
          * @param {Object} options.ttsOptions - TTS configuration (voice, rate, pitch, volume)
          * @param {Function} options.callback - Called when both speech and animation complete
          * @returns {Promise<Boolean>} - Promise that resolves to true if successful, false if animation doesn't exist
@@ -77,7 +77,7 @@
             options = options || {};
             var animationTimeout = options.animationTimeout !== undefined ? options.animationTimeout : 5000;
             var hold = options.hold || false;
-            var useTTS = options.useTTS || false;
+            var useTTS = options.useTTS !== undefined ? options.useTTS : this.isTTSEnabled();
             var ttsOptions = options.ttsOptions || {};
             var callback = options.callback;
 
@@ -163,7 +163,7 @@
     clippy.Agent.prototype.speakWithRepeatingAnimation = function (text, animation, options) {
         options = options || {};
         var hold = options.hold || false;
-        var useTTS = options.useTTS || false;
+        var useTTS = options.useTTS !== undefined ? options.useTTS : this.isTTSEnabled();
         var ttsOptions = options.ttsOptions || {};
         var callback = options.callback;
         var animationDelay = options.animationDelay || 200; // Delay between animation cycles
@@ -415,13 +415,13 @@
      * @param {String} text - The text to speak
      * @param {String} emotion - 'happy', 'sad', 'excited', 'thinking', 'surprised', etc.
      * @param {Object} options - Additional options
-     * @param {Boolean} options.useTTS - Whether to use text-to-speech (default: false)
+     * @param {Boolean=} options.useTTS - Whether to use text-to-speech (defaults to agent preference)
      * @param {Object} options.ttsOptions - TTS configuration (voice, rate, pitch, volume)
      * @returns {Boolean} - True if successful
      */
     clippy.Agent.prototype.speakWithEmotion = function (text, emotion, options) {
         options = options || {};
-        var useTTS = options.useTTS || false;
+        var useTTS = options.useTTS !== undefined ? options.useTTS : this.isTTSEnabled();
         var ttsOptions = options.ttsOptions || {};
 
         var emotionAnimations = {
@@ -861,6 +861,156 @@
         return this.hasAnimation("Goodbye") ? "Goodbye" : this.hasAnimation("GoodBye") ? "GoodBye" : "Hide";
     }
 
+    /**
+     * Show an interactive input balloon
+     * @param {Object} options - Configuration options
+     * @param {String} options.title - The title text (default: "What would you like to do?")
+     * @param {String} options.placeholder - Placeholder for the textarea
+     * @param {String} options.askButtonText - Text for the ask button (default: "Ask")
+     * @param {String} options.cancelButtonText - Text for the cancel button (default: "Cancel")
+     * @param {Number} options.timeout - Auto-close timeout in ms (default: 60000)
+     * @param {Function} options.onAsk - Called when the ask button is clicked, with the input value
+     * @param {Function} options.onCancel - Called when the cancel button is clicked
+     */
+    clippy.Agent.prototype.ask = function (options) {
+        options = options || {};
+        var self = this;
+        var title = options.title || "What would you like to do?";
+        var placeholder = options.placeholder || "Ask me anything...";
+        var askButtonText = options.askButtonText || "Ask";
+        var cancelButtonText = options.cancelButtonText || "Cancel";
+        var timeout = options.timeout || 60000;
+        var inputBalloonTimeout = null;
+
+        this.stop();
+
+        var balloonContent =
+            '<div class="clippy-input">' +
+            '<b>' + title + '</b>' +
+            '<textarea rows="2" placeholder="' + placeholder + '"></textarea>' +
+            '<div class="clippy-input-buttons">' +
+            '<button class="ask-button default">' + askButtonText + '</button>' +
+            '<button class="cancel-button">' + cancelButtonText + '</button>' +
+            '</div>' +
+            '</div>';
+
+        this._balloon.showHtml(balloonContent, true);
+
+        var balloon = this._balloon._balloon;
+        var input = balloon.find("textarea");
+        var askButton = balloon.find(".ask-button");
+        var cancelButton = balloon.find(".cancel-button");
+
+        input.focus();
+
+        // Reposition balloon after a delay to allow for rendering
+        setTimeout(function () {
+            self._balloon.reposition();
+        }, 0);
+
+        var resetBalloonTimeout = function () {
+            if (inputBalloonTimeout) {
+                clearTimeout(inputBalloonTimeout);
+            }
+            inputBalloonTimeout = setTimeout(function () {
+                self.closeBalloon();
+            }, timeout);
+        };
+
+        var clearBalloonTimeout = function () {
+            if (inputBalloonTimeout) {
+                clearTimeout(inputBalloonTimeout);
+            }
+        };
+
+        var askHandler = function () {
+            clearBalloonTimeout();
+            var question = input.val();
+            if (options.onAsk) options.onAsk(question);
+            self.closeBalloon();
+        };
+
+        input.on("keypress", function (e) {
+            resetBalloonTimeout();
+            if (e.which === 13) {
+                e.preventDefault();
+                askHandler();
+            }
+        });
+
+        askButton.on("click", askHandler);
+
+        cancelButton.on("click", function () {
+            clearBalloonTimeout();
+            if (options.onCancel) options.onCancel();
+            self.closeBalloon();
+        });
+
+        resetBalloonTimeout();
+    };
+
+    /**
+     * Automatically set a recommended voice based on language and name patterns
+     * @param {String} lang - Language code (default: 'en')
+     */
+    clippy.Agent.prototype.setRecommendedVoice = function (lang) {
+        lang = lang || 'en';
+        var self = this;
+
+        var doSetRecommendedVoice = function() {
+            var voices = self.getTTSVoices();
+            if (voices.length === 0) return false;
+
+            var englishVoices = voices.filter(function (v) { return v.lang.startsWith(lang); });
+            var maleNames = [
+                "male", "david", "alex", "fred", "daniel", "george",
+                "paul", "tom", "mark", "james", "michael"
+            ];
+
+            var defaultVoice = englishVoices.find(function (v) {
+                return maleNames.some(function (name) {
+                    return v.name.toLowerCase().includes(name);
+                });
+            });
+
+            if (!defaultVoice) {
+                var femaleNames = [
+                    "zira", "hazel", "samantha", "susan", "karen",
+                    "sara", "emma", "lucy", "anna"
+                ];
+                var nonFemaleVoices = englishVoices.filter(function (v) {
+                    return !femaleNames.some(function (name) {
+                        return v.name.toLowerCase().includes(name);
+                    }) && !v.name.toLowerCase().includes("female");
+                });
+
+                if (nonFemaleVoices.length > 0) {
+                    defaultVoice = nonFemaleVoices[0];
+                } else {
+                    defaultVoice = englishVoices[0];
+                }
+            }
+
+            self.setTTSOptions({
+                voice: defaultVoice,
+                rate: 0.9,
+                pitch: 0.9,
+                volume: 0.8,
+            });
+
+            return true;
+        };
+
+        if (this.getTTSVoices().length > 0) {
+            return doSetRecommendedVoice();
+        } else if (window.speechSynthesis) {
+            window.speechSynthesis.addEventListener('voiceschanged', doSetRecommendedVoice, { once: true });
+            return true;
+        }
+
+        return false;
+    };
+
     // =============================================================================
     // INITIAL POSITION OVERRIDE
     // =============================================================================
@@ -899,14 +1049,15 @@
 
     // Add version info
     clippy.extensions = {
-        version: '1.0.0',
+        version: '1.1.0',
         methods: [
             'speakAndAnimate', 'speakWithRepeatingAnimation', 'speakWithIdleAnimation',
             'randomAnimation', 'gestureDirection', 'animationSequence',
             'speakWithEmotion', 'whisper', 'announce',
             'setPersonality', 'greetWithPersonality', 'farewellWithPersonality',
             'contextualResponse', 'performSequence', 'getAnimationInfo', 'isBusy', 'getQueueLength',
-            'showError', 'showSuccess', 'showLoading', 'showWarning', 'getGoodbyeAnimation'
+            'showError', 'showSuccess', 'showLoading', 'showWarning', 'getGoodbyeAnimation',
+            'ask', 'setRecommendedVoice'
         ]
     };
 

--- a/public/clippy/index.html
+++ b/public/clippy/index.html
@@ -1,0 +1,225 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Clippy.js Reusable Library Demo</title>
+    <link rel="stylesheet" href="https://unpkg.com/98.css">
+    <link rel="stylesheet" href="clippy.css">
+    <style>
+        body {
+            background-color: #008080;
+            padding: 50px;
+            display: flex;
+            justify-content: center;
+            align-items: flex-start;
+            min-height: 100vh;
+            margin: 0;
+        }
+
+        .window {
+            width: 600px;
+        }
+
+        .window-body {
+            padding: 10px;
+        }
+
+        .controls {
+            display: grid;
+            grid-template-columns: repeat(2, 1fr);
+            gap: 10px;
+            margin-top: 15px;
+        }
+
+        .field-row-stacked {
+            margin-bottom: 15px;
+        }
+
+        pre {
+            background: #fff;
+            padding: 10px;
+            border: 1px inset #d2d2d2;
+            overflow-x: auto;
+            margin: 0;
+        }
+
+        code {
+            font-family: 'Courier New', Courier, monospace;
+            font-size: 12px;
+        }
+
+        .status-bar {
+            margin-top: 20px;
+        }
+    </style>
+</head>
+<body>
+    <div class="window">
+        <div class="title-bar">
+            <div class="title-bar-text">Clippy.js Demo - Reusable Assistant</div>
+            <div class="title-bar-controls">
+                <button aria-label="Minimize"></button>
+                <button aria-label="Maximize"></button>
+                <button aria-label="Close"></button>
+            </div>
+        </div>
+        <div class="window-body">
+            <p>This demo showcases the decoupled Clippy library using 98.css. It works on any standard webpage!</p>
+
+            <fieldset>
+                <legend>Assistant Settings</legend>
+                <div class="field-row">
+                    <label for="agentSelect">Agent:</label>
+                    <select id="agentSelect">
+                        <option value="Clippy" selected>Clippy</option>
+                        <option value="Bonzi">Bonzi</option>
+                        <option value="Genie">Genie</option>
+                        <option value="Genius">Genius</option>
+                        <option value="Links">Links</option>
+                        <option value="Merlin">Merlin</option>
+                        <option value="Peedy">Peedy</option>
+                        <option value="Rocky">Rocky</option>
+                        <option value="Rover">Rover</option>
+                        <option value="F1">F1</option>
+                    </select>
+                </div>
+                <div class="field-row">
+                    <input type="checkbox" id="ttsCheckbox">
+                    <label for="ttsCheckbox">Enable Text-to-Speech (TTS)</label>
+                </div>
+            </fieldset>
+
+            <fieldset>
+                <legend>Actions</legend>
+                <div class="controls">
+                    <button onclick="speak()">Speak Randomly</button>
+                    <button onclick="ask()">Ask Question (New!)</button>
+                    <button onclick="animateRandomly()">Play Animation</button>
+                    <button onclick="moveToRandom()">Move to Random Pos</button>
+                    <button onclick="changePersonality()">Change Personality</button>
+                    <button onclick="currentAgent.animate()">Random Animation</button>
+                </div>
+            </fieldset>
+
+            <fieldset style="margin-top: 15px;">
+                <legend>Implementation Example</legend>
+                <div class="field-row-stacked">
+                    <pre><code>clippy.load('Clippy', function(agent) {
+    agent.show();
+    agent.setRecommendedVoice();
+
+    // New reusable Ask feature
+    agent.ask({
+        title: 'User Prompt',
+        onAsk: (val) => agent.speak('Received: ' + val)
+    });
+});</code></pre>
+                </div>
+            </fieldset>
+
+            <div class="status-bar">
+                <p class="status-bar-field">Status: <span id="status">Ready</span></p>
+                <p class="status-bar-field">Personality: <span id="personality">Default</span></p>
+                <p class="status-bar-field">CPU Usage: 0%</p>
+            </div>
+        </div>
+    </div>
+
+    <!-- Dependencies -->
+    <script src="https://code.jquery.com/jquery-3.6.0.min.js"></script>
+    <script src="clippy.js"></script>
+    <script src="clippy_extensions_complete.js"></script>
+
+    <script>
+        var currentAgent = null;
+        var personalities = ['helpful', 'playful', 'professional', 'sarcastic'];
+        var currentPIdx = 0;
+
+        function setStatus(text) {
+            document.getElementById('status').innerText = text;
+        }
+
+        function loadAgent(name) {
+            setStatus('Loading ' + name + '...');
+
+            if (currentAgent) {
+                currentAgent.hide(true, function() {
+                    $('.clippy, .clippy-balloon').remove();
+                });
+            }
+
+            clippy.load(name, function(agent) {
+                currentAgent = agent;
+                agent.show();
+                agent.setRecommendedVoice();
+
+                var ttsEnabled = document.getElementById('ttsCheckbox').checked;
+                agent.setTTSEnabled(ttsEnabled);
+
+                setStatus(name + ' Ready');
+                agent.speak('Assistant ' + name + ' is ready for duty!');
+            });
+        }
+
+        function speak() {
+            if (!currentAgent) return;
+            var phrases = [
+                "I'm now using 98.css for this demo!",
+                "Does this look nostalgic enough?",
+                "I can be easily integrated into any site.",
+                "Check out the implementation details below.",
+                "My logic is fully decoupled from the main OS."
+            ];
+            currentAgent.speak(phrases[Math.floor(Math.random() * phrases.length)]);
+        }
+
+        function ask() {
+            if (!currentAgent) return;
+            currentAgent.ask({
+                title: "Question for User",
+                placeholder: "Type your response...",
+                onAsk: function(val) {
+                    if (val) {
+                        currentAgent.speakAndAnimate("Interesting. You said: " + val, "Explain");
+                    }
+                }
+            });
+        }
+
+        function animateRandomly() {
+            if (!currentAgent) return;
+            currentAgent.animate();
+        }
+
+        function moveToRandom() {
+            if (!currentAgent) return;
+            var x = Math.random() * (window.innerWidth - 200);
+            var y = Math.random() * (window.innerHeight - 200);
+            currentAgent.moveTo(x, y);
+        }
+
+        function changePersonality() {
+            if (!currentAgent) return;
+            currentPIdx = (currentPIdx + 1) % personalities.length;
+            var p = personalities[currentPIdx];
+            currentAgent.setPersonality(p);
+            document.getElementById('personality').innerText = p.charAt(0).toUpperCase() + p.slice(1);
+            currentAgent.greetWithPersonality();
+        }
+
+        document.getElementById('agentSelect').addEventListener('change', function(e) {
+            loadAgent(e.target.value);
+        });
+
+        document.getElementById('ttsCheckbox').addEventListener('change', function(e) {
+            if (currentAgent) currentAgent.setTTSEnabled(e.target.checked);
+        });
+
+        $(document).ready(function() {
+            clippy.BASE_PATH = 'agents/';
+            loadAgent('Clippy');
+        });
+    </script>
+</body>
+</html>

--- a/src/apps/clippy/clippy.js
+++ b/src/apps/clippy/clippy.js
@@ -12,7 +12,6 @@ import { appManager } from '../../system/app-manager.js';
 window.clippyAppInstance = null;
 let currentAgentName =
   getItem(LOCAL_STORAGE_KEYS.CLIPPY_AGENT_NAME) || "Clippy";
-let inputBalloonTimeout = null;
 
 function setCurrentAgentName(name) {
   currentAgentName = name;
@@ -23,71 +22,11 @@ function showClippyInputBalloon() {
   const agent = window.clippyAgent;
   if (!agent) return;
 
-  agent.stop();
-
-  const balloonContent = `
-    <div class="clippy-input" style="display: flex; flex-direction: column; align-items: center; padding: 5px;">
-      <b style="align-self: flex-start; margin-bottom: 5px;">What would you like to do?</b>
-      <textarea rows="2" placeholder="Ask me anything..." style="width: 100%; margin-bottom: 10px; background-color: white; border: 1px solid grey; box-shadow: none; resize: none; font-family: inherit; font-size: inherit;"></textarea>
-      <div style="display: flex; justify-content: space-between; width: 100%;">
-        <button class="ask-button default" style="margin-right: 5px; background-color: transparent; border: 1px solid grey; border-radius: 4px; width: 70px">Ask</button>
-        <button class="cancel-button" style="background-color: transparent; border: 1px solid grey; border-radius: 4px; width: 70px">Cancel</button>
-      </div>
-    </div>
-  `;
-
-  agent._balloon.showHtml(balloonContent, true);
-
-  const balloon = agent._balloon._balloon;
-  const input = balloon.find("textarea");
-  const askButton = balloon.find(".ask-button");
-  const cancelButton = balloon.find(".cancel-button");
-
-  input.focus();
-
-  // Reposition balloon after a delay to allow for rendering
-  setTimeout(() => {
-    agent._balloon.reposition();
-  }, 0);
-
-  const resetBalloonTimeout = () => {
-    if (inputBalloonTimeout) {
-      clearTimeout(inputBalloonTimeout);
-    }
-    inputBalloonTimeout = setTimeout(() => {
-      agent.closeBalloon();
-    }, 60000); // 1 minute
-  };
-
-  const clearBalloonTimeout = () => {
-    if (inputBalloonTimeout) {
-      clearTimeout(inputBalloonTimeout);
-    }
-  };
-
-  const askClippyHandler = () => {
-    clearBalloonTimeout();
-    const question = input.val();
-    askClippy(agent, question);
-    agent.closeBalloon();
-  };
-
-  input.on("keypress", (e) => {
-    resetBalloonTimeout();
-    if (e.which === 13) {
-      e.preventDefault();
-      askClippyHandler();
-    }
+  agent.ask({
+    onAsk: (question) => {
+      askClippy(agent, question);
+    },
   });
-
-  askButton.on("click", askClippyHandler);
-
-  cancelButton.on("click", () => {
-    clearBalloonTimeout();
-    agent.closeBalloon();
-  });
-
-  resetBalloonTimeout(); // Start the timer when the balloon is shown
 }
 
 async function askClippy(agent, question) {
@@ -238,61 +177,7 @@ export function launchClippyApp(app, agentName = currentAgentName) {
     const ttsEnabled = agent.isTTSEnabled();
     if (ttsEnabled) {
       const setDefaultVoice = () => {
-        const voices = agent.getTTSVoices();
-        if (voices.length > 0) {
-          // Improved voice selection logic
-          const englishVoices = voices.filter((v) => v.lang.startsWith("en"));
-
-          // Prioritize male-sounding voices by name patterns
-          let defaultVoice = englishVoices.find(
-            (v) =>
-              v.name.toLowerCase().includes("male") ||
-              v.name.toLowerCase().includes("david") ||
-              v.name.toLowerCase().includes("alex") ||
-              v.name.toLowerCase().includes("fred") ||
-              v.name.toLowerCase().includes("daniel") ||
-              v.name.toLowerCase().includes("george") ||
-              v.name.toLowerCase().includes("paul") ||
-              v.name.toLowerCase().includes("tom") ||
-              v.name.toLowerCase().includes("mark") ||
-              v.name.toLowerCase().includes("james") ||
-              v.name.toLowerCase().includes("michael"),
-          );
-
-          // If no male voice found, prefer voices that are NOT obviously female
-          if (!defaultVoice) {
-            const femaleNames = [
-              "zira",
-              "hazel",
-              "samantha",
-              "susan",
-              "karen",
-              "sara",
-              "emma",
-              "lucy",
-              "anna",
-            ];
-            const nonFemaleVoices = englishVoices.filter(
-              (v) =>
-                !femaleNames.some((name) =>
-                  v.name.toLowerCase().includes(name),
-                ) && !v.name.toLowerCase().includes("female"),
-            );
-
-            if (nonFemaleVoices.length > 0) {
-              defaultVoice = nonFemaleVoices[0]; // Take first non-female voice
-            } else {
-              defaultVoice = englishVoices[0]; // Fallback to any English voice
-            }
-          }
-
-          agent.setTTSOptions({
-            voice: defaultVoice,
-            rate: 0.9,
-            pitch: 0.9,
-            volume: 0.8,
-          });
-        }
+        agent.setRecommendedVoice();
       };
       if (window.speechSynthesis.getVoices().length) {
         setDefaultVoice();


### PR DESCRIPTION
This PR refactors the Clippy implementation to separate generic assistant logic from Windows 98-specific application code. 

Key changes include:
- **Generic Input API**: Added `agent.ask(options)` to the public Clippy extensions, providing a reusable way to prompt users with a text input balloon.
- **Voice Recommendation**: Added `agent.setRecommendedVoice()` to the library to encapsulate voice selection logic based on language and gender patterns.
- **Environment Agnostic**: Updated the core `clippy.js` to gracefully fall back to `document.body` if the `#screen` element (specific to the Windows 98 desktop) is not present.
- **Styling**: Moved input balloon CSS from the application source to `public/clippy/clippy.css` for self-contained reusability.
- **Simplified App Code**: The Windows 98 Clippy application in `src` now leverages these library methods, reducing boilerplate while keeping unique features like the Vercel API integration and Win98 busy-state management.

These changes make the `public/clippy` folder a truly reusable library that can be dropped into any random webpage, as requested.

---
*PR created automatically by Jules for task [8230609796843262203](https://jules.google.com/task/8230609796843262203) started by @azayrahmad*