### PR TITLE
Fix Internet Explorer 404 errors in Retro Mode

### DIFF
--- a/src/shell/explorer/explorer-app.js
+++ b/src/shell/explorer/explorer-app.js
@@ -1085,7 +1085,7 @@ export class ZenExplorerApp extends Application {
       !finalUrl.startsWith("http://") &&
       !finalUrl.startsWith("https://")
     ) {
-      finalUrl = `https://${finalUrl}`;
+      finalUrl = this.retroMode ? `http://${finalUrl}` : `https://${finalUrl}`;
     }
 
     const loadIframe = async (target) => {
@@ -1125,12 +1125,9 @@ export class ZenExplorerApp extends Application {
 
           const data = await response.json();
           const snapshot = data?.archived_snapshots?.closest;
-          const has1998Snapshot =
-            snapshot?.available === true &&
-            typeof snapshot?.timestamp === "string" &&
-            snapshot.timestamp.startsWith("1998");
+          const isAvailable = snapshot?.available === true;
 
-          if (!has1998Snapshot) {
+          if (!isAvailable) {
             loadIframe("./internet-explorer/404.html");
             return;
           }


### PR DESCRIPTION
I investigated why Internet Explorer was frequently showing 404 errors when navigating to websites like google.com or bbc.com in Retro Mode.

I found two primary issues:
1. **Protocol sensitivity:** The browser was defaulting to `https://` for untyped URLs. Since most of the 1998 web was HTTP-only, the Wayback Machine availability API often failed to find matching snapshots for the HTTPS version of these domains.
2. **Overly strict filtering:** The code manually rejected any snapshot that didn't have a timestamp starting with "1998". This caused issues for sites like Google, whose first significant archives appeared in late 1998/early 1999, or for cases where the API returned the "closest" match that wasn't exactly in 1998.

I've updated the logic to default to `http://` in Retro Mode and to allow any available snapshot to be loaded (relying on the `/web/1998/` URL prefix to tell the Wayback Machine to find the best match for that year).

Verified the fix through simulated API calls and visual inspection in the app.

---
*PR created automatically by Jules for task [13126038226758041316](https://jules.google.com/task/13126038226758041316) started by @azayrahmad*