### PR TITLE
Enable Ask Agent by single click on the agent

### DIFF
--- a/src/apps/agent/agent.js
+++ b/src/apps/agent/agent.js
@@ -250,17 +250,34 @@ export async function launchAgentApp(app, agentName = currentAgentName) {
     agent.balloon._balloonEl.setAttribute("data-agent-interaction", "true");
   }
 
+  let startX, startY;
   const onAgentClick = (e) => {
     // Only if a context menu is not open
-    if (document.querySelector(".menu-popup")) return;
-    // Check if we were dragging
-    if (agent.wasDragging) return;
+    if (document.querySelector(".menu-popup-wrapper.open")) return;
 
+    // Custom drag detection: if we moved more than 10 pixels, ignore the click
+    const diffX = Math.abs(e.clientX - startX);
+    const diffY = Math.abs(e.clientY - startY);
+    if (diffX > 10 || diffY > 10) return;
+
+    // If already speaking/busy, stop it first
     if (agent.stop) agent.stop();
     showAgentInputBalloon();
   };
 
-  agent.on("click", onAgentClick);
+  // The library's "click" event might not always fire as expected or might be blocked.
+  // We use direct DOM listeners on the canvas for better reliability.
+  if (agent.renderer && agent.renderer.canvas) {
+    agent.renderer.canvas.addEventListener("mousedown", (e) => {
+      startX = e.clientX;
+      startY = e.clientY;
+    });
+    agent.renderer.canvas.addEventListener("click", (e) => {
+      onAgentClick(e);
+    });
+  } else {
+    agent.on("click", onAgentClick);
+  }
 
   // Use the library's contextmenu event if available, otherwise fallback to canvas
   agent.on("contextmenu", (e) => {

--- a/src/apps/clippy/clippy.js
+++ b/src/apps/clippy/clippy.js
@@ -224,14 +224,27 @@ export function launchClippyApp(app, agentName = currentAgentName) {
       { useTTS: ttsEnabled },
     );
 
+    let startX, startY;
+    agent._el.on("mousedown", (e) => {
+      startX = e.clientX;
+      startY = e.clientY;
+    });
+
     agent._el.on("click", (e) => {
+      // Custom drag detection
+      const diffX = Math.abs(e.clientX - startX);
+      const diffY = Math.abs(e.clientY - startY);
+      if (diffX > 10 || diffY > 10) return;
+
       if (contextMenuOpened) {
         contextMenuOpened = false;
         return;
       }
-      if (agent.isSpeaking) return;
       // Also check if a context menu is open
-      if (document.querySelector(".menu-popup")) return;
+      if (document.querySelector(".menu-popup-wrapper.open")) return;
+
+      // Interrupt current speech/animation if clicking
+      if (agent.stop) agent.stop();
       showClippyInputBalloon();
     });
 

--- a/src/config/app-registry.js
+++ b/src/config/app-registry.js
@@ -5,6 +5,22 @@ import { getESheepMenuItems } from '../apps/esheep/esheep.js';
 import { getWebampMenuItems } from '../apps/webamp/webamp.js';
 
 export const appRegistry = {
+  "about": {
+    config: {
+    id: "about",
+    title: "About",
+    description: "Displays information about this application.",
+    summary: "<b>azOS Second Edition</b><br>Copyright © 2024",
+    icon: ICONS.windowsUpdate,
+    width: 400,
+    height: 280,
+    resizable: false,
+    minimizeButton: false,
+    maximizeButton: false,
+    isSingleton: true,
+  },
+    importApp: () => import("../shell/about/about-app.js")
+  },
   "agent": {
     config: {
         id: "agent",
@@ -22,22 +38,6 @@ export const appRegistry = {
         ],
     },
     importApp: () => import("../apps/agent/agent-app.js")
-  },
-  "about": {
-    config: {
-    id: "about",
-    title: "About",
-    description: "Displays information about this application.",
-    summary: "<b>azOS Second Edition</b><br>Copyright © 2024",
-    icon: ICONS.windowsUpdate,
-    width: 400,
-    height: 280,
-    resizable: false,
-    minimizeButton: false,
-    maximizeButton: false,
-    isSingleton: true,
-  },
-    importApp: () => import("../shell/about/about-app.js")
   },
   "app-maker": {
     config: {
@@ -559,7 +559,8 @@ export const appRegistry = {
     id: "webamp",
     title: "Winamp",
     description: "A classic music player.",
-    icon: ICONS.webamp, category: "",
+    icon: ICONS.webamp,
+    category: "",
     hasTaskbarButton: true,
     isSingleton: true,
     tray: {


### PR DESCRIPTION
The Agent and Clippy apps now correctly trigger the input balloon ('Ask Agent') when clicked or tapped once. Previously, this interaction was often ignored, especially if the agent was already speaking or performing an animation. I implemented direct DOM listeners where necessary and ensured that ongoing agent actions are interrupted to show the input balloon immediately upon clicking.

---
*PR created automatically by Jules for task [14596751950902221123](https://jules.google.com/task/14596751950902221123) started by @azayrahmad*