### PR TITLE
Add WebLLM support to Clippy assistant

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -4,6 +4,7 @@
     "": {
       "name": "win98-web",
       "dependencies": {
+        "@mlc-ai/web-llm": "^0.2.81",
         "@xterm/addon-fit": "^0.11.0",
         "@xterm/addon-image": "^0.9.0",
         "@xterm/xterm": "^5.5.0",
@@ -274,6 +275,8 @@
     "@jridgewell/sourcemap-codec": ["@jridgewell/sourcemap-codec@1.5.5", "", {}, "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og=="],
 
     "@jridgewell/trace-mapping": ["@jridgewell/trace-mapping@0.3.31", "", { "dependencies": { "@jridgewell/resolve-uri": "^3.1.0", "@jridgewell/sourcemap-codec": "^1.4.14" } }, "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw=="],
+
+    "@mlc-ai/web-llm": ["@mlc-ai/web-llm@0.2.81", "", { "dependencies": { "loglevel": "^1.9.1" } }, "sha512-V2zdaHeCfv7KjnN6WOrt85v6tfefDVyTvWXZ5IN7OXu21Ee1hDg/jQu3ANWN/wjy2qdhVD16cAhoNpnxqyf+Gg=="],
 
     "@playwright/test": ["@playwright/test@1.58.2", "", { "dependencies": { "playwright": "1.58.2" }, "bin": { "playwright": "cli.js" } }, "sha512-akea+6bHYBBfA9uQqSYmlJXn61cTa+jbO87xVLCWbTqbWadRVmhxlXATaOjOgcBaWU4ePo0wB41KMFv3o35IXA=="],
 
@@ -644,6 +647,8 @@
     "lodash.debounce": ["lodash.debounce@4.0.8", "", {}, "sha512-FT1yDzDYEoYWhnSGnpE/4Kj1fLZkDFyqRb7fNt6FdYOSxlUWAtp42Eh6Wb0rGIv/m9Bgo7x4GhQbm5Ys4SG5ow=="],
 
     "lodash.sortby": ["lodash.sortby@4.7.0", "", {}, "sha512-HDWXG8isMntAyRF5vZ7xKuEvOhT4AhlRt/3czTSjvGUxjYCBVRQY48ViDHyfYz9VIoBkW4TMGQNapx+l3RUwdA=="],
+
+    "loglevel": ["loglevel@1.9.2", "", {}, "sha512-HgMmCqIJSAKqo68l0rS2AanEWfkxaZ5wNiEFb5ggm08lDs9Xl2KxBlX3PTcaD2chBM1gXAYf491/M2Rv8Jwayg=="],
 
     "lru-cache": ["lru-cache@5.1.1", "", { "dependencies": { "yallist": "^3.0.2" } }, "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w=="],
 

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "vite-plugin-pwa": "^1.2.0"
   },
   "dependencies": {
+    "@mlc-ai/web-llm": "^0.2.81",
     "@xterm/addon-fit": "^0.11.0",
     "@xterm/addon-image": "^0.9.0",
     "@xterm/xterm": "^5.5.0",

--- a/src/apps/clippy/clippy.js
+++ b/src/apps/clippy/clippy.js
@@ -49,8 +49,21 @@ async function askClippy(agent, question) {
            // so we just wait for it to be ready.
         });
       }
