### PR TITLE
Add README Badges and Enhance Bug Reporting

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,17 @@
 # Windows 98 Web Edition
 
+<div align="center">
+
+[![Deploy static content to Pages](https://github.com/azayrahmad/win98-web/actions/workflows/static.yml/badge.svg)](https://github.com/azayrahmad/win98-web/actions/workflows/static.yml)
+[![GitHub release (latest by date)](https://img.shields.io/github/v/release/azayrahmad/win98-web?style=flat-square)](https://github.com/azayrahmad/win98-web/releases)
+[![GitHub](https://img.shields.io/github/license/azayrahmad/win98-web?style=flat-square)](https://github.com/azayrahmad/win98-web/blob/main/LICENSE)
+[![GitHub issues](https://img.shields.io/github/issues/azayrahmad/win98-web?style=flat-square)](https://github.com/azayrahmad/win98-web/issues)
+[![GitHub stars](https://img.shields.io/github/stars/azayrahmad/win98-web?style=flat-square)](https://github.com/azayrahmad/win98-web/stargazers)
+[![Built with Bun](https://img.shields.io/badge/Built%20with-Bun-black?style=flat-square&logo=bun)](https://bun.sh)
+
 > An ultimate pixel-perfect browser‑based recreation attempt of Windows 98.
+
+</div>
 
 A web-based recreation of the classic Windows 98 desktop experience, built using vanilla JavaScript, HTML, and CSS. Experience the familiar interface of Windows 98 directly in your modern browser, complete with working applications and games, customizable themes, and an AI-powered Clippy.
 
@@ -93,6 +104,20 @@ Windows 98 Web Edition includes a growing collection of built-in applications. T
 * **Display Properties & Desktop Themes** for theme and appearance customization.
 * **Disk Defragmenter** (visual simulation, not real defragmentation).
 * **Help & Report A Bug**.
+
+---
+
+## 🐞 Bug Reporting
+
+We want to make Windows 98 Web Edition as stable and authentic as possible! If you encounter any issues, please let us know.
+
+### **The Preferred Way: GitHub Issues**
+For the best tracking, please report bugs directly on our GitHub repository. This allows the community to discuss, track, and fix issues transparently.
+
+👉 **[Report a Bug on GitHub](https://github.com/azayrahmad/win98-web/issues/new/choose)**
+
+### **In-App Reporting**
+If you don't have a GitHub account, you can also use the **Report a Bug** application within the OS (Start → Programs → Accessories → Report a Bug). Note that these reports are anonymous and we may not be able to follow up with you directly.
 
 ### Special Features
 * **Assistant (Clippy)**: An intelligent assistant that can answer questions and help navigate the system.

--- a/src/apps/report-a-bug/report-abug-app.js
+++ b/src/apps/report-a-bug/report-abug-app.js
@@ -30,8 +30,8 @@ export default class ReportABugApp extends Application {
 
     const preface = document.createElement("p");
     preface.className = "reportabug-preface";
-    preface.textContent =
-      "We are sorry you are experiencing an issue. Please provide a detailed description of the bug you encountered. Your feedback is valuable and helps us improve the system.";
+    preface.innerHTML =
+      "We use GitHub to track bugs and feature requests. For the best experience, please use our <b>GitHub Issues</b> page.";
     container.appendChild(preface);
 
     this.textarea = document.createElement("textarea");
@@ -43,13 +43,27 @@ export default class ReportABugApp extends Application {
     buttonContainer.className = "reportabug-buttons";
     container.appendChild(buttonContainer);
 
+    this.githubButton = document.createElement("button");
+    this.githubButton.className = "button-default-size";
+    this.githubButton.style.marginRight = "10px";
+    this.githubButton.textContent = "Report on GitHub";
+    this.githubButton.onclick = () => this.handleGithubReport();
+    buttonContainer.appendChild(this.githubButton);
+
     this.sendButton = document.createElement("button");
     this.sendButton.className = "button-default-size";
-    this.sendButton.textContent = "Send";
+    this.sendButton.textContent = "Quick Send";
     this.sendButton.onclick = () => this.handleSend();
     buttonContainer.appendChild(this.sendButton);
 
     return win;
+  }
+
+  handleGithubReport() {
+    const baseUrl = "https://github.com/azayrahmad/win98-web/issues/new";
+    const body = encodeURIComponent(this.textarea.value);
+    const url = `${baseUrl}${body ? "?body=" + body : ""}`;
+    window.open(url, "_blank");
   }
 
   async _onLaunch() {

--- a/src/apps/report-a-bug/reportabug.css
+++ b/src/apps/report-a-bug/reportabug.css
@@ -21,3 +21,9 @@
   display: flex;
   justify-content: flex-end;
 }
+
+.reportabug-buttons button {
+  min-width: 80px;
+  width: auto !important;
+  white-space: nowrap;
+}

--- a/src/config/app-registry.js
+++ b/src/config/app-registry.js
@@ -450,6 +450,7 @@ export const appRegistry = {
     id: "report-a-bug",
     title: "Report a Bug",
     icon: ICONS.error,
+    category: "Accessories",
     width: 400,
     height: 320,
     resizable: false,


### PR DESCRIPTION
This PR enhances the project's visibility and community engagement by adding informative badges to the README and streamlining the bug reporting process. 

Key changes:
1.  **README Badges**: Added a set of `flat-square` badges (matching the retro aesthetic) for build status, versioning, license, and GitHub stats.
2.  **GitHub-First Bug Reporting**: The README now explicitly guides users to report bugs via GitHub Issues. 
3.  **App Update**: The "Report a Bug" application within the OS has been updated with a "Report on GitHub" button that pre-fills the issue body with user input. The app also now correctly appears in the "Accessories" menu.
4.  **Documentation**: Improved the "Bug Reporting" section in README.md with clear links and instructions.

---
*PR created automatically by Jules for task [6676806963307200718](https://jules.google.com/task/6676806963307200718) started by @azayrahmad*