-      const answer = await webLLMService.ask(question.trim());
-      await agent.speakAndAnimate(answer, "Explain", { useTTS: ttsEnabled });
+      const response = await webLLMService.ask(question.trim());
+      let data;
+      try {
+        data = JSON.parse(response);
+        if (!Array.isArray(data)) data = [{ answer: response, animation: "Explain" }];
+      } catch (e) {
+        data = [{ answer: response, animation: "Explain" }];
+      }
+
+      for (const fragment of data) {
+        const cleanAnswer = fragment.answer.replace(/\*\*/g, "");
+        await agent.speakAndAnimate(cleanAnswer, fragment.animation || "Explain", {
+          useTTS: ttsEnabled,
+        });
+      }
       return;
     } catch (error) {
       console.error("Local LLM Error:", error);

--- a/src/apps/clippy/clippy.js
+++ b/src/apps/clippy/clippy.js
@@ -8,6 +8,7 @@ import {
   releaseBusyState,
 } from '../../system/busy-state-manager.js';
 import { appManager } from '../../system/app-manager.js';
+import { webLLMService } from './webllm-service.js';
 
 window.clippyAppInstance = null;
 let currentAgentName =
@@ -33,9 +34,29 @@ async function askClippy(agent, question) {
   if (!question || question.trim().length === 0) return;
 
   const ttsEnabled = agent.isTTSEnabled();
+  const backend = getItem(LOCAL_STORAGE_KEYS.CLIPPY_BACKEND) || "cloud";
+
   agent.speakAndAnimate("Let me think about it...", "Thinking", {
     useTTS: ttsEnabled,
   });
+
+  if (backend === "local") {
+    try {
+      if (!webLLMService.engine) {
+        agent.speakAndAnimate("Hold on, I need to load my local brain first...", "Processing", { useTTS: ttsEnabled });
+        await webLLMService.init((report) => {
+           // We can't really show detailed progress here without blocking,
+           // so we just wait for it to be ready.
+        });
+      }
+      const answer = await webLLMService.ask(question.trim());
+      await agent.speakAndAnimate(answer, "Explain", { useTTS: ttsEnabled });
+      return;
+    } catch (error) {
+      console.error("Local LLM Error:", error);
+      agent.speakAndAnimate("My local brain is fuzzy... falling back to the cloud!", "Confused", { useTTS: ttsEnabled });
+    }
+  }
 
   try {
     const encodedQuestion = encodeURIComponent(question.trim());
@@ -62,6 +83,56 @@ async function askClippy(agent, question) {
 
 import { AGENT_NAMES } from '../../config/agents.js';
 
+async function showBackendChoice(agent) {
+  const isWebGPU = await webLLMService.isWebGPUSupported();
+
+  const title = isWebGPU
+    ? "Would you like me to use my Local brain (WebGPU) or Cloud service (Vercel)?"
+    : "Your browser doesn't support WebGPU for my local brain. Use Cloud service?";
+
+  agent.ask({
+    title: title,
+    askButtonText: isWebGPU ? "Local" : "Cloud",
+    cancelButtonText: isWebGPU ? "Cloud" : "Cancel",
+    placeholder: isWebGPU ? "Type 'local' or 'cloud'..." : "Cloud is recommended.",
+    onAsk: (val) => {
+        const choice = val.toLowerCase().includes('cloud') ? 'cloud' : 'local';
+        setBackend(agent, choice);
+    },
+    onCancel: () => {
+        setBackend(agent, 'cloud');
+    }
+  });
+}
+
+async function setBackend(agent, mode) {
+    if (mode === 'local') {
+        const isWebGPU = await webLLMService.isWebGPUSupported();
+        if (!isWebGPU) {
+            agent.speakAndAnimate("Sorry, your browser doesn't support WebGPU. I'll have to use the Cloud!", "Sad");
+            setItem(LOCAL_STORAGE_KEYS.CLIPPY_BACKEND, 'cloud');
+            return;
+        }
+
+        agent.speakAndAnimate("I'm preparing to download my brain (~700MB). This might take a while...", "Processing");
+        try {
+            await webLLMService.init((report) => {
+                const percent = Math.floor((report.progress || 0) * 100);
+                agent._balloon.showHtml(`<b>Downloading: ${percent}%</b><br>${report.text}`, true);
+            });
+            agent.speakAndAnimate("I'm all set! My brain is now local.", "Congratulate");
+            setItem(LOCAL_STORAGE_KEYS.CLIPPY_BACKEND, 'local');
+        } catch (e) {
+            agent.speakAndAnimate("Something went wrong with the download. Let's stick to the Cloud for now.", "Sad");
+            setItem(LOCAL_STORAGE_KEYS.CLIPPY_BACKEND, 'cloud');
+        }
+    } else {
+        setItem(LOCAL_STORAGE_KEYS.CLIPPY_BACKEND, 'cloud');
+        webLLMService.unload();
+        agent.speakAndAnimate("Switched to Cloud service.", "Explain");
+    }
+}
+
 export function getClippyMenuItems(app) {
   const appInstance = app || window.clippyAppInstance;
   const agent = window.clippyAgent;
@@ -70,6 +141,7 @@ export function getClippyMenuItems(app) {
   }
 
   const ttsEnabled = agent.isTTSEnabled();
+  const currentBackend = getItem(LOCAL_STORAGE_KEYS.CLIPPY_BACKEND) || "cloud";
 
   return [
     {
@@ -114,6 +186,24 @@ export function getClippyMenuItems(app) {
             }
           },
         },
+        "MENU_DIVIDER",
+        {
+            label: "Backend",
+            submenu: [
+                {
+                    radioItems: [
+                        { label: "Cloud (Vercel)", value: "cloud" },
+                        { label: "Local (WebGPU)", value: "local" },
+                    ],
+                    getValue: () => currentBackend,
+                    setValue: (value) => {
+                        if (currentBackend !== value) {
+                            setBackend(agent, value);
+                        }
+                    }
+                }
+            ]
+        }
       ],
     },
     "MENU_DIVIDER",
@@ -218,11 +308,16 @@ export function launchClippyApp(app, agentName = currentAgentName) {
       return originalSpeakAndAnimate.call(this, text, animation, newOptions);
     };
 
-    agent.speakAndAnimate(
-      "Hey, there. Want quick answers to your questions? Just click me.",
-      "Explain",
-      { useTTS: ttsEnabled },
-    );
+    const backend = getItem(LOCAL_STORAGE_KEYS.CLIPPY_BACKEND);
+    if (!backend) {
+        showBackendChoice(agent);
+    } else {
+        agent.speakAndAnimate(
+            "Hey, there. Want quick answers to your questions? Just click me.",
+            "Explain",
+            { useTTS: ttsEnabled },
+        );
+    }
 
     agent._el.on("click", (e) => {
       if (contextMenuOpened) {

--- a/src/apps/clippy/webllm-service.js
+++ b/src/apps/clippy/webllm-service.js
@@ -10,7 +10,13 @@ You live in Windows 98 Web Edition, a web-based simulation of Windows 98 created
 Your goal is to assist users with their questions about Windows 98, the azOS project, or anything else they might be curious about.
 Keep your responses concise and maintain your helpful assistant persona.
 If you don't know something, be honest but stay in character.
-Always refer to yourself as Clippy, regardless of which agent character is currently being used visually.`;
+Always refer to yourself as Clippy, regardless of which agent character is currently being used visually.
+
+IMPORTANT: You must respond ONLY with a JSON array of objects. Each object represents a fragment of your speech and an associated animation.
+Format: [{"answer": "text", "animation": "AnimationName"}]
+
+Valid AnimationNames: Explain, Wave, Thinking, Congratulate, Sad, Confused, GetAttention, Victory, Processing.
+Use "Explain" as default. Split long answers into 2-3 fragments.`;
     }
 
     async isWebGPUSupported() {

--- a/src/apps/clippy/webllm-service.js
+++ b/src/apps/clippy/webllm-service.js
@@ -1,0 +1,74 @@
+import { CreateMLCEngine } from "@mlc-ai/web-llm";
+
+export class WebLLMService {
+    constructor() {
+        this.engine = null;
+        this.modelId = "Llama-3.2-1B-Instruct-q4f16_1-MLC";
+        this.systemPrompt = `You are Clippy, the legendary Microsoft Office Assistant.
+You are friendly, helpful, and a bit quirky.
+You live in Windows 98 Web Edition, a web-based simulation of Windows 98 created by Aziz (azayrahmad).
+Your goal is to assist users with their questions about Windows 98, the azOS project, or anything else they might be curious about.
+Keep your responses concise and maintain your helpful assistant persona.
+If you don't know something, be honest but stay in character.
+Always refer to yourself as Clippy, regardless of which agent character is currently being used visually.`;
+    }
+
+    async isWebGPUSupported() {
+        if (!navigator.gpu) {
+            return false;
+        }
+        try {
+            const adapter = await navigator.gpu.requestAdapter();
+            return !!adapter;
+        } catch (e) {
+            return false;
+        }
+    }
+
+    async init(onProgress) {
+        if (this.engine) return;
+
+        try {
+            this.engine = await CreateMLCEngine(this.modelId, {
+                initProgressCallback: (report) => {
+                    if (onProgress) {
+                        onProgress(report);
+                    }
+                },
+            });
+        } catch (error) {
+            console.error("WebLLM Init Error:", error);
+            throw error;
+        }
+    }
+
+    async ask(question) {
+        if (!this.engine) {
+            throw new Error("WebLLM Engine not initialized");
+        }
+
+        const messages = [
+            { role: "system", content: this.systemPrompt },
+            { role: "user", content: question },
+        ];
+
+        try {
+            const reply = await this.engine.chat.completions.create({
+                messages,
+            });
+            return reply.choices[0].message.content;
+        } catch (error) {
+            console.error("WebLLM Chat Error:", error);
+            throw error;
+        }
+    }
+
+    async unload() {
+        if (this.engine) {
+            await this.engine.unload();
+            this.engine = null;
+        }
+    }
+}
+
+export const webLLMService = new WebLLMService();

--- a/src/system/local-storage.js
+++ b/src/system/local-storage.js
@@ -33,6 +33,7 @@ export const LOCAL_STORAGE_KEYS = {
   MUTED: 'muted',
   SOLITAIRE_SHOW_STATUS_BAR: "solitaireShowStatusBar",
   SOLITAIRE_KEEP_SCORE: "solitaireKeepScore",
+  CLIPPY_BACKEND: 'clippyBackend',
 };
 
 export function getItem(key) {


### PR DESCRIPTION
Integrated WebLLM as the primary local backend for the Clippy assistant, utilizing WebGPU for in-browser inference. The system now prompts users to choose between Local (WebGPU) and Cloud (Vercel) modes on first launch. If Local is selected, it handles the ~700MB model download with visual progress tracking in Clippy's balloon. The existing Vercel backend serves as a robust fallback for browsers without WebGPU or if local inference fails. Users can toggle between backends via a new "Backend" entry in Clippy's right-click context menu.

---
*PR created automatically by Jules for task [2852325315890912593](https://jules.google.com/task/2852325315890912593) started by @azayrahmad